### PR TITLE
Changes to desktop KPI dash

### DIFF
--- a/KPI/dashboards/desktop_kpis_with_filters.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters.dashboard.lookml
@@ -1,12 +1,11 @@
-- dashboard: desktop_kpi_dashboard_with_filters__editable
-  title: Desktop KPI Dashboard with Filters - editable
+- dashboard: desktop_kpi_dashboard_with_filters
+  title: Desktop KPI Dashboard with Filters
   layout: newspaper
   preferred_viewer: dashboards-next
-  load_configuration: wait
-  refresh: 2147484 seconds
+  refresh: 1 day
   elements:
-  - title: Desktop DAU
-    name: Desktop DAU
+  - title: Desktop Daily Active Users (DAU)
+    name: Desktop Daily Active Users (DAU)
     model: kpi
     explore: firefox_desktop_usage_2021
     type: looker_line
@@ -53,6 +52,14 @@
         series_index: 1, show_label: true}]
     defaults_version: 1
     hidden_fields:
+    note_state: collapsed
+    note_display: hover
+    note_text: 'An Fx profile counts to DAU on days that we receive a main ping from
+      them. The upper and lower bounds of the forecast (triangles) show the 10th and
+      90th percentiles of forecasted DAU values for that day. Note that we should
+      expect some days to fall outside of this range due to chance - generally we
+      should be looking for multiple *consecutive* days outside of the range when
+      determining if the actuals are truly starting to differ from the forecast. '
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -60,12 +67,12 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 23
+    row: 25
     col: 0
     width: 24
     height: 9
-  - title: Cumulative Days of Use
-    name: Cumulative Days of Use
+  - title: Cumulative Days of Use (CDOU)
+    name: Cumulative Days of Use (CDOU)
     model: kpi
     explore: firefox_desktop_usage_2021
     type: looker_line
@@ -105,6 +112,10 @@
       prediction.cdou_target: CDOU Target Pace
     defaults_version: 1
     hidden_fields: []
+    note_state: collapsed
+    note_display: hover
+    note_text: This shows the growth in CDOU since Jan 1, in comparison to forecast
+      and the +5% Target Pace.
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -112,7 +123,7 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 14
+    row: 16
     col: 12
     width: 12
     height: 9
@@ -140,6 +151,11 @@
         strikethrough: false, fields: !!null ''}]
     series_types: {}
     defaults_version: 1
+    note_state: collapsed
+    note_display: hover
+    note_text: CDOU is the sum of DAU (Daily Active Users) for the year to-date. The
+      target for CDOU is +5% over forecast. An Fx profile counts to DAU on days that
+      we receive a main ping from them.
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -147,7 +163,7 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 2
+    row: 4
     col: 0
     width: 5
     height: 5
@@ -177,6 +193,10 @@
           palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
         strikethrough: false, fields: !!null ''}]
     defaults_version: 1
+    note_state: collapsed
+    note_display: hover
+    note_text: 'Forecasts are derived using the prophet method. Official forecasts
+      are fixed as of Jan 19th and are NOT updated. '
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -184,7 +204,7 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 2
+    row: 4
     col: 5
     width: 5
     height: 5
@@ -241,6 +261,9 @@
     totals_color: "#808080"
     defaults_version: 1
     series_types: {}
+    note_state: collapsed
+    note_display: hover
+    note_text: 'The target pace is set by adding 5% to the forecast. '
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -248,7 +271,7 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 2
+    row: 4
     col: 10
     width: 5
     height: 5
@@ -256,13 +279,17 @@
     type: text
     title_text: ''
     subtitle_text: ''
-    body_text: "# Top Line Numbers"
+    body_text: "# Top Line Numbers\nHover on the info icons for more…. info on each\
+      \ chart.\n\nAbout the filters:\n\nSee [this documentation](https://docs.telemetry.mozilla.org/concepts/segments.html#activity-segments-informal)\
+      \ for information about how the activity segments are defined.\n\n\"Attributed\"\
+      \ profiles are those tagged as having originated via a download from mozilla.org.\
+      \ (Previously known as the \"light funnel\"). "
     row: 0
     col: 0
     width: 24
-    height: 2
-  - title: Number of Desktop New Profiles in 2021
-    name: Number of Desktop New Profiles in 2021
+    height: 4
+  - title: Cumulative Desktop New Profiles in 2021
+    name: Cumulative Desktop New Profiles in 2021
     model: kpi
     explore: firefox_desktop_usage_2021
     type: single_value
@@ -280,6 +307,11 @@
     conditional_formatting_include_nulls: false
     comparison_label: New Profiles Expected Today From Forecast
     defaults_version: 1
+    note_state: collapsed
+    note_display: hover
+    note_text: 'For the KPI we count a profile as new on the date we receive their
+      first main ping. Note not all new clients send us a main ping - some churn before
+      this point. They are not counted. '
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -287,12 +319,12 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 7
+    row: 9
     col: 0
     width: 5
     height: 5
-  - title: Difference in New Profiles From Forecast
-    name: Difference in New Profiles From Forecast
+  - title: Cumulative Desktop New Profiles in 2021
+    name: Cumulative Desktop New Profiles in 2021 (2)
     model: kpi
     explore: firefox_desktop_usage_2021
     type: single_value
@@ -344,6 +376,10 @@
     totals_color: "#808080"
     defaults_version: 1
     series_types: {}
+    note_state: collapsed
+    note_display: hover
+    note_text: 'Forecasts are derived using the prophet method. Official forecasts
+      are fixed as of Jan 19th and are NOT updated. '
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -351,7 +387,7 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 7
+    row: 9
     col: 5
     width: 5
     height: 5
@@ -371,7 +407,7 @@
     enable_conditional_formatting: true
     conditional_formatting_include_totals: false
     conditional_formatting_include_nulls: false
-    comparison_label: Expected New Profiles Today if We Were on Track
+    comparison_label: Expected New Profiles to Date if We Were on Track
     conditional_formatting: [{type: less than, value: 0, background_color: "#B32F37",
         font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
           palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
@@ -415,7 +451,7 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 7
+    row: 9
     col: 10
     width: 5
     height: 5
@@ -424,7 +460,7 @@
     title_text: ''
     subtitle_text: ''
     body_text: "# Desktop Days of Use and DAU"
-    row: 12
+    row: 14
     col: 0
     width: 24
     height: 2
@@ -433,16 +469,17 @@
     title_text: ''
     subtitle_text: ''
     body_text: "# Desktop New Profiles"
-    row: 32
+    row: 34
     col: 0
     width: 24
     height: 2
-  - title: Cumulative Difference from CDOU Forecast
-    name: Cumulative Difference from CDOU Forecast
+  - title: Difference from CDOU Forecast
+    name: Difference from CDOU Forecast
     model: kpi
     explore: firefox_desktop_usage_2021
     type: looker_line
-    fields: [firefox_desktop_usage_2021.date, firefox_desktop_usage_2021.delta_from_forecast_count]
+    fields: [firefox_desktop_usage_2021.date, firefox_desktop_usage_2021.delta_from_forecast_count,
+      firefox_desktop_usage_2021.delta_from_target_count]
     fill_fields: [firefox_desktop_usage_2021.date]
     sorts: [firefox_desktop_usage_2021.date]
     limit: 500
@@ -470,14 +507,24 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
-    y_axes: [{label: Difference From Forecast, orientation: left, series: [{axisId: firefox_desktop_usage_2021.delta_from_forecast_count_running,
-            id: firefox_desktop_usage_2021.delta_from_forecast_count_running, name: Delta
-              From Forecast Count Running}], showLabels: true, showValues: true, unpinAxis: false,
+    y_axes: [{label: Difference From Forecast, orientation: left, series: [{axisId: firefox_desktop_usage_2021.delta_from_forecast_count,
+            id: firefox_desktop_usage_2021.delta_from_forecast_count, name: Delta
+              From Forecast Count}], showLabels: true, showValues: true, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}, {label: !!null '',
+        orientation: right, series: [{axisId: firefox_desktop_usage_2021.delta_from_target_count,
+            id: firefox_desktop_usage_2021.delta_from_target_count, name: Delta From
+              Target Count}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
-        margin_value: mean, margin_bottom: deviation, label_position: right, color: "#000000",
+        margin_value: mean, margin_bottom: deviation, label_position: right, color: "#1A73E8",
         line_value: '0', label: At Forecast}]
     defaults_version: 1
+    note_state: collapsed
+    note_display: hover
+    note_text: This shows the difference between CDOU and (1) the forecast (Dark Blue)
+      and (2) the Target (Light Blue). Positive numbers indicate that we are above
+      forecast/target, negative numbers indicate we are below. Positive numbers indicate
+      that we are above forecast/target, negative numbers indicate we are below.
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -485,7 +532,7 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 14
+    row: 16
     col: 0
     width: 12
     height: 9
@@ -528,6 +575,10 @@
       prediction.cum_new_profiles_target: Target Pace
       firefox_desktop_usage_2021.new_profiles_cumulative: Cumulative New Profiles
     defaults_version: 1
+    note_state: collapsed
+    note_display: hover
+    note_text: This shows the growth in cumulative new profiles since Jan 1, in comparison
+      to forecast and the +5% Target Pace.
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -535,7 +586,7 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 34
+    row: 36
     col: 12
     width: 12
     height: 9
@@ -589,6 +640,11 @@
       prediction.new_profiles_forecast_lower: triangle
       prediction.new_profiles_forecast_upper: triangle-down
     defaults_version: 1
+    note_state: collapsed
+    note_display: hover
+    note_text: 'An Fx profile counts as new on the day that we receive their first
+      main ping. The upper and lower bounds of the forecast (triangles) show the 10th
+      and 90th percentiles of forecasted new profiles for that day. '
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -596,17 +652,19 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 43
+    row: 45
     col: 0
     width: 24
     height: 10
-  - title: Cumulative Difference from New Profile Forecast
-    name: Cumulative Difference from New Profile Forecast
+  - title: Difference from Cumulative New Profile Forecast
+    name: Difference from Cumulative New Profile Forecast
     model: kpi
     explore: firefox_desktop_usage_2021
     type: looker_line
-    fields: [firefox_desktop_usage_2021.date, firefox_desktop_usage_2021.delta_from_forecast_new_profiles_count]
+    fields: [firefox_desktop_usage_2021.date, firefox_desktop_usage_2021.delta_from_forecast_new_profiles_count,
+      firefox_desktop_usage_2021.delta_from_target_new_profiles_count]
     fill_fields: [firefox_desktop_usage_2021.date]
+    sorts: [firefox_desktop_usage_2021.date desc]
     limit: 500
     x_axis_gridlines: false
     y_axis_gridlines: true
@@ -632,12 +690,24 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
-    y_axes: [{label: Difference From Forecast, orientation: left, series: [{axisId: firefox_desktop_usage_2021.delta_from_forecast_new_profiles_count_running,
-            id: firefox_desktop_usage_2021.delta_from_forecast_new_profiles_count_running,
-            name: Delta From Forecast New Profiles Count Running}], showLabels: true,
-        showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
-        type: linear}]
+    y_axes: [{label: Difference From Forecast, orientation: left, series: [{axisId: firefox_desktop_usage_2021.delta_from_forecast_new_profiles_count,
+            id: firefox_desktop_usage_2021.delta_from_forecast_new_profiles_count,
+            name: Delta From Forecast New Profiles Count}], showLabels: true, showValues: true,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear},
+      {label: Difference From Target, orientation: right, series: [{axisId: firefox_desktop_usage_2021.delta_from_target_new_profiles_count,
+            id: firefox_desktop_usage_2021.delta_from_target_new_profiles_count, name: Delta
+              From Target New Profiles Count}], showLabels: true, showValues: true,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
+        margin_value: mean, margin_bottom: deviation, label_position: left, color: "#1A73E8",
+        line_value: '0', label: At Forecast}]
     defaults_version: 1
+    note_state: collapsed
+    note_display: hover
+    note_text: This shows the difference between the cumulative number of new profiles
+      and (1) the forecast (Dark Blue) and (2) the Target (Light Blue). Positive numbers
+      indicate that we are above forecast/target, negative numbers indicate we are
+      below.
     listen:
       Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
@@ -645,7 +715,7 @@
       Country: firefox_desktop_usage_2021.country
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-    row: 34
+    row: 36
     col: 0
     width: 12
     height: 9

--- a/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
@@ -2,7 +2,7 @@
   title: Desktop KPI Dashboard with Filters Alternate
   layout: newspaper
   preferred_viewer: dashboards-next
-  refresh: 1 day
+  refresh: 2147484 seconds
   elements:
   - title: Desktop Daily Active Users (DAU)
     name: Desktop Daily Active Users (DAU)
@@ -67,7 +67,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 22
+    row: 23
     col: 0
     width: 24
     height: 9
@@ -123,7 +123,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 13
+    row: 14
     col: 12
     width: 12
     height: 9
@@ -145,7 +145,7 @@
     body_text: "<h1 style=\"margin-top:20px; padding: 5px; border-bottom: solid 1px\
       \ #412399; height: 60px; color: #412399; text-align: center;\" id=\"new_profiles\"\
       >Desktop New Profiles</h1>\n\n"
-    row: 31
+    row: 32
     col: 0
     width: 24
     height: 3
@@ -208,7 +208,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 13
+    row: 14
     col: 0
     width: 12
     height: 9
@@ -262,7 +262,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 43
+    row: 46
     col: 12
     width: 12
     height: 9
@@ -328,7 +328,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 52
+    row: 55
     col: 0
     width: 24
     height: 10
@@ -391,7 +391,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 43
+    row: 46
     col: 0
     width: 12
     height: 9
@@ -454,7 +454,7 @@
     row: 4
     col: 0
     width: 24
-    height: 9
+    height: 10
   - title: Top Line Numbers for New Profiles
     name: Top Line Numbers for New Profiles
     model: kpi
@@ -513,10 +513,10 @@
     title_hidden: true
     listen:
       Date: firefox_desktop_usage_2021.date
-    row: 34
+    row: 35
     col: 0
     width: 24
-    height: 9
+    height: 11
   - name: " (3)"
     type: text
     title_text: ''
@@ -538,7 +538,7 @@
       <p>This is the count of new desktop client_ids (profiles) that are created over the course of the year. A new Firefox profile counts to  this metric on the day we receive its first main ping.</p>
       <p>The 2021 target for cumulative new profiles is +5% over forecast. </p>
       </div>
-    row: 62
+    row: 65
     col: 0
     width: 15
     height: 9

--- a/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
@@ -1,8 +1,8 @@
-- dashboard: desktop_kpi_dashboard_with_filters
-  title: Desktop KPI Dashboard with Filters
+- dashboard: desktop_kpi_dashboard_with_filters_alternate
+  title: Desktop KPI Dashboard with Filters Alternate
   layout: newspaper
   preferred_viewer: dashboards-next
-  refresh: 12 hours
+  refresh: 1 day
   elements:
   - title: Desktop Daily Active Users (DAU)
     name: Desktop Daily Active Users (DAU)
@@ -61,13 +61,13 @@
       should be looking for multiple *consecutive* days outside of the range when
       determining if the actuals are truly starting to differ from the forecast. '
     listen:
-      Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
       Activity Segment: firefox_desktop_usage_2021.activity_segment
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
-    row: 25
+      Date: firefox_desktop_usage_2021.date
+    row: 21
     col: 0
     width: 24
     height: 9
@@ -117,359 +117,35 @@
     note_text: This shows the growth in CDOU since Jan 1, in comparison to forecast
       and the +5% Target Pace.
     listen:
-      Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
       Activity Segment: firefox_desktop_usage_2021.activity_segment
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
-    row: 16
+      Date: firefox_desktop_usage_2021.date
+    row: 12
     col: 12
     width: 12
     height: 9
-  - title: Cumulative Desktop Days of Use (CDOU) in 2021
-    name: Cumulative Desktop Days of Use (CDOU) in 2021
-    model: kpi
-    explore: firefox_desktop_usage_2021
-    type: single_value
-    fields: [firefox_desktop_usage_2021.recent_cdou, prediction.recent_cdou_forecast]
-    limit: 500
-    custom_color_enabled: true
-    show_single_value_title: true
-    show_comparison: false
-    comparison_type: value
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    enable_conditional_formatting: false
-    conditional_formatting_include_totals: false
-    conditional_formatting_include_nulls: false
-    value_format: ''
-    comparison_label: Forecasted CDOU as of today
-    conditional_formatting: [{type: equal to, value: !!null '', background_color: "#3EB0D5",
-        font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
-          palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}]
-    series_types: {}
-    defaults_version: 1
-    note_state: collapsed
-    note_display: hover
-    note_text: CDOU is the sum of DAU (Daily Active Users) for the year to-date. The
-      target for CDOU is +5% over forecast. An Fx profile counts to DAU on days that
-      we receive a main ping from them.
-    listen:
-      Date: firefox_desktop_usage_2021.date
-      Channel: firefox_desktop_usage_2021.channel
-      Activity Segment: firefox_desktop_usage_2021.activity_segment
-      OS: firefox_desktop_usage_2021.os
-      Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-      Country Name: firefox_desktop_usage_2021.country_name
-    row: 4
-    col: 0
-    width: 7
-    height: 5
-  - title: CDOU Difference From Forecast
-    name: CDOU Difference From Forecast
-    model: kpi
-    explore: firefox_desktop_usage_2021
-    type: single_value
-    fields: [firefox_desktop_usage_2021.delta_from_forecast, prediction.recent_cdou_forecast]
-    limit: 500
-    custom_color_enabled: true
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: value
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    enable_conditional_formatting: true
-    conditional_formatting_include_totals: false
-    conditional_formatting_include_nulls: false
-    value_format: ''
-    comparison_label: Expected CDOU Today From Jan Forecast
-    conditional_formatting: [{type: less than, value: 0, background_color: "#B32F37",
-        font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
-          palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}, {type: greater than, value: 0, background_color: "#72D16D",
-        font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
-          palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}]
-    defaults_version: 1
-    note_state: collapsed
-    note_display: hover
-    note_text: 'Forecasts are derived using the prophet method. Official forecasts
-      are fixed as of Jan 19th and are NOT updated. '
-    listen:
-      Date: firefox_desktop_usage_2021.date
-      Channel: firefox_desktop_usage_2021.channel
-      Activity Segment: firefox_desktop_usage_2021.activity_segment
-      OS: firefox_desktop_usage_2021.os
-      Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-      Country Name: firefox_desktop_usage_2021.country_name
-    row: 4
-    col: 7
-    width: 8
-    height: 5
-  - title: Current Delta From CDOU Target Pace
-    name: Current Delta From CDOU Target Pace
-    model: kpi
-    explore: firefox_desktop_usage_2021
-    type: single_value
-    fields: [firefox_desktop_usage_2021.delta_from_target, prediction.recent_cdou_target]
-    limit: 500
-    custom_color_enabled: true
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: value
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    enable_conditional_formatting: true
-    conditional_formatting_include_totals: false
-    conditional_formatting_include_nulls: false
-    comparison_label: Expected CDOU Today if We Were On Track
-    conditional_formatting: [{type: less than, value: 0, background_color: "#B32F37",
-        font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
-          palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}, {type: greater than, value: 0, background_color: "#72D16D",
-        font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
-          palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}]
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    defaults_version: 1
-    series_types: {}
-    note_state: collapsed
-    note_display: hover
-    note_text: 'The target pace is set by adding 5% to the forecast. '
-    listen:
-      Date: firefox_desktop_usage_2021.date
-      Channel: firefox_desktop_usage_2021.channel
-      Activity Segment: firefox_desktop_usage_2021.activity_segment
-      OS: firefox_desktop_usage_2021.os
-      Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-      Country Name: firefox_desktop_usage_2021.country_name
-    row: 4
-    col: 15
-    width: 8
-    height: 5
   - name: ''
     type: text
     title_text: ''
     subtitle_text: ''
-    body_text: "# Top Line Numbers\nHover on the info icons for more…. info on each\
-      \ chart.\n\nAbout the filters:\n\nSee [this documentation](https://docs.telemetry.mozilla.org/concepts/segments.html#activity-segments-informal)\
-      \ for information about how the activity segments are defined.\n\n\"Attributed\"\
-      \ profiles are those tagged as having originated via a download from mozilla.org.\
-      \ (Previously known as the \"light funnel\"). "
+    body_text: '<h1 style="margin-top:20px; padding: 5px; border-bottom: solid 1px
+      #412399; height: 60px; color: #412399; text-align: center;" id="dou">Desktop
+      Days of Use and DAU</h1>'
     row: 0
     col: 0
     width: 24
     height: 4
-  - title: Cumulative Desktop New Profiles in 2021
-    name: Cumulative Desktop New Profiles in 2021
-    model: kpi
-    explore: firefox_desktop_usage_2021
-    type: single_value
-    fields: [firefox_desktop_usage_2021.recent_new_profiles_cumulative, prediction.recent_cum_new_profiles_forecast]
-    limit: 500
-    filter_expression: "${firefox_desktop_usage_2021.date} >= date(2021,1,1)"
-    custom_color_enabled: true
-    show_single_value_title: true
-    show_comparison: false
-    comparison_type: value
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    enable_conditional_formatting: false
-    conditional_formatting_include_totals: false
-    conditional_formatting_include_nulls: false
-    comparison_label: New Profiles Expected Today From Forecast
-    defaults_version: 1
-    note_state: collapsed
-    note_display: hover
-    note_text: 'For the KPI we count a profile as new on the date we receive their
-      first main ping. Note not all new clients send us a main ping - some churn before
-      this point. They are not counted. '
-    listen:
-      Date: firefox_desktop_usage_2021.date
-      Channel: firefox_desktop_usage_2021.channel
-      Activity Segment: firefox_desktop_usage_2021.activity_segment
-      OS: firefox_desktop_usage_2021.os
-      Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-      Country Name: firefox_desktop_usage_2021.country_name
-    row: 9
-    col: 0
-    width: 7
-    height: 5
-  - title: Cumulative Desktop New Profiles in 2021
-    name: Cumulative Desktop New Profiles in 2021 (2)
-    model: kpi
-    explore: firefox_desktop_usage_2021
-    type: single_value
-    fields: [firefox_desktop_usage_2021.delta_from_forecast_new_profiles, prediction.recent_cum_new_profiles_forecast]
-    limit: 500
-    custom_color_enabled: true
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: value
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    enable_conditional_formatting: true
-    conditional_formatting_include_totals: false
-    conditional_formatting_include_nulls: false
-    comparison_label: Expected New Profiles To Date From Jan Forecast
-    conditional_formatting: [{type: less than, value: 0, background_color: "#B32F37",
-        font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
-          palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}, {type: greater than, value: 0, background_color: "#72D16D",
-        font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
-          palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}]
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    defaults_version: 1
-    series_types: {}
-    note_state: collapsed
-    note_display: hover
-    note_text: 'Forecasts are derived using the prophet method. Official forecasts
-      are fixed as of Jan 19th and are NOT updated. '
-    listen:
-      Date: firefox_desktop_usage_2021.date
-      Channel: firefox_desktop_usage_2021.channel
-      Activity Segment: firefox_desktop_usage_2021.activity_segment
-      OS: firefox_desktop_usage_2021.os
-      Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-      Country Name: firefox_desktop_usage_2021.country_name
-    row: 9
-    col: 7
-    width: 8
-    height: 5
-  - title: Delta From New Profile Target Pace
-    name: Delta From New Profile Target Pace
-    model: kpi
-    explore: firefox_desktop_usage_2021
-    type: single_value
-    fields: [firefox_desktop_usage_2021.delta_from_target_new_profiles, prediction.recent_cum_new_profiles_target]
-    limit: 500
-    custom_color_enabled: true
-    show_single_value_title: true
-    show_comparison: true
-    comparison_type: value
-    comparison_reverse_colors: false
-    show_comparison_label: true
-    enable_conditional_formatting: true
-    conditional_formatting_include_totals: false
-    conditional_formatting_include_nulls: false
-    comparison_label: Expected New Profiles to Date if We Were on Track
-    conditional_formatting: [{type: less than, value: 0, background_color: "#B32F37",
-        font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
-          palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}, {type: greater than, value: 0, background_color: "#72D16D",
-        font_color: !!null '', color_application: {collection_id: b43731d5-dc87-4a8e-b807-635bef3948e7,
-          palette_id: 85de97da-2ded-4dec-9dbd-e6a7d36d5825}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}]
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    defaults_version: 1
-    series_types: {}
-    listen:
-      Date: firefox_desktop_usage_2021.date
-      Channel: firefox_desktop_usage_2021.channel
-      Activity Segment: firefox_desktop_usage_2021.activity_segment
-      OS: firefox_desktop_usage_2021.os
-      Attributed (Yes / No): firefox_desktop_usage_2021.attributed
-      Country Name: firefox_desktop_usage_2021.country_name
-    row: 9
-    col: 15
-    width: 8
-    height: 5
   - name: " (2)"
     type: text
     title_text: ''
     subtitle_text: ''
-    body_text: "# Desktop Days of Use and DAU"
-    row: 14
-    col: 0
-    width: 24
-    height: 2
-  - name: " (3)"
-    type: text
-    title_text: ''
-    subtitle_text: ''
-    body_text: "# Desktop New Profiles"
-    row: 34
+    body_text: "<h1 style=\"margin-top:20px; padding: 5px; border-bottom: solid 1px\
+      \ #412399; height: 60px; color: #412399; text-align: center;\" id=\"new_profiles\"\
+      >Desktop New Profiles</h1>\n\n"
+    row: 30
     col: 0
     width: 24
     height: 2
@@ -526,13 +202,13 @@
       forecast/target, negative numbers indicate we are below. Positive numbers indicate
       that we are above forecast/target, negative numbers indicate we are below.
     listen:
-      Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
       Activity Segment: firefox_desktop_usage_2021.activity_segment
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
-    row: 16
+      Date: firefox_desktop_usage_2021.date
+    row: 12
     col: 0
     width: 12
     height: 9
@@ -580,13 +256,13 @@
     note_text: This shows the growth in cumulative new profiles since Jan 1, in comparison
       to forecast and the +5% Target Pace.
     listen:
-      Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
       Activity Segment: firefox_desktop_usage_2021.activity_segment
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
-    row: 36
+      Date: firefox_desktop_usage_2021.date
+    row: 40
     col: 12
     width: 12
     height: 9
@@ -646,13 +322,13 @@
       main ping. The upper and lower bounds of the forecast (triangles) show the 10th
       and 90th percentiles of forecasted new profiles for that day. '
     listen:
-      Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
       Activity Segment: firefox_desktop_usage_2021.activity_segment
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
-    row: 45
+      Date: firefox_desktop_usage_2021.date
+    row: 49
     col: 0
     width: 24
     height: 10
@@ -709,15 +385,162 @@
       indicate that we are above forecast/target, negative numbers indicate we are
       below.
     listen:
-      Date: firefox_desktop_usage_2021.date
       Channel: firefox_desktop_usage_2021.channel
       Activity Segment: firefox_desktop_usage_2021.activity_segment
       OS: firefox_desktop_usage_2021.os
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
-    row: 36
+      Date: firefox_desktop_usage_2021.date
+    row: 40
     col: 0
     width: 12
+    height: 9
+  - title: Top Line Numbers for CDOU
+    name: Top Line Numbers for CDOU
+    model: kpi
+    explore: firefox_desktop_usage_2021
+    type: looker_grid
+    fields: [firefox_desktop_usage_2021.delta_from_forecast_format2]
+    limit: 500
+    show_view_names: false
+    show_row_numbers: false
+    transpose: false
+    truncate_text: false
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: unstyled
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: ''
+    header_font_size: '12'
+    rows_font_size: '99'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: false
+    show_row_totals: false
+    series_labels:
+      firefox_desktop_usage_2021.delta_from_forecast_format2: "."
+    series_column_widths:
+      firefox_desktop_usage_2021.delta_from_forecast_format2: 2445
+    series_cell_visualizations:
+      firefox_desktop_usage_2021.delta_from_forecast_format:
+        is_active: true
+      firefox_desktop_usage_2021.delta_from_forecast_format2:
+        is_active: false
+    series_text_format:
+      firefox_desktop_usage_2021.delta_from_forecast_format2:
+        align: left
+    limit_displayed_rows_values:
+      show_hide: show
+      first_last: first
+      num_rows: '1'
+    conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#1A73E8",
+        font_color: !!null '', color_application: {collection_id: 7c56cc21-66e4-41c9-81ce-a60e1c3967b2,
+          palette_id: 56d0c358-10a0-4fd6-aa0b-b117bef527ab}, bold: false, italic: false,
+        strikethrough: false, fields: !!null ''}]
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    series_types: {}
+    title_hidden: true
+    listen:
+      Date: firefox_desktop_usage_2021.date
+    row: 4
+    col: 0
+    width: 24
+    height: 8
+  - title: Top Line Numbers for New Profiles
+    name: Top Line Numbers for New Profiles
+    model: kpi
+    explore: firefox_desktop_usage_2021
+    type: looker_grid
+    fields: [firefox_desktop_usage_2021.delta_from_forecast_format]
+    limit: 500
+    show_view_names: false
+    show_row_numbers: false
+    transpose: false
+    truncate_text: false
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: false
+    table_theme: unstyled
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: ''
+    header_font_size: '12'
+    rows_font_size: '99'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: false
+    show_row_totals: false
+    series_labels:
+      firefox_desktop_usage_2021.delta_from_forecast_format2: Top Line CDOU
+      firefox_desktop_usage_2021.delta_from_forecast_format: "."
+    series_column_widths:
+      firefox_desktop_usage_2021.delta_from_forecast_format2: 2445
+      firefox_desktop_usage_2021.delta_from_forecast_format: 2417
+    series_cell_visualizations:
+      firefox_desktop_usage_2021.delta_from_forecast_format:
+        is_active: false
+      firefox_desktop_usage_2021.delta_from_forecast_format2:
+        is_active: false
+    series_text_format:
+      firefox_desktop_usage_2021.delta_from_forecast_format2:
+        align: left
+    limit_displayed_rows_values:
+      show_hide: show
+      first_last: first
+      num_rows: '1'
+    conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#1A73E8",
+        font_color: !!null '', color_application: {collection_id: 7c56cc21-66e4-41c9-81ce-a60e1c3967b2,
+          palette_id: 56d0c358-10a0-4fd6-aa0b-b117bef527ab}, bold: false, italic: false,
+        strikethrough: false, fields: !!null ''}]
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    series_types: {}
+    title_hidden: true
+    listen:
+      Date: firefox_desktop_usage_2021.date
+    row: 32
+    col: 0
+    width: 24
+    height: 8
+  - name: " (3)"
+    type: text
+    title_text: ''
+    subtitle_text: ''
+    body_text: |
+      <div style="border: solid 1px #4285F4; border-radius: 3px; padding: 5px 10px; background: #eaf1fe; height: 340px">
+              <a style="font-weight: bold;" href="https://datastudio.google.com/u/0/reporting/7a716807-bbff-48e1-9842-401bcecf27d3/page/I7AwB">☰
+
+            Link to Old Data Studio Version</a>
+      <h1 id="explainer"> About the Desktop KPIs </h1>
+
+
+
+      <a href="#dou"><h2>Cumulative Days of Use (CDOU)</h2></a>
+
+      <p>CDOU tracks the total number of Firefox Desktop usage days over the year.  It is equivalent to Daily Active Users (DAU) summed over the year. A Firefox profile counts to CDOU if we receive a main ping from them on a given day.</p>
+      <p>The 2021 target for CDOU is +5% over forecast. </p>
+      <a href="#new_profiles"><h2>Cumulative New Profiles</h2></a>
+      <p>This is the count of new desktop client_ids (profiles) that are created over the course of the year. A new Firefox profile counts to  this metric on the day we receive its first main ping.</p>
+      <p>The 2021 target for cumulative new profiles is +5% over forecast. </p>
+      </div>
+    row: 59
+    col: 0
+    width: 15
     height: 9
   filters:
   - name: Date

--- a/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
@@ -67,7 +67,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 21
+    row: 22
     col: 0
     width: 24
     height: 9
@@ -123,7 +123,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 12
+    row: 13
     col: 12
     width: 12
     height: 9
@@ -145,10 +145,10 @@
     body_text: "<h1 style=\"margin-top:20px; padding: 5px; border-bottom: solid 1px\
       \ #412399; height: 60px; color: #412399; text-align: center;\" id=\"new_profiles\"\
       >Desktop New Profiles</h1>\n\n"
-    row: 30
+    row: 31
     col: 0
     width: 24
-    height: 2
+    height: 3
   - title: Difference from CDOU Forecast
     name: Difference from CDOU Forecast
     model: kpi
@@ -208,7 +208,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 12
+    row: 13
     col: 0
     width: 12
     height: 9
@@ -262,7 +262,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 40
+    row: 43
     col: 12
     width: 12
     height: 9
@@ -328,7 +328,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 49
+    row: 52
     col: 0
     width: 24
     height: 10
@@ -391,7 +391,7 @@
       Attributed (Yes / No): firefox_desktop_usage_2021.attributed
       Country Name: firefox_desktop_usage_2021.country_name
       Date: firefox_desktop_usage_2021.date
-    row: 40
+    row: 43
     col: 0
     width: 12
     height: 9
@@ -423,7 +423,7 @@
     series_labels:
       firefox_desktop_usage_2021.delta_from_forecast_format2: "."
     series_column_widths:
-      firefox_desktop_usage_2021.delta_from_forecast_format2: 2445
+      firefox_desktop_usage_2021.delta_from_forecast_format2: 1541
     series_cell_visualizations:
       firefox_desktop_usage_2021.delta_from_forecast_format:
         is_active: true
@@ -454,7 +454,7 @@
     row: 4
     col: 0
     width: 24
-    height: 8
+    height: 9
   - title: Top Line Numbers for New Profiles
     name: Top Line Numbers for New Profiles
     model: kpi
@@ -468,7 +468,7 @@
     truncate_text: false
     hide_totals: false
     hide_row_totals: false
-    size_to_fit: false
+    size_to_fit: true
     table_theme: unstyled
     limit_displayed_rows: false
     enable_conditional_formatting: false
@@ -485,7 +485,7 @@
       firefox_desktop_usage_2021.delta_from_forecast_format: "."
     series_column_widths:
       firefox_desktop_usage_2021.delta_from_forecast_format2: 2445
-      firefox_desktop_usage_2021.delta_from_forecast_format: 2417
+      firefox_desktop_usage_2021.delta_from_forecast_format: 1537
     series_cell_visualizations:
       firefox_desktop_usage_2021.delta_from_forecast_format:
         is_active: false
@@ -513,10 +513,10 @@
     title_hidden: true
     listen:
       Date: firefox_desktop_usage_2021.date
-    row: 32
+    row: 34
     col: 0
     width: 24
-    height: 8
+    height: 9
   - name: " (3)"
     type: text
     title_text: ''
@@ -538,7 +538,7 @@
       <p>This is the count of new desktop client_ids (profiles) that are created over the course of the year. A new Firefox profile counts to  this metric on the day we receive its first main ping.</p>
       <p>The 2021 target for cumulative new profiles is +5% over forecast. </p>
       </div>
-    row: 59
+    row: 62
     col: 0
     width: 15
     height: 9

--- a/KPI/kpi.model.lkml
+++ b/KPI/kpi.model.lkml
@@ -13,7 +13,7 @@ explore: firefox_desktop_usage_2021 {
     sql_on: ${firefox_desktop_usage_2021.date} = ${prediction.date} ;;
     relationship: one_to_one
   }
-  hidden: yes
+  hidden: no
 }
 
 # For suggestions

--- a/KPI/views/firefox_desktop_usage_2021.view.lkml
+++ b/KPI/views/firefox_desktop_usage_2021.view.lkml
@@ -155,6 +155,11 @@ derived_table: {
     sql: ${TABLE}.cdou ;;
   }
 
+  measure: recent_date {
+    type: date
+    sql: MAX(CAST(${TABLE}.submission_date AS TIMESTAMP)) ;;
+  }
+
   measure: wau {
     type: sum
     value_format: "#,##0"
@@ -207,6 +212,46 @@ derived_table: {
     type: number
     value_format: "#,##0"
     sql: ${new_profiles_cumulative} - ${prediction.cum_new_profiles_target} ;;
+  }
+
+  measure: delta_from_forecast_format{
+    type: number
+    sql: ${delta_from_forecast_new_profiles} ;;
+    html:
+    {% assign target_delta = firefox_desktop_usage_2021.delta_from_target_new_profiles._value | times: 100 %}
+    {% assign forecast_delta = firefox_desktop_usage_2021.delta_from_forecast_new_profiles._value | times: 100 %}
+    <div class="topline" style="font-size: 30px; background-color: #d7d7db; color:#000000; padding: 12px; margin: 12px;">
+      <center>
+      <h1><b><u><font color="#ff9400">Progress in Desktop Cumulative New Profiles As Of {{ firefox_desktop_usage_2021.recent_date._rendered_value }}</font></u></b></h1>
+      <img src="https://d33wubrfki0l68.cloudfront.net/06185f059f69055733688518b798a0feb4c7f160/9f07a/images/product-identity-assets/firefox.png" alt="Firefox Logo" style="width:300px;height:300px;float:right">
+      <img src="https://d33wubrfki0l68.cloudfront.net/06185f059f69055733688518b798a0feb4c7f160/9f07a/images/product-identity-assets/firefox.png" alt="Firefox Logo" style="width:300px;height:300px;float:left">
+      <h2><b><font color= "#45a1ff">Current Cumulative New Profiles: {{ firefox_desktop_usage_2021.recent_new_profiles_cumulative._rendered_value }} </font></b></h2>
+      <p><em>{% if target_delta > 0 %} <font color="#30e60b">▲ {{ firefox_desktop_usage_2021.delta_from_target_new_profiles._rendered_value }}</font> {% else %} <font color="#ff0039">▼ {{ firefox_desktop_usage_2021.delta_from_target_new_profiles._rendered_value }}</font> {% endif %}  from +5% Target Pace ({{ prediction.recent_cum_new_profiles_target._rendered_value }})</em></p>
+      <p>{% if forecast_delta > 0 %} <font color="#30e60b">▲ {{ firefox_desktop_usage_2021.delta_from_forecast_new_profiles._rendered_value }}</font> {% else %} <font color="#ff0039">▼ {{ firefox_desktop_usage_2021.delta_from_forecast_new_profiles._rendered_value }}</font> {% endif %} from Forecast ({{ prediction.recent_cum_new_profiles_forecast._rendered_value }})</p>
+      <a href="#explainer" style="color: #0000EE"><u>Explainer</u></a>
+      </center>
+    </div>
+   ;;
+  }
+
+  measure: delta_from_forecast_format2{
+    type: number
+    sql: ${delta_from_forecast} ;;
+    html:
+    {% assign target_delta = firefox_desktop_usage_2021.delta_from_target._value | times: 100 %}
+    {% assign forecast_delta = firefox_desktop_usage_2021.delta_from_forecast._value | times: 100 %}
+    <div class="topline" style="font-size: 30px; background-color: #d7d7db; color:#000000; padding: 12px; margin: 12px;">
+      <center>
+      <h1><b><u><font color="#ff9400">Progress in Desktop Cumulative Days of Use (CDOU) As Of {{ firefox_desktop_usage_2021.recent_date._rendered_value }}</font></u></b></h1>
+      <img src="https://d33wubrfki0l68.cloudfront.net/06185f059f69055733688518b798a0feb4c7f160/9f07a/images/product-identity-assets/firefox.png" alt="Firefox Logo" style="width:300px;height:300px;float:right">
+      <img src="https://d33wubrfki0l68.cloudfront.net/06185f059f69055733688518b798a0feb4c7f160/9f07a/images/product-identity-assets/firefox.png" alt="Firefox Logo" style="width:300px;height:300px;float:left">
+      <h2><b><font color= "#45a1ff">Current CDOU: {{ firefox_desktop_usage_2021.recent_cdou._rendered_value }}</font></b></h2>
+      <p><em>{% if target_delta > 0 %} <font color="#30e60b">▲ {{ firefox_desktop_usage_2021.delta_from_target._rendered_value }}</font> {% else %} <font color="#ff0039">▼ {{ firefox_desktop_usage_2021.delta_from_target._rendered_value }}</font> {% endif %}  from +5% Target Pace ({{ prediction.recent_cdou_target._rendered_value }})</em></p>
+      <p>{% if forecast_delta > 0 %} <font color="#30e60b">▲ {{ firefox_desktop_usage_2021.delta_from_forecast._rendered_value }}</font> {% else %} <font color="#ff0039">▼ {{ firefox_desktop_usage_2021.delta_from_forecast._rendered_value }}</font> {% endif %} from Forecast ({{ prediction.recent_cdou_forecast._rendered_value }})</p>
+      <a href="#explainer" style="color: #0000EE"><u>Explainer</u></a>
+      </center>
+    </div>
+   ;;
   }
 
 }

--- a/KPI/views/firefox_desktop_usage_2021.view.lkml
+++ b/KPI/views/firefox_desktop_usage_2021.view.lkml
@@ -17,6 +17,7 @@ derived_table: {
         AND {% condition firefox_desktop_usage_2021.channel %} channel {% endcondition %}
         AND {% condition firefox_desktop_usage_2021.content %} content {% endcondition %}
         AND {% condition firefox_desktop_usage_2021.country %} country {% endcondition %}
+        AND {% condition firefox_desktop_usage_2021.country_name %} country_name {% endcondition %}
         AND {% condition firefox_desktop_usage_2021.distribution_id %} distribution_id {% endcondition %}
         AND {% condition firefox_desktop_usage_2021.id_bucket %} id_bucket {% endcondition %}
         AND {% condition firefox_desktop_usage_2021.medium %} medium {% endcondition %}
@@ -53,6 +54,12 @@ derived_table: {
   filter: country {
     suggest_explore: firefox_desktop_usage_fields
     suggest_dimension: firefox_desktop_usage_fields.country
+    type: string
+  }
+
+  filter: country_name {
+    suggest_explore: firefox_desktop_usage_fields
+    suggest_dimension: firefox_desktop_usage_fields.country_name
     type: string
   }
 

--- a/KPI/views/firefox_desktop_usage_2021.view.lkml
+++ b/KPI/views/firefox_desktop_usage_2021.view.lkml
@@ -10,7 +10,7 @@ derived_table: {
         sum(new_profiles) as new_profiles,
         sum(cumulative_new_profiles) as cumulative_new_profiles,
     from
-        `mozdata.telemetry.firefox_desktop_usage_2021`
+        ${firefox_desktop_usage_fields.SQL_TABLE_NAME} AS firefox_desktop_usage_fields
     where
         {% condition firefox_desktop_usage_2021.activity_segment %} activity_segment {% endcondition %}
         AND {% condition firefox_desktop_usage_2021.campaign %} campaign {% endcondition %}
@@ -100,26 +100,31 @@ derived_table: {
 
   measure: dau {
     type: sum
+    value_format: "#,##0"
     sql: ${TABLE}.dau ;;
   }
 
   measure: mau {
     type: sum
+    value_format: "#,##0"
     sql: ${TABLE}.mau ;;
   }
 
   measure: new_profiles {
     type: sum
+    value_format: "#,##0"
     sql: ${TABLE}.new_profiles ;;
   }
 
   measure: new_profiles_cumulative {
     type: sum
+    value_format: "#,##0"
     sql: ${TABLE}.cumulative_new_profiles ;;
   }
 
   measure: cdou {
     type: sum
+    value_format: "#,##0"
     sql: ${TABLE}.cdou ;;
   }
 
@@ -133,16 +138,19 @@ derived_table: {
 
   measure: recent_new_profiles_cumulative {
     type: max
+    value_format: "#,##0"
     sql: ${TABLE}.cumulative_new_profiles ;;
   }
 
   measure: recent_cdou {
     type: max
+    value_format: "#,##0"
     sql: ${TABLE}.cdou ;;
   }
 
   measure: wau {
     type: sum
+    value_format: "#,##0"
     sql: ${TABLE}.wau ;;
   }
 
@@ -160,13 +168,13 @@ derived_table: {
 
   measure: delta_from_target_count {
     type: number
-    value_format: "0"
+    value_format: "#,##0"
     sql: ${cdou} - ${prediction.cdou_target} ;;
   }
 
   measure: delta_from_forecast_count {
     type: number
-    value_format: "0"
+    value_format: "#,##0"
     sql: ${cdou} - ${prediction.cdou_forecast}  ;;
   }
 
@@ -184,13 +192,14 @@ derived_table: {
 
   measure: delta_from_forecast_new_profiles_count {
     type: number
-    value_format: "0"
+    value_format: "#,##0"
     sql: ${new_profiles_cumulative} - ${prediction.cum_new_profiles_forecast}  ;;
   }
 
   measure: delta_from_target_new_profiles_count {
     type: number
-    value_format: "0"
+    value_format: "#,##0"
     sql: ${new_profiles_cumulative} - ${prediction.cum_new_profiles_target} ;;
   }
+
 }

--- a/KPI/views/firefox_desktop_usage_fields.view.lkml
+++ b/KPI/views/firefox_desktop_usage_fields.view.lkml
@@ -1,15 +1,5 @@
 view: firefox_desktop_usage_fields {
-  derived_table: {
-    sql:
-      select
-        u.* EXCEPT(country),
-        COALESCE(n.name, u.country) as country
-      from
-        `mozdata.telemetry.firefox_desktop_usage_2021` u
-      left join `moz-fx-data-shared-prod.static.country_codes_v1` n
-        on u.country = n.code
-    ;;
-  }
+  sql_table_name: mozdata.telemetry.firefox_desktop_usage_2021 ;;
 
   dimension: activity_segment {
     type: string
@@ -35,6 +25,12 @@ view: firefox_desktop_usage_fields {
     type: string
     map_layer_name: countries
     sql: ${TABLE}.country ;;
+  }
+
+  dimension: country_name {
+    type: string
+    map_layer_name: countries
+    sql: ${TABLE}.country_name ;;
   }
 
   dimension: distribution_id {
@@ -72,35 +68,4 @@ view: firefox_desktop_usage_fields {
     convert_tz: no
     sql: CAST(${TABLE}.submission_date AS TIMESTAMP) ;;
   }
-
-  measure: dau {
-    type: sum
-    value_format: "#,##0"
-    sql: ${TABLE}.dau ;;
-  }
-
-  measure: mau {
-    type: sum
-    value_format: "#,##0"
-    sql: ${TABLE}.mau ;;
-  }
-
-  measure: new_profiles {
-    type: sum
-    value_format: "#,##0"
-    sql: ${TABLE}.new_profiles ;;
-  }
-
-  measure: new_profiles_cumulative {
-    type: sum
-    value_format: "#,##0"
-    sql: ${TABLE}.cumulative_new_profiles ;;
-  }
-
-  measure: cdou {
-    type: sum
-    value_format: "#,##0"
-    sql: ${TABLE}.cdou ;;
-  }
-
 }

--- a/KPI/views/firefox_desktop_usage_fields.view.lkml
+++ b/KPI/views/firefox_desktop_usage_fields.view.lkml
@@ -1,5 +1,15 @@
 view: firefox_desktop_usage_fields {
-  sql_table_name: mozdata.telemetry.firefox_desktop_usage_2021 ;;
+  derived_table: {
+    sql:
+      select
+        u.* EXCEPT(country),
+        COALESCE(n.name, u.country) as country
+      from
+        `mozdata.telemetry.firefox_desktop_usage_2021` u
+      left join `moz-fx-data-shared-prod.static.country_codes_v1` n
+        on u.country = n.code
+    ;;
+  }
 
   dimension: activity_segment {
     type: string
@@ -62,4 +72,35 @@ view: firefox_desktop_usage_fields {
     convert_tz: no
     sql: CAST(${TABLE}.submission_date AS TIMESTAMP) ;;
   }
+
+  measure: dau {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.dau ;;
+  }
+
+  measure: mau {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.mau ;;
+  }
+
+  measure: new_profiles {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.new_profiles ;;
+  }
+
+  measure: new_profiles_cumulative {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.cumulative_new_profiles ;;
+  }
+
+  measure: cdou {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.cdou ;;
+  }
+
 }

--- a/KPI/views/firefox_desktop_usage_forecast.view.lkml
+++ b/KPI/views/firefox_desktop_usage_forecast.view.lkml
@@ -209,66 +209,79 @@ view: prediction {
 
   measure: cdou_forecast {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.cdou_forecast) ;;
   }
 
   measure: cdou_target {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.cdou_target) ;;
   }
 
   measure: cum_new_profiles_forecast {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.cum_new_profiles_forecast) ;;
   }
 
   measure: cum_new_profiles_target {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.cum_new_profiles_target) ;;
   }
 
   measure: dau_forecast {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.dau_forecast) ;;
   }
 
   measure: dau_forecast_lower {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.dau_forecast_lower) ;;
   }
 
   measure: dau_forecast_upper {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.dau_forecast_upper) ;;
   }
 
   measure: dau_target {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.dau_target) ;;
   }
 
   measure: new_profiles_forecast {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.new_profiles_forecast) ;;
   }
 
   measure: new_profiles_forecast_lower {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.new_profiles_forecast_lower) ;;
   }
 
   measure: new_profiles_forecast_upper {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.new_profiles_forecast_upper) ;;
   }
 
   measure: new_profiles_target {
     type: number
+    value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.new_profiles_target) ;;
   }
 
   measure: recent_cum_new_profiles_forecast {
     type: max
+    value_format: "#,##0"
     sql: ${TABLE}.cum_new_profiles_forecast ;;
     filters: [
       date: "after 2021-01-01"
@@ -277,6 +290,7 @@ view: prediction {
 
   measure: recent_cum_new_profiles_target {
     type: max
+    value_format: "#,##0"
     sql: ${TABLE}.cum_new_profiles_target ;;
     filters: [
       date: "after 2021-01-01"
@@ -285,6 +299,7 @@ view: prediction {
 
   measure: recent_cdou_forecast {
     type: max
+    value_format: "#,##0"
     sql: ${TABLE}.cdou_forecast ;;
     filters: [
       date: "after 2021-01-01"
@@ -293,6 +308,7 @@ view: prediction {
 
   measure: recent_cdou_target {
     type: max
+    value_format: "#,##0"
     sql: ${TABLE}.cdou_target ;;
     filters: [
       date: "after 2021-01-01"

--- a/KPI/views/firefox_desktop_usage_forecast.view.lkml
+++ b/KPI/views/firefox_desktop_usage_forecast.view.lkml
@@ -8,6 +8,7 @@ view: dau_model {
       {% condition firefox_desktop_usage_2021.channel %} channel {% endcondition %}
       {% condition firefox_desktop_usage_2021.content %} content {% endcondition %}
       {% condition firefox_desktop_usage_2021.country %} country {% endcondition %}
+      {% condition firefox_desktop_usage_2021.country_name %} country_name {% endcondition %}
       {% condition firefox_desktop_usage_2021.distribution_id %} distribution_id {% endcondition %}
       {% condition firefox_desktop_usage_2021.id_bucket %} id_bucket {% endcondition %}
       {% condition firefox_desktop_usage_2021.medium %} medium {% endcondition %}
@@ -54,6 +55,7 @@ view: new_profiles_model {
       {% condition firefox_desktop_usage_2021.channel %} channel {% endcondition %}
       {% condition firefox_desktop_usage_2021.content %} content {% endcondition %}
       {% condition firefox_desktop_usage_2021.country %} country {% endcondition %}
+      {% condition firefox_desktop_usage_2021.country_name %} country_name {% endcondition %}
       {% condition firefox_desktop_usage_2021.distribution_id %} distribution_id {% endcondition %}
       {% condition firefox_desktop_usage_2021.id_bucket %} id_bucket {% endcondition %}
       {% condition firefox_desktop_usage_2021.medium %} medium {% endcondition %}
@@ -97,6 +99,7 @@ view: insert_stmnt {
       {% condition firefox_desktop_usage_2021.channel %} channel {% endcondition %}
       {% condition firefox_desktop_usage_2021.content %} content {% endcondition %}
       {% condition firefox_desktop_usage_2021.country %} country {% endcondition %}
+      {% condition firefox_desktop_usage_2021.country_name %} country_name {% endcondition %}
       {% condition firefox_desktop_usage_2021.distribution_id %} distribution_id {% endcondition %}
       {% condition firefox_desktop_usage_2021.id_bucket %} id_bucket {% endcondition %}
       {% condition firefox_desktop_usage_2021.medium %} medium {% endcondition %}
@@ -193,6 +196,7 @@ view: prediction {
       {% condition firefox_desktop_usage_2021.channel %} channel {% endcondition %}
       {% condition firefox_desktop_usage_2021.content %} content {% endcondition %}
       {% condition firefox_desktop_usage_2021.country %} country {% endcondition %}
+      {% condition firefox_desktop_usage_2021.country_name %} country_name {% endcondition %}
       {% condition firefox_desktop_usage_2021.distribution_id %} distribution_id {% endcondition %}
       {% condition firefox_desktop_usage_2021.id_bucket %} id_bucket {% endcondition %}
       {% condition firefox_desktop_usage_2021.medium %} medium {% endcondition %}

--- a/firefox-desktop/views/mobile_forecasts.view.lkml
+++ b/firefox-desktop/views/mobile_forecasts.view.lkml
@@ -28,7 +28,7 @@ view: mobile_forecasts {
             date,
             yhat,
             yhat_p0,
-            * EXCEPT(dateyhatyhat_p0),
+            * EXCEPT(date, yhat, yhat_p0),
             .028 AS target_lift
           FROM  `mozdata.analysis.final_fx_ios_2021_forecast`
         )
@@ -39,8 +39,8 @@ view: mobile_forecasts {
               WHEN product = "Focus iOS" THEN "focus_ios"
               WHEN product = "Firefox Android" THEN "fennec_fenix"
               WHEN product = "Firefox iOS" THEN "focus_ios" END AS app_name,
-          SUM(yhat) OVER (PARTITION BY product EXTRACT(year FROM DATE(date)) ORDER BY date) AS yhat_cumulative,
-          SUM(yhat) OVER (PARTITION BY product EXTRACT(year FROM DATE(date)) ORDER BY date) * (1 + target_lift) AS target_pace
+          SUM(yhat) OVER (PARTITION BY product, EXTRACT(year FROM DATE(date)) ORDER BY date) AS yhat_cumulative,
+          SUM(yhat) OVER (PARTITION BY product, EXTRACT(year FROM DATE(date)) ORDER BY date) * (1 + target_lift) AS target_pace
         FROM base
       ;;
   }


### PR DESCRIPTION
Most of this is changes to the actual dashboard, adding info text, renaming things, etc.

I did make one noticeable change to the KPI views. I joined the `firefox_desktop_usage_2021` onto `moz-fx-data-shared-prod.static.country_codes_v1` to get the readable names of countries, so those will be displayed in the filter instead of the two letter country code. I had to move some things around but it seemed to work when I tested it. We could also consider adding the country names directly to the underlying `firefox_desktop_usage_2021` BQ table, which would make the in-looker join unnecessary. Notice that I coalesce the country code with the country name, so if no matching name is found then it displays the code. this does seem to happen in a couple of cases. 

