### PR TITLE
change KPI dash to show 7 day movoing averages

### DIFF
--- a/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
@@ -284,7 +284,7 @@
     type: looker_line
     fields: [firefox_desktop_usage_2021.date, firefox_desktop_usage_2021.new_profiles_7day_ma,
       prediction.new_profiles_forecast_7day_ma, prediction.new_profiles_forecast_lower_7day_ma,
-      prediction.new_profiles_forecast_upper_7day_ma]
+      prediction.new_profiles_forecast_upper_7day_ma, firefox_desktop_usage_2021.year_over_year_new_profiles_7day_ma]
     fill_fields: [firefox_desktop_usage_2021.date]
     sorts: [firefox_desktop_usage_2021.date desc]
     limit: 500

--- a/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
@@ -9,8 +9,8 @@
     model: kpi
     explore: firefox_desktop_usage_2021
     type: looker_line
-    fields: [firefox_desktop_usage_2021.dau, firefox_desktop_usage_2021.date, prediction.dau_forecast,
-      prediction.dau_forecast_lower, prediction.dau_forecast_upper]
+    fields: [firefox_desktop_usage_2021.date, firefox_desktop_usage_2021.dau_7day_ma,
+      prediction.dau_forecast_7day_ma, prediction.dau_forecast_lower_7day_ma, prediction.dau_forecast_upper_7day_ma]
     fill_fields: [firefox_desktop_usage_2021.date]
     sorts: [firefox_desktop_usage_2021.date desc]
     limit: 500
@@ -38,6 +38,14 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: firefox_desktop_usage_2021.dau_7day_ma,
+            id: firefox_desktop_usage_2021.dau_7day_ma, name: DAU (7 Day MA)}, {axisId: prediction.dau_forecast_7day_ma,
+            id: prediction.dau_forecast_7day_ma, name: DAU Forecast (7 Day MA)}, {
+            axisId: prediction.dau_forecast_lower_7day_ma, id: prediction.dau_forecast_lower_7day_ma,
+            name: DAU Forecast Lower Bound}, {axisId: prediction.dau_forecast_upper_7day_ma,
+            id: prediction.dau_forecast_upper_7day_ma, name: DAU Forecast Upper Bound}],
+        showLabels: true, showValues: true, minValue: 50000000, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}]
     series_types:
       prediction.dau_forecast_lower: scatter
       prediction.dau_forecast_upper: scatter
@@ -45,11 +53,17 @@
     series_colors:
       prediction.dau_forecast_upper: "#b7b5c2"
       prediction.dau_forecast_lower: "#b7b5c2"
+      prediction.dau_forecast_lower_7day_ma: "#80868B"
+      prediction.dau_forecast_upper_7day_ma: "#80868B"
+    series_labels:
+      firefox_desktop_usage_2021.dau_7day_ma: DAU (7 Day MA)
+      prediction.dau_forecast_7day_ma: DAU Forecast (7 Day MA)
+      prediction.dau_forecast_lower_7day_ma: DAU Forecast Lower Bound
+      prediction.dau_forecast_upper_7day_ma: DAU Forecast Upper Bound
     series_point_styles:
       prediction.dau_forecast_lower: triangle
       prediction.dau_forecast_upper: triangle-down
-    trend_lines: [{color: "#000000", label_position: center, period: 7, regression_type: average,
-        series_index: 1, show_label: true}]
+    trend_lines: []
     defaults_version: 1
     hidden_fields:
     note_state: collapsed
@@ -268,8 +282,9 @@
     model: kpi
     explore: firefox_desktop_usage_2021
     type: looker_line
-    fields: [firefox_desktop_usage_2021.new_profiles, firefox_desktop_usage_2021.date,
-      prediction.new_profiles_forecast, prediction.new_profiles_forecast_lower, prediction.new_profiles_forecast_upper]
+    fields: [firefox_desktop_usage_2021.date, firefox_desktop_usage_2021.new_profiles_7day_ma,
+      prediction.new_profiles_forecast_7day_ma, prediction.new_profiles_forecast_lower_7day_ma,
+      prediction.new_profiles_forecast_upper_7day_ma]
     fill_fields: [firefox_desktop_usage_2021.date]
     sorts: [firefox_desktop_usage_2021.date desc]
     limit: 500
@@ -297,6 +312,15 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: firefox_desktop_usage_2021.new_profiles_7day_ma,
+            id: firefox_desktop_usage_2021.new_profiles_7day_ma, name: New Profiles
+              (7 Day MA)}, {axisId: prediction.new_profiles_forecast_7day_ma, id: prediction.new_profiles_forecast_7day_ma,
+            name: New Profiles Forecast (7 Day MA)}, {axisId: prediction.new_profiles_forecast_lower_7day_ma,
+            id: prediction.new_profiles_forecast_lower_7day_ma, name: New Profiles
+              Lower Bound}, {axisId: prediction.new_profiles_forecast_upper_7day_ma,
+            id: prediction.new_profiles_forecast_upper_7day_ma, name: New Profiles
+              Upper Bound}], showLabels: true, showValues: true, minValue: 500000,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     series_types:
       prediction.new_profiles_forecast_lower: scatter
       prediction.new_profiles_forecast_upper: scatter
@@ -305,15 +329,22 @@
       prediction.new_profiles_forecast_lower: "#b7b5c2"
       prediction.new_profiles_forecast_upper: "#b7b5c2"
       prediction.new_profiles_forecast: "#E52592"
+      prediction.new_profiles_forecast_lower_7day_ma: "#80868B"
+      prediction.new_profiles_forecast_upper_7day_ma: "#80868B"
     series_labels:
       prediction.new_profiles_forecast_lower: Forecast Lower
       prediction.new_profiles_forecast_upper: Forecast Upper
       prediction.new_profiles_forecast: Forecast
+      firefox_desktop_usage_2021.new_profiles_7day_ma: New Profiles (7 Day MA)
+      prediction.new_profiles_forecast_7day_ma: New Profiles Forecast (7 Day MA)
+      prediction.new_profiles_forecast_lower_7day_ma: New Profiles Forecast Lower
+        Bound
+      prediction.new_profiles_forecast_upper_7day_ma: New Profiles Forecast Upper
+        Bound
     series_point_styles:
       prediction.new_profiles_forecast_lower: triangle
       prediction.new_profiles_forecast_upper: triangle-down
-    trend_lines: [{color: "#000000", label_position: center, period: 7, regression_type: average,
-        series_index: 1, show_label: true}]
+    trend_lines: []
     defaults_version: 1
     note_state: collapsed
     note_display: hover

--- a/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
@@ -10,7 +10,8 @@
     explore: firefox_desktop_usage_2021
     type: looker_line
     fields: [firefox_desktop_usage_2021.date, firefox_desktop_usage_2021.dau_7day_ma,
-      prediction.dau_forecast_7day_ma, prediction.dau_forecast_lower_7day_ma, prediction.dau_forecast_upper_7day_ma]
+      prediction.dau_forecast_7day_ma, prediction.dau_forecast_lower_7day_ma, prediction.dau_forecast_upper_7day_ma,
+      firefox_desktop_usage_2021.year_over_year_dau_7day_ma]
     fill_fields: [firefox_desktop_usage_2021.date]
     sorts: [firefox_desktop_usage_2021.date desc]
     limit: 500

--- a/KPI/views/firefox_desktop_usage_2021.view.lkml
+++ b/KPI/views/firefox_desktop_usage_2021.view.lkml
@@ -296,6 +296,12 @@ derived_table: {
     sql: ${firefox_desktop_usage_2020.dau} ;;
   }
 
+  measure: year_over_year_dau_7day_ma {
+    label: "2020 Dau MA"
+    type: number
+    sql: ${firefox_desktop_usage_2020.dau_7day_ma} ;;
+  }
+
   measure: year_over_year_wau {
     label: "2020 Wau"
     type: number
@@ -325,6 +331,12 @@ derived_table: {
     label: "2020 New Profiles"
     type: number
     sql: ${firefox_desktop_usage_2020.new_profiles} ;;
+  }
+
+  measure: year_over_year_new_profiles_7day_ma {
+    label: "2020 New Profiles MA"
+    type: number
+    sql: ${firefox_desktop_usage_2020.new_profiles_7day_ma} ;;
   }
 
   measure: year_over_year_new_profiles_cumulative {

--- a/KPI/views/firefox_desktop_usage_forecast.view.lkml
+++ b/KPI/views/firefox_desktop_usage_forecast.view.lkml
@@ -186,7 +186,15 @@ view: prediction {
   derived_table: {
     sql:
     SELECT
-      *
+      *,
+      avg(dau_forecast) over (order by submission_date rows between 6 preceding and current row) as dau_forecast_7day_ma,
+      avg(dau_target) over (order by submission_date rows between 6 preceding and current row) as dau_target_7day_ma,
+      avg(dau_forecast_lower) over (order by submission_date rows between 6 preceding and current row) as dau_forecast_lower_7day_ma,
+      avg(dau_forecast_upper) over (order by submission_date rows between 6 preceding and current row) as dau_forecast_upper_7day_ma,
+      avg(new_profiles_forecast) over (order by submission_date rows between 6 preceding and current row) as new_profiles_forecast_7day_ma,
+      avg(new_profiles_target) over (order by submission_date rows between 6 preceding and current row) as new_profiles_target_7day_ma,
+      avg(new_profiles_forecast_lower) over (order by submission_date rows between 6 preceding and current row) as new_profiles_forecast_lower_7day_ma,
+      avg(new_profiles_forecast_upper) over (order by submission_date rows between 6 preceding and current row) as new_profiles_forecast_upper_7day_ma
     FROM
       mozdata.analysis.dou_forecasts
     WHERE -- Also requires ${insert_stmnt.SQL_TABLE_NAME}
@@ -241,10 +249,22 @@ view: prediction {
     sql: ANY_VALUE(${TABLE}.dau_forecast) ;;
   }
 
+  measure: dau_forecast_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.dau_forecast_7day_ma) ;;
+  }
+
   measure: dau_forecast_lower {
     type: number
     value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.dau_forecast_lower) ;;
+  }
+
+  measure: dau_forecast_lower_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.dau_forecast_lower_7day_ma) ;;
   }
 
   measure: dau_forecast_upper {
@@ -253,10 +273,22 @@ view: prediction {
     sql: ANY_VALUE(${TABLE}.dau_forecast_upper) ;;
   }
 
+  measure: dau_forecast_upper_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.dau_forecast_upper_7day_ma) ;;
+  }
+
   measure: dau_target {
     type: number
     value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.dau_target) ;;
+  }
+
+  measure: dau_target_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.dau_target_7day_ma) ;;
   }
 
   measure: new_profiles_forecast {
@@ -265,10 +297,22 @@ view: prediction {
     sql: ANY_VALUE(${TABLE}.new_profiles_forecast) ;;
   }
 
+  measure: new_profiles_forecast_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.new_profiles_forecast_7day_ma) ;;
+  }
+
   measure: new_profiles_forecast_lower {
     type: number
     value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.new_profiles_forecast_lower) ;;
+  }
+
+  measure: new_profiles_forecast_lower_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.new_profiles_forecast_lower_7day_ma) ;;
   }
 
   measure: new_profiles_forecast_upper {
@@ -277,10 +321,22 @@ view: prediction {
     sql: ANY_VALUE(${TABLE}.new_profiles_forecast_upper) ;;
   }
 
+  measure: new_profiles_forecast_upper_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.new_profiles_forecast_upper_7day_ma) ;;
+  }
+
   measure: new_profiles_target {
     type: number
     value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.new_profiles_target) ;;
+  }
+
+  measure: new_profiles_target_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.new_profiles_target_7day_ma) ;;
   }
 
   measure: recent_cum_new_profiles_forecast {

--- a/KPI/views/firefox_desktop_usage_forecast.view.lkml
+++ b/KPI/views/firefox_desktop_usage_forecast.view.lkml
@@ -188,13 +188,13 @@ view: prediction {
     SELECT
       *,
       AVG(dau_forecast) OVER window_7day AS dau_forecast_7day_ma,
-      avg(dau_target) over (order by submission_date rows between 6 preceding and current row) as dau_target_7day_ma,
-      avg(dau_forecast_lower) over (order by submission_date rows between 6 preceding and current row) as dau_forecast_lower_7day_ma,
-      avg(dau_forecast_upper) over (order by submission_date rows between 6 preceding and current row) as dau_forecast_upper_7day_ma,
-      avg(new_profiles_forecast) over (order by submission_date rows between 6 preceding and current row) as new_profiles_forecast_7day_ma,
-      avg(new_profiles_target) over (order by submission_date rows between 6 preceding and current row) as new_profiles_target_7day_ma,
-      avg(new_profiles_forecast_lower) over (order by submission_date rows between 6 preceding and current row) as new_profiles_forecast_lower_7day_ma,
-      avg(new_profiles_forecast_upper) over (order by submission_date rows between 6 preceding and current row) as new_profiles_forecast_upper_7day_ma
+      avg(dau_target) over window_7day as dau_target_7day_ma,
+      avg(dau_forecast_lower) over window_7day as dau_forecast_lower_7day_ma,
+      avg(dau_forecast_upper) over window_7day as dau_forecast_upper_7day_ma,
+      avg(new_profiles_forecast) over window_7day as new_profiles_forecast_7day_ma,
+      avg(new_profiles_target) over window_7day as new_profiles_target_7day_ma,
+      avg(new_profiles_forecast_lower) over window_7day as new_profiles_forecast_lower_7day_ma,
+      avg(new_profiles_forecast_upper) over window_7day as new_profiles_forecast_upper_7day_ma
     FROM
       mozdata.analysis.dou_forecasts
     WHERE -- Also requires ${insert_stmnt.SQL_TABLE_NAME}
@@ -211,7 +211,8 @@ view: prediction {
       {% condition firefox_desktop_usage_2021.os %} os {% endcondition %}
       {% condition firefox_desktop_usage_2021.source %} source {% endcondition %}
       {% condition firefox_desktop_usage_2021.attributed %} (attributed) {% endcondition %}
-      """, r"(\(.*\))"), '');;
+      """, r"(\(.*\))"), '')
+    WINDOW window_7day AS (order by submission_date rows between 6 preceding and current row);;
   }
 
   dimension: date {

--- a/KPI/views/firefox_desktop_usage_forecast.view.lkml
+++ b/KPI/views/firefox_desktop_usage_forecast.view.lkml
@@ -187,7 +187,7 @@ view: prediction {
     sql:
     SELECT
       *,
-      avg(dau_forecast) over (order by submission_date rows between 6 preceding and current row) as dau_forecast_7day_ma,
+      AVG(dau_forecast) OVER window_7day AS dau_forecast_7day_ma,
       avg(dau_target) over (order by submission_date rows between 6 preceding and current row) as dau_target_7day_ma,
       avg(dau_forecast_lower) over (order by submission_date rows between 6 preceding and current row) as dau_forecast_lower_7day_ma,
       avg(dau_forecast_upper) over (order by submission_date rows between 6 preceding and current row) as dau_forecast_upper_7day_ma,


### PR DESCRIPTION
We got a request to show moving averages for the dau and new profiles kpis on the dashboard rather than the raw daily values. This does that. 

