### PR TITLE
mobile new profiles and kpi dashboard

### DIFF
--- a/KPI/dashboards/mobile_kpis.dashboard.lookml
+++ b/KPI/dashboards/mobile_kpis.dashboard.lookml
@@ -2,7 +2,7 @@
   title: Mobile KPIs
   layout: newspaper
   preferred_viewer: dashboards-next
-  refresh: 12 hours
+  refresh: 2147484 seconds
   elements:
   - title: Firefox for Android (Fennec + Fenix) Daily Active Users (DAU)
     name: Firefox for Android (Fennec + Fenix) Daily Active Users (DAU)
@@ -59,6 +59,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 17
     col: 12
     width: 12
@@ -118,6 +119,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 72
     col: 11
     width: 13
@@ -177,6 +179,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 45
     col: 12
     width: 12
@@ -236,6 +239,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 98
     col: 11
     width: 13
@@ -261,6 +265,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 0
     col: 0
     width: 24
@@ -286,6 +291,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 54
     col: 0
     width: 24
@@ -311,6 +317,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 27
     col: 0
     width: 24
@@ -336,6 +343,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 81
     col: 0
     width: 24
@@ -384,6 +392,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 8
     col: 12
     width: 12
@@ -432,6 +441,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 36
     col: 12
     width: 12
@@ -480,6 +490,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 89
     col: 11
     width: 13
@@ -528,6 +539,7 @@
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 63
     col: 11
     width: 13
@@ -568,11 +580,9 @@
     show_null_points: true
     interpolation: linear
     y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.delta_from_target_count,
-            id: mobile_usage_2021.delta_from_target_count, name: Delta From Target
-              Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}, {label: !!null '', orientation: right,
-        series: [{axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
-            name: Delta From Forecast Count}], showLabels: true, showValues: true,
+            id: mobile_usage_2021.delta_from_target_count, name: Difference From Target},
+          {axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
+            name: Difference From Forecast}], showLabels: true, showValues: true,
         unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     series_types: {}
     series_labels:
@@ -580,10 +590,11 @@
       mobile_usage_2021.delta_from_forecast_count: Difference From Forecast
     reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
         margin_value: mean, margin_bottom: deviation, label_position: center, color: "#000000",
-        line_value: '0', label: At Target (Left) / Forecast (Right)}]
+        line_value: '0', label: At Target / Forecast}]
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 8
     col: 0
     width: 12
@@ -624,11 +635,9 @@
     show_null_points: true
     interpolation: linear
     y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.delta_from_target_count,
-            id: mobile_usage_2021.delta_from_target_count, name: Delta From Target
-              Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}, {label: !!null '', orientation: right,
-        series: [{axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
-            name: Delta From Forecast Count}], showLabels: true, showValues: true,
+            id: mobile_usage_2021.delta_from_target_count, name: Difference From Target},
+          {axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
+            name: Difference From Forecast}], showLabels: true, showValues: true,
         unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     series_types: {}
     series_labels:
@@ -636,10 +645,11 @@
       mobile_usage_2021.delta_from_forecast_count: Difference From Forecast
     reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
         margin_value: mean, margin_bottom: deviation, label_position: center, color: "#000000",
-        line_value: '0', label: At Target (Left) / Forecast (Right)}]
+        line_value: '0', label: At Target / Forecast}]
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 89
     col: 0
     width: 11
@@ -680,11 +690,9 @@
     show_null_points: true
     interpolation: linear
     y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.delta_from_target_count,
-            id: mobile_usage_2021.delta_from_target_count, name: Delta From Target
-              Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}, {label: !!null '', orientation: right,
-        series: [{axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
-            name: Delta From Forecast Count}], showLabels: true, showValues: true,
+            id: mobile_usage_2021.delta_from_target_count, name: Difference From Target},
+          {axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
+            name: Difference From Forecast}], showLabels: true, showValues: true,
         unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     series_types: {}
     series_labels:
@@ -692,10 +700,11 @@
       mobile_usage_2021.delta_from_forecast_count: Difference From Forecast
     reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
         margin_value: mean, margin_bottom: deviation, label_position: center, color: "#000000",
-        line_value: '0', label: At Target (Left) / Forecast (Right)}]
+        line_value: '0', label: At Target / Forecast}]
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 63
     col: 0
     width: 11
@@ -736,11 +745,9 @@
     show_null_points: true
     interpolation: linear
     y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.delta_from_target_count,
-            id: mobile_usage_2021.delta_from_target_count, name: Delta From Target
-              Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}, {label: !!null '', orientation: right,
-        series: [{axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
-            name: Delta From Forecast Count}], showLabels: true, showValues: true,
+            id: mobile_usage_2021.delta_from_target_count, name: Difference From Target},
+          {axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
+            name: Difference From Forecast}], showLabels: true, showValues: true,
         unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     series_types: {}
     series_labels:
@@ -748,10 +755,11 @@
       mobile_usage_2021.delta_from_forecast_count: Difference From Forecast
     reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
         margin_value: mean, margin_bottom: deviation, label_position: center, color: "#000000",
-        line_value: '0', label: At Target (Left) / Forecast (Right)}]
+        line_value: '0', label: At Target / Forecast}]
     defaults_version: 1
     listen:
       Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 36
     col: 0
     width: 12
@@ -970,7 +978,6 @@
     fill_fields: [mobile_usage_2021.date]
     filters:
       mobile_usage_2021.app_name: '"fennec_fenix"'
-      mobile_usage_2021.date: after 2021/01/01
     sorts: [mobile_usage_2021.date]
     limit: 500
     show_view_names: false
@@ -1022,7 +1029,9 @@
     show_comparison_label: true
     defaults_version: 1
     title_hidden: true
-    listen: {}
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 17
     col: 0
     width: 12
@@ -1037,7 +1046,6 @@
     fill_fields: [mobile_usage_2021.date]
     filters:
       mobile_usage_2021.app_name: '"firefox_ios"'
-      mobile_usage_2021.date: after 2021/01/01
     sorts: [mobile_usage_2021.date]
     limit: 500
     show_view_names: false
@@ -1089,6 +1097,9 @@
     show_comparison_label: true
     defaults_version: 1
     title_hidden: true
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 45
     col: 0
     width: 12
@@ -1103,7 +1114,6 @@
     fill_fields: [mobile_usage_2021.date]
     filters:
       mobile_usage_2021.app_name: '"focus_android"'
-      mobile_usage_2021.date: after 2021/01/01
     sorts: [mobile_usage_2021.date]
     limit: 500
     show_view_names: false
@@ -1155,6 +1165,9 @@
     show_comparison_label: true
     defaults_version: 1
     title_hidden: true
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 72
     col: 0
     width: 11
@@ -1169,7 +1182,6 @@
     fill_fields: [mobile_usage_2021.date]
     filters:
       mobile_usage_2021.app_name: '"focus_ios"'
-      mobile_usage_2021.date: after 2021/01/01
     sorts: [mobile_usage_2021.date]
     limit: 500
     show_view_names: false
@@ -1221,6 +1233,9 @@
     show_comparison_label: true
     defaults_version: 1
     title_hidden: true
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
     row: 98
     col: 0
     width: 11

--- a/KPI/dashboards/mobile_kpis.dashboard.lookml
+++ b/KPI/dashboards/mobile_kpis.dashboard.lookml
@@ -1,0 +1,1256 @@
+- dashboard: mobile_kpis
+  title: Mobile KPIs
+  layout: newspaper
+  preferred_viewer: dashboards-next
+  refresh: 12 hours
+  elements:
+  - title: Firefox for Android (Fennec + Fenix) Daily Active Users (DAU)
+    name: Firefox for Android (Fennec + Fenix) Daily Active Users (DAU)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.dau_7day_ma, mobile_prediction.dau_forecast_7day_ma,
+      mobile_prediction.dau_forecast_lower_7day_ma, mobile_prediction.dau_forecast_upper_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"fennec_fenix"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.dau_7day_ma,
+            id: mobile_usage_2021.dau_7day_ma, name: DAU (7 Day Moving Average)},
+          {axisId: mobile_prediction.dau_forecast_7day_ma, id: mobile_prediction.dau_forecast_7day_ma,
+            name: DAU Forecast (7 Day MA)}, {axisId: mobile_prediction.dau_forecast_lower_7day_ma,
+            id: mobile_prediction.dau_forecast_lower_7day_ma, name: Forecast Lower
+              Bound}, {axisId: mobile_prediction.dau_forecast_upper_7day_ma, id: mobile_prediction.dau_forecast_upper_7day_ma,
+            name: Forecast Upper Bound}], showLabels: true, showValues: true, minValue: !!null '',
+        unpinAxis: true, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_colors:
+      mobile_prediction.dau_forecast_lower_7day_ma: "#80868B"
+      mobile_prediction.dau_forecast_upper_7day_ma: "#80868B"
+    series_labels:
+      mobile_prediction.dau_forecast_upper_7day_ma: Forecast Upper Bound
+      mobile_prediction.dau_forecast_lower_7day_ma: Forecast Lower Bound
+      mobile_prediction.dau_forecast_7day_ma: DAU Forecast (7 Day MA)
+      mobile_usage_2021.dau_7day_ma: DAU (7 Day Moving Average)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 17
+    col: 12
+    width: 12
+    height: 10
+  - title: Focus Android Daily Active Users (DAU)
+    name: Focus Android Daily Active Users (DAU)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.dau_7day_ma, mobile_prediction.dau_forecast_7day_ma,
+      mobile_prediction.dau_forecast_lower_7day_ma, mobile_prediction.dau_forecast_upper_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_android"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.dau_7day_ma,
+            id: mobile_usage_2021.dau_7day_ma, name: DAU (7 Day Moving Average)},
+          {axisId: mobile_prediction.dau_forecast_7day_ma, id: mobile_prediction.dau_forecast_7day_ma,
+            name: DAU Forecast (7 Day MA)}, {axisId: mobile_prediction.dau_forecast_lower_7day_ma,
+            id: mobile_prediction.dau_forecast_lower_7day_ma, name: Forecast Lower
+              Bound}, {axisId: mobile_prediction.dau_forecast_upper_7day_ma, id: mobile_prediction.dau_forecast_upper_7day_ma,
+            name: Forecast Upper Bound}], showLabels: true, showValues: true, minValue: !!null '',
+        unpinAxis: true, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_colors:
+      mobile_prediction.dau_forecast_lower_7day_ma: "#80868B"
+      mobile_prediction.dau_forecast_upper_7day_ma: "#80868B"
+    series_labels:
+      mobile_prediction.dau_forecast_upper_7day_ma: Forecast Upper Bound
+      mobile_prediction.dau_forecast_lower_7day_ma: Forecast Lower Bound
+      mobile_prediction.dau_forecast_7day_ma: DAU Forecast (7 Day MA)
+      mobile_usage_2021.dau_7day_ma: DAU (7 Day Moving Average)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 72
+    col: 11
+    width: 13
+    height: 9
+  - title: Firefox for iOS Daily Active Users (DAU)
+    name: Firefox for iOS Daily Active Users (DAU)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.dau_7day_ma, mobile_prediction.dau_forecast_7day_ma,
+      mobile_prediction.dau_forecast_lower_7day_ma, mobile_prediction.dau_forecast_upper_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"firefox_ios"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.dau_7day_ma,
+            id: mobile_usage_2021.dau_7day_ma, name: DAU (7 Day Moving Average)},
+          {axisId: mobile_prediction.dau_forecast_7day_ma, id: mobile_prediction.dau_forecast_7day_ma,
+            name: DAU Forecast (7 Day MA)}, {axisId: mobile_prediction.dau_forecast_lower_7day_ma,
+            id: mobile_prediction.dau_forecast_lower_7day_ma, name: Forecast Lower
+              Bound}, {axisId: mobile_prediction.dau_forecast_upper_7day_ma, id: mobile_prediction.dau_forecast_upper_7day_ma,
+            name: Forecast Upper Bound}], showLabels: true, showValues: true, minValue: !!null '',
+        unpinAxis: true, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_colors:
+      mobile_prediction.dau_forecast_lower_7day_ma: "#80868B"
+      mobile_prediction.dau_forecast_upper_7day_ma: "#80868B"
+    series_labels:
+      mobile_prediction.dau_forecast_upper_7day_ma: Forecast Upper Bound
+      mobile_prediction.dau_forecast_lower_7day_ma: Forecast Lower Bound
+      mobile_prediction.dau_forecast_7day_ma: DAU Forecast (7 Day MA)
+      mobile_usage_2021.dau_7day_ma: DAU (7 Day Moving Average)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 45
+    col: 12
+    width: 12
+    height: 9
+  - title: Focus iOS Daily Active Users (DAU)
+    name: Focus iOS Daily Active Users (DAU)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.dau_7day_ma, mobile_prediction.dau_forecast_7day_ma,
+      mobile_prediction.dau_forecast_lower_7day_ma, mobile_prediction.dau_forecast_upper_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_ios"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.dau_7day_ma,
+            id: mobile_usage_2021.dau_7day_ma, name: DAU (7 Day Moving Average)},
+          {axisId: mobile_prediction.dau_forecast_7day_ma, id: mobile_prediction.dau_forecast_7day_ma,
+            name: DAU Forecast (7 Day MA)}, {axisId: mobile_prediction.dau_forecast_lower_7day_ma,
+            id: mobile_prediction.dau_forecast_lower_7day_ma, name: Forecast Lower
+              Bound}, {axisId: mobile_prediction.dau_forecast_upper_7day_ma, id: mobile_prediction.dau_forecast_upper_7day_ma,
+            name: Forecast Upper Bound}], showLabels: true, showValues: true, minValue: !!null '',
+        unpinAxis: true, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_colors:
+      mobile_prediction.dau_forecast_lower_7day_ma: "#80868B"
+      mobile_prediction.dau_forecast_upper_7day_ma: "#80868B"
+    series_labels:
+      mobile_prediction.dau_forecast_upper_7day_ma: Forecast Upper Bound
+      mobile_prediction.dau_forecast_lower_7day_ma: Forecast Lower Bound
+      mobile_prediction.dau_forecast_7day_ma: DAU Forecast (7 Day MA)
+      mobile_usage_2021.dau_7day_ma: DAU (7 Day Moving Average)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 98
+    col: 11
+    width: 13
+    height: 8
+  - title: Firefox for Android (Fennec + Fenix)
+    name: Firefox for Android (Fennec + Fenix)
+    model: kpi
+    explore: mobile_usage_2021
+    type: single_value
+    fields: [mobile_usage_2021.delta_from_forecast_format]
+    filters:
+      mobile_usage_2021.app_name: '"fennec_fenix"'
+    limit: 500
+    custom_color_enabled: true
+    show_single_value_title: false
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 0
+    col: 0
+    width: 24
+    height: 8
+  - title: Focus for Android
+    name: Focus for Android
+    model: kpi
+    explore: mobile_usage_2021
+    type: single_value
+    fields: [mobile_usage_2021.delta_from_forecast_format]
+    filters:
+      mobile_usage_2021.app_name: '"focus_android"'
+    limit: 500
+    custom_color_enabled: true
+    show_single_value_title: false
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 54
+    col: 0
+    width: 24
+    height: 9
+  - title: Firefox for iOS
+    name: Firefox for iOS
+    model: kpi
+    explore: mobile_usage_2021
+    type: single_value
+    fields: [mobile_usage_2021.delta_from_forecast_format]
+    filters:
+      mobile_usage_2021.app_name: '"firefox_ios"'
+    limit: 500
+    custom_color_enabled: true
+    show_single_value_title: false
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 27
+    col: 0
+    width: 24
+    height: 9
+  - title: Focus for iOS
+    name: Focus for iOS
+    model: kpi
+    explore: mobile_usage_2021
+    type: single_value
+    fields: [mobile_usage_2021.delta_from_forecast_format]
+    filters:
+      mobile_usage_2021.app_name: '"focus_ios"'
+    limit: 500
+    custom_color_enabled: true
+    show_single_value_title: false
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 81
+    col: 0
+    width: 24
+    height: 8
+  - title: Firefox for Android CDOU Burn-Up
+    name: Firefox for Android CDOU Burn-Up
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.cdou, mobile_prediction.cdou_forecast,
+      mobile_prediction.cdou_target]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"fennec_fenix"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.cdou: Cumulative Days of Use (CDOU)
+      mobile_prediction.cdou_forecast: CDOU Forecast
+      mobile_prediction.cdou_target: CDOU Target Pace
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 8
+    col: 12
+    width: 12
+    height: 9
+  - title: Firefox for iOS CDOU Burn-Up
+    name: Firefox for iOS CDOU Burn-Up
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.cdou, mobile_prediction.cdou_forecast,
+      mobile_prediction.cdou_target]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"firefox_ios"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.cdou: Cumulative Days of Use (CDOU)
+      mobile_prediction.cdou_forecast: CDOU Forecast
+      mobile_prediction.cdou_target: CDOU Target Pace
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 36
+    col: 12
+    width: 12
+    height: 9
+  - title: Focus for iOS CDOU Burn-Up
+    name: Focus for iOS CDOU Burn-Up
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.cdou, mobile_prediction.cdou_forecast,
+      mobile_prediction.cdou_target]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_ios"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.cdou: Cumulative Days of Use (CDOU)
+      mobile_prediction.cdou_forecast: CDOU Forecast
+      mobile_prediction.cdou_target: CDOU Target Pace
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 89
+    col: 11
+    width: 13
+    height: 9
+  - title: Focus for Android CDOU Burn-Up
+    name: Focus for Android CDOU Burn-Up
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.cdou, mobile_prediction.cdou_forecast,
+      mobile_prediction.cdou_target]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_android"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.cdou: Cumulative Days of Use (CDOU)
+      mobile_prediction.cdou_forecast: CDOU Forecast
+      mobile_prediction.cdou_target: CDOU Target Pace
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 63
+    col: 11
+    width: 13
+    height: 9
+  - title: Cumulative Difference vs Target / Forecast
+    name: Cumulative Difference vs Target / Forecast
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.delta_from_target_count, mobile_usage_2021.delta_from_forecast_count]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"fennec_fenix"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.delta_from_target_count,
+            id: mobile_usage_2021.delta_from_target_count, name: Delta From Target
+              Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}, {label: !!null '', orientation: right,
+        series: [{axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
+            name: Delta From Forecast Count}], showLabels: true, showValues: true,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.delta_from_target_count: Difference From Target
+      mobile_usage_2021.delta_from_forecast_count: Difference From Forecast
+    reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
+        margin_value: mean, margin_bottom: deviation, label_position: center, color: "#000000",
+        line_value: '0', label: At Target (Left) / Forecast (Right)}]
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 8
+    col: 0
+    width: 12
+    height: 9
+  - title: Cumulative Difference vs Target / Forecast
+    name: Cumulative Difference vs Target / Forecast (2)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.delta_from_target_count, mobile_usage_2021.delta_from_forecast_count]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_ios"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.delta_from_target_count,
+            id: mobile_usage_2021.delta_from_target_count, name: Delta From Target
+              Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}, {label: !!null '', orientation: right,
+        series: [{axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
+            name: Delta From Forecast Count}], showLabels: true, showValues: true,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.delta_from_target_count: Difference From Target
+      mobile_usage_2021.delta_from_forecast_count: Difference From Forecast
+    reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
+        margin_value: mean, margin_bottom: deviation, label_position: center, color: "#000000",
+        line_value: '0', label: At Target (Left) / Forecast (Right)}]
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 89
+    col: 0
+    width: 11
+    height: 9
+  - title: Cumulative Difference vs Target / Forecast
+    name: Cumulative Difference vs Target / Forecast (3)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.delta_from_target_count, mobile_usage_2021.delta_from_forecast_count]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_android"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.delta_from_target_count,
+            id: mobile_usage_2021.delta_from_target_count, name: Delta From Target
+              Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}, {label: !!null '', orientation: right,
+        series: [{axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
+            name: Delta From Forecast Count}], showLabels: true, showValues: true,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.delta_from_target_count: Difference From Target
+      mobile_usage_2021.delta_from_forecast_count: Difference From Forecast
+    reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
+        margin_value: mean, margin_bottom: deviation, label_position: center, color: "#000000",
+        line_value: '0', label: At Target (Left) / Forecast (Right)}]
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 63
+    col: 0
+    width: 11
+    height: 9
+  - title: Cumulative Difference vs Target / Forecast
+    name: Cumulative Difference vs Target / Forecast (4)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.delta_from_target_count, mobile_usage_2021.delta_from_forecast_count]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"firefox_ios"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.delta_from_target_count,
+            id: mobile_usage_2021.delta_from_target_count, name: Delta From Target
+              Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}, {label: !!null '', orientation: right,
+        series: [{axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
+            name: Delta From Forecast Count}], showLabels: true, showValues: true,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.delta_from_target_count: Difference From Target
+      mobile_usage_2021.delta_from_forecast_count: Difference From Forecast
+    reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
+        margin_value: mean, margin_bottom: deviation, label_position: center, color: "#000000",
+        line_value: '0', label: At Target (Left) / Forecast (Right)}]
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+    row: 36
+    col: 0
+    width: 12
+    height: 9
+  - title: Firefox for Android New Profiles Per Day
+    name: Firefox for Android New Profiles Per Day
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_7day_ma, mobile_usage_2021.year_over_year_new_profiles_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"fennec_fenix"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.new_profiles_7day_ma,
+            id: mobile_usage_2021.new_profiles_7day_ma, name: New Profiles 7day Ma}],
+        showLabels: true, showValues: true, unpinAxis: true, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    series_labels:
+      mobile_usage_2021.new_profiles_7day_ma: 2021 New Profiles (7 Day MA)
+      mobile_usage_2021.year_over_year_new_profiles_7day_ma: 2020 New Profiles (7
+        Day MA)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 19
+    col: 0
+    width: 12
+    height: 8
+  - title: Firefox for iOS New Profiles Per Day
+    name: Firefox for iOS New Profiles Per Day
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_7day_ma, mobile_usage_2021.year_over_year_new_profiles_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"firefox_ios"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.new_profiles_7day_ma,
+            id: mobile_usage_2021.new_profiles_7day_ma, name: New Profiles 7day Ma}],
+        showLabels: true, showValues: true, unpinAxis: true, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    series_labels:
+      mobile_usage_2021.new_profiles_7day_ma: 2021 New Profiles (7 Day MA)
+      mobile_usage_2021.year_over_year_new_profiles_7day_ma: 2020 New Profiles (7
+        Day MA)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 47
+    col: 0
+    width: 12
+    height: 7
+  - title: Focus for iOS New Profiles Per Day
+    name: Focus for iOS New Profiles Per Day
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_7day_ma, mobile_usage_2021.year_over_year_new_profiles_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_ios"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.new_profiles_7day_ma,
+            id: mobile_usage_2021.new_profiles_7day_ma, name: New Profiles 7day Ma}],
+        showLabels: true, showValues: true, unpinAxis: true, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    series_labels:
+      mobile_usage_2021.new_profiles_7day_ma: 2021 New Profiles (7 Day MA)
+      mobile_usage_2021.year_over_year_new_profiles_7day_ma: 2020 New Profiles (7
+        Day MA)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 100
+    col: 0
+    width: 11
+    height: 6
+  - title: Focus for Android New Profiles Per Day
+    name: Focus for Android New Profiles Per Day
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_7day_ma, mobile_usage_2021.year_over_year_new_profiles_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_android"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.new_profiles_7day_ma,
+            id: mobile_usage_2021.new_profiles_7day_ma, name: New Profiles 7day Ma}],
+        showLabels: true, showValues: true, unpinAxis: true, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    series_labels:
+      mobile_usage_2021.new_profiles_7day_ma: 2021 New Profiles (7 Day MA)
+      mobile_usage_2021.year_over_year_new_profiles_7day_ma: 2020 New Profiles (7
+        Day MA)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 74
+    col: 0
+    width: 11
+    height: 7
+  - title: 2021 Cumulative New Profiles (Copy)
+    name: 2021 Cumulative New Profiles (Copy)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_grid
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_cumulative, mobile_usage_2021.year_over_year_new_profiles_cumulative,
+      mobile_usage_2021.year_over_year_new_profiles_delta]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"fennec_fenix"'
+      mobile_usage_2021.date: after 2021/01/01
+    sorts: [mobile_usage_2021.date]
+    limit: 500
+    show_view_names: false
+    show_row_numbers: false
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: true
+    enable_conditional_formatting: false
+    header_text_alignment: ''
+    header_font_size: '15'
+    rows_font_size: '30'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    series_labels:
+      mobile_usage_2021.new_profiles_cumulative: 2021  New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 2020 New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_delta: YoY % Change
+    series_column_widths:
+      mobile_usage_2021.date: 197
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 183
+      mobile_usage_2021.new_profiles_cumulative: 201
+    series_cell_visualizations:
+      mobile_usage_2021.new_profiles_cumulative:
+        is_active: false
+    series_text_format:
+      mobile_usage_2021.new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_delta:
+        align: left
+    limit_displayed_rows_values:
+      show_hide: show
+      first_last: last
+      num_rows: '1'
+    series_types: {}
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    title_hidden: true
+    listen: {}
+    row: 17
+    col: 0
+    width: 12
+    height: 2
+  - title: 2021 Cumulative New Profiles (Copy 0)
+    name: 2021 Cumulative New Profiles (Copy 0)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_grid
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_cumulative, mobile_usage_2021.year_over_year_new_profiles_cumulative,
+      mobile_usage_2021.year_over_year_new_profiles_delta]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"firefox_ios"'
+      mobile_usage_2021.date: after 2021/01/01
+    sorts: [mobile_usage_2021.date]
+    limit: 500
+    show_view_names: false
+    show_row_numbers: false
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: true
+    enable_conditional_formatting: false
+    header_text_alignment: ''
+    header_font_size: '15'
+    rows_font_size: '30'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    series_labels:
+      mobile_usage_2021.new_profiles_cumulative: 2021  New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 2020 New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_delta: YoY % Change
+    series_column_widths:
+      mobile_usage_2021.date: 197
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 183
+      mobile_usage_2021.new_profiles_cumulative: 185
+    series_cell_visualizations:
+      mobile_usage_2021.new_profiles_cumulative:
+        is_active: false
+    series_text_format:
+      mobile_usage_2021.new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_delta:
+        align: left
+    limit_displayed_rows_values:
+      show_hide: show
+      first_last: last
+      num_rows: '1'
+    series_types: {}
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    title_hidden: true
+    row: 45
+    col: 0
+    width: 12
+    height: 2
+  - title: 2021 Cumulative New Profiles (Copy 3)
+    name: 2021 Cumulative New Profiles (Copy 3)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_grid
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_cumulative, mobile_usage_2021.year_over_year_new_profiles_cumulative,
+      mobile_usage_2021.year_over_year_new_profiles_delta]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_android"'
+      mobile_usage_2021.date: after 2021/01/01
+    sorts: [mobile_usage_2021.date]
+    limit: 500
+    show_view_names: false
+    show_row_numbers: false
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: true
+    enable_conditional_formatting: false
+    header_text_alignment: ''
+    header_font_size: '15'
+    rows_font_size: '30'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    series_labels:
+      mobile_usage_2021.new_profiles_cumulative: 2021  New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 2020 New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_delta: YoY % Change
+    series_column_widths:
+      mobile_usage_2021.date: 197
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 183
+      mobile_usage_2021.new_profiles_cumulative: 185
+    series_cell_visualizations:
+      mobile_usage_2021.new_profiles_cumulative:
+        is_active: false
+    series_text_format:
+      mobile_usage_2021.new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_delta:
+        align: left
+    limit_displayed_rows_values:
+      show_hide: show
+      first_last: last
+      num_rows: '1'
+    series_types: {}
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    title_hidden: true
+    row: 72
+    col: 0
+    width: 11
+    height: 2
+  - title: 2021 Cumulative New Profiles (Copy 2)
+    name: 2021 Cumulative New Profiles (Copy 2)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_grid
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_cumulative, mobile_usage_2021.year_over_year_new_profiles_cumulative,
+      mobile_usage_2021.year_over_year_new_profiles_delta]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"focus_ios"'
+      mobile_usage_2021.date: after 2021/01/01
+    sorts: [mobile_usage_2021.date]
+    limit: 500
+    show_view_names: false
+    show_row_numbers: false
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: true
+    enable_conditional_formatting: false
+    header_text_alignment: ''
+    header_font_size: '15'
+    rows_font_size: '30'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    series_labels:
+      mobile_usage_2021.new_profiles_cumulative: 2021  New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 2020 New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_delta: YoY % Change
+    series_column_widths:
+      mobile_usage_2021.date: 197
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 183
+      mobile_usage_2021.new_profiles_cumulative: 185
+    series_cell_visualizations:
+      mobile_usage_2021.new_profiles_cumulative:
+        is_active: false
+    series_text_format:
+      mobile_usage_2021.new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_delta:
+        align: left
+    limit_displayed_rows_values:
+      show_hide: show
+      first_last: last
+      num_rows: '1'
+    series_types: {}
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    title_hidden: true
+    row: 98
+    col: 0
+    width: 11
+    height: 2
+  filters:
+  - name: Date
+    title: Date
+    type: field_filter
+    default_value: after 2021/01/01
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: popover
+      options: []
+    model: kpi
+    explore: mobile_usage_2021
+    listens_to_filters: []
+    field: mobile_usage_2021.date
+  - name: Country
+    title: Country
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: tag_list
+      display: popover
+      options: []
+    model: kpi
+    explore: mobile_usage_fields
+    listens_to_filters: []
+    field: mobile_usage_fields.country

--- a/KPI/kpi.model.lkml
+++ b/KPI/kpi.model.lkml
@@ -39,7 +39,14 @@ explore: mobile_usage_2021 {
     sql_on: ${mobile_usage_2021.date} = ${mobile_prediction.date} AND ${mobile_usage_2021.app_name} = ${mobile_prediction.app_name};;
     relationship: one_to_one
   }
-  hidden: no
+  join:  mobile_usage_2020 {
+    from: mobile_usage_2021
+    fields: []
+    view_label: "Firefox Mobile Usage 2020"
+    type: left_outer
+    sql_on: DATE_SUB(${mobile_usage_2021.date}, INTERVAL 1 YEAR) = ${mobile_usage_2020.date} AND ${mobile_usage_2021.app_name} = ${mobile_usage_2020.app_name} ;;
+    relationship: one_to_one
+  }
 }
 
 # For suggestions

--- a/KPI/views/mobile_usage_2021.view.lkml
+++ b/KPI/views/mobile_usage_2021.view.lkml
@@ -2,31 +2,55 @@ view: mobile_usage_2021 {
   derived_table: {
     sql:
       with
-        base as (
-      select
-          submission_date,
-          app_name,
-          canonical_app_name,
-          sum(dau) as dau,
-          sum(wau) as wau,
-          sum(mau) as mau,
-          sum(cdou) as cdou
-      from
-          ${mobile_usage_fields.SQL_TABLE_NAME} AS mobile_usage_fields
-      where
-          {% condition mobile_usage_2021.campaign %} campaign {% endcondition %}
-          AND {% condition mobile_usage_2021.channel %} channel {% endcondition %}
-          AND {% condition mobile_usage_2021.country %} country {% endcondition %}
-          AND {% condition mobile_usage_2021.country_name %} country_name {% endcondition %}
-          AND {% condition mobile_usage_2021.distribution_id %} distribution_id {% endcondition %}
-          AND {% condition mobile_usage_2021.id_bucket %} id_bucket {% endcondition %}
-          AND {% condition mobile_usage_2021.os %} os {% endcondition %}
-      group by 1,2,3 )
+      dau as (
+        select
+            submission_date,
+            app_name,
+            canonical_app_name,
+            sum(dau) as dau,
+            sum(wau) as wau,
+            sum(mau) as mau,
+            sum(cdou) as cdou
+        from
+            ${mobile_usage_fields.SQL_TABLE_NAME} AS mobile_usage_fields
+        where
+            {% condition mobile_usage_2021.campaign %} campaign {% endcondition %}
+            AND {% condition mobile_usage_2021.channel %} channel {% endcondition %}
+            AND {% condition mobile_usage_2021.country %} country {% endcondition %}
+            AND {% condition mobile_usage_2021.country_name %} country_name {% endcondition %}
+            AND {% condition mobile_usage_2021.distribution_id %} distribution_id {% endcondition %}
+            AND {% condition mobile_usage_2021.id_bucket %} id_bucket {% endcondition %}
+            AND {% condition mobile_usage_2021.os %} os {% endcondition %}
+        group by 1,2,3
+        ),
+
+      # temporary - this is NOT using first_seen_date for now.
+      new_profiles as (
+        select
+            cohort_date as submission_date,
+            case when product in ("Fenix", "Fennec") then "fennec_fenix"
+              when product = "Firefox iOS" then "firefox_ios"
+              when product = "Focus iOS" then "focus_ios"
+              when product = "Focus Android" then "focus_android" end as app_name,
+            case when product in ("Fenix", "Fennec") then "Firefox for Android (Fennec + Fenix)"
+              when product = "Firefox iOS" then "Firefox for iOS"
+              when product = "Focus iOS" then "Firefox Focus for iOS"
+              when product = "Focus Android" then "Firefox Focus for Android" end as canonical_app_name,
+            sum(new_profiles) AS new_profiles
+        from `mozdata.telemetry.firefox_nondesktop_day_2_7_activation`
+        where
+          {% condition mobile_usage_2021.country %} country {% endcondition %}
+        group by 1,2,3
+      )
 
       select
         *,
-        avg(dau) over (partition by app_name order by submission_date rows between 6 preceding and current row) as dau_7day_ma
-      from base
+        avg(dau.dau) over (partition by app_name order by submission_date rows between 6 preceding and current row) as dau_7day_ma,
+        avg(new_profiles.new_profiles) over (partition by app_name order by submission_date rows between 6 preceding and current row) as new_profiles_7day_ma,
+        sum(new_profiles.new_profiles) over (partition by extract(year from submission_date), app_name order by submission_date) as new_profiles_cumulative
+      from dau
+      left join new_profiles
+      using(submission_date, app_name, canonical_app_name)
       ;;
   }
 
@@ -115,6 +139,7 @@ view: mobile_usage_2021 {
     description: "Daily Active Users."
   }
 
+
   measure: dau_7day_ma {
     type: sum
     value_format: "#,##0"
@@ -127,6 +152,20 @@ view: mobile_usage_2021 {
     value_format: "#,##0"
     sql: ${TABLE}.mau ;;
     description: "Monthly Active Users."
+  }
+
+  measure: new_profiles {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.new_profiles ;;
+    description: "New Profiles."
+  }
+
+  measure: new_profiles_7day_ma {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.new_profiles_7day_ma ;;
+    hidden: yes
   }
 
   measure: recent_cdou {
@@ -207,5 +246,86 @@ view: mobile_usage_2021 {
     sql: (${mobile_prediction.recent_cdou_target} / ${mobile_prediction.recent_cdou_forecast} ) - 1 ;;
     hidden: yes
   }
+
+  measure: new_profiles_cumulative {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.new_profiles_cumulative ;;
+    description: "Cumulative New Profiles in that calendar year."
+  }
+
+  # YoY Measures
+
+  measure: year_over_year_dau {
+    label: "2020 Dau"
+    type: number
+    sql: ${mobile_usage_2020.dau} ;;
+    description: "Daily Active Users on this day in 2020."
+  }
+
+  measure: year_over_year_dau_7day_ma {
+    label: "2020 Dau MA"
+    type: number
+    sql: ${mobile_usage_2020.dau_7day_ma} ;;
+    hidden: yes
+  }
+
+  measure: year_over_year_wau {
+    label: "2020 Wau"
+    type: number
+    sql: ${mobile_usage_2020.wau} ;;
+    description: "Weekly Active Users on this day in 2020."
+  }
+
+  measure: year_over_year_mau {
+    label: "2020 Mau"
+    type: number
+    sql: ${mobile_usage_2020.mau} ;;
+    description: "Monthly Active Users on this day in 2020."
+  }
+
+  measure: year_over_year_cdou {
+    label: "2020 Cdou"
+    type: number
+    sql: ${mobile_usage_2020.cdou} ;;
+    description: "Cumulative Days of Use on this day in 2020."
+  }
+
+  measure: year_over_year_cdou_delta_count {
+    label: "Cdou: Absolute Delta from 2020"
+    type: number
+    value_format: "#,##0"
+    sql: ${cdou} - ${year_over_year_cdou} ;;
+    description: "Absolute (given as a whole number) difference between 2020's CDOU and 2021's CDOU."
+  }
+
+  measure: year_over_year_new_profiles {
+    label: "2020 New Profiles"
+    type: number
+    sql: ${mobile_usage_2020.new_profiles} ;;
+    description: "Number of New Profiles on this day in 2020."
+  }
+
+  measure: year_over_year_new_profiles_7day_ma {
+    label: "2020 New Profiles MA"
+    type: number
+    sql: ${mobile_usage_2020.new_profiles_7day_ma} ;;
+    hidden: yes
+  }
+
+  measure: year_over_year_new_profiles_cumulative {
+    type: number
+    value_format: "#,##0"
+    sql: ${mobile_usage_2020.new_profiles_cumulative} ;;
+    description: "Cumulative New Profiles on this day in 2020."
+  }
+
+  measure: year_over_year_new_profiles_delta {
+    type: number
+    value_format: "0.000%"
+    sql: (${mobile_usage_2021.new_profiles_cumulative} / ${mobile_usage_2020.year_over_year_new_profiles_cumulative}) - 1 ;;
+    description: "Cumulative New Profiles on this day in 2020."
+  }
+
 
 }


### PR DESCRIPTION
So I didn't end up putting in the new profiles based on first_seen_date yet, for a couple reasons:

1. first_seen_date and new_profiles are not yet incorporated downstream into the 2021_mobile_usage dataset (I filed a bug [here](https://github.com/mozilla/bigquery-etl/issues/1954))
2. I don't think first_seen_date has been added to the the core_clients_last_seen dataset yet, and we need that for focus android new profiles (since its not on glean).

So I ended up just using what we're using right now in the datastudio dash, which is based on profile creation date from `firefox_nondesktop_day_2_7_activation`.

This has a lookml dashboard for the mobile KPIs, so I'm also going to close the other PR on the shared branch for now in the name of expediency. 