### PR TITLE
Add "in_cache" feature to desktop KPI report

### DIFF
--- a/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
@@ -612,6 +612,7 @@
     col: 0
     width: 24
     height: 2
+    refresh: 10 seconds
   filters:
   - name: Date
     title: Date

--- a/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
@@ -1,5 +1,5 @@
-- dashboard: desktop_kpi_dashboard__edit_for_in_cache
-  title: Desktop KPI Dashboard - Edit for in cache
+- dashboard: desktop_kpi_dashboard
+  title: Desktop KPI Dashboard
   layout: newspaper
   preferred_viewer: dashboards-next
   refresh: 2147484 seconds

--- a/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
+++ b/KPI/dashboards/desktop_kpis_with_filters_alternate.dashboard.lookml
@@ -1,5 +1,5 @@
-- dashboard: desktop_kpi_dashboard
-  title: Desktop KPI Dashboard
+- dashboard: desktop_kpi_dashboard__edit_for_in_cache
+  title: Desktop KPI Dashboard - Edit for in cache
   layout: newspaper
   preferred_viewer: dashboards-next
   refresh: 2147484 seconds
@@ -583,13 +583,31 @@
     col: 0
     width: 24
     height: 9
-  - name: " (4)"
-    type: text
-    title_text: ''
-    subtitle_text: ''
-    body_text: "*Running slow? If no one has queried a slice before, it will take\
-      \ a 2-3 minutes to build the forecasting models. From then on, queries against\
-      \ that slice should run within 10-15 seconds.*"
+  - title: ''
+    name: " (4)"
+    model: kpi
+    explore: firefox_desktop_usage_2021
+    type: single_value
+    fields: [key_in_cache.is_cached]
+    limit: 500
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    series_types: {}
+    defaults_version: 1
+    listen:
+      Channel: firefox_desktop_usage_2021.channel
+      Activity Segment: firefox_desktop_usage_2021.activity_segment
+      OS: firefox_desktop_usage_2021.os
+      Attributed (Yes / No): firefox_desktop_usage_2021.attributed
+      Country Name: firefox_desktop_usage_2021.country_name
+      Date: firefox_desktop_usage_2021.date
     row: 0
     col: 0
     width: 24

--- a/KPI/kpi.model.lkml
+++ b/KPI/kpi.model.lkml
@@ -21,6 +21,10 @@ explore: firefox_desktop_usage_2021 {
     sql_on: DATE_SUB(${firefox_desktop_usage_2021.date}, INTERVAL 1 YEAR) = ${firefox_desktop_usage_2020.date} ;;
     relationship: one_to_one
   }
+  join: key_in_cache {
+    type: cross
+    relationship: many_to_one
+  }
   hidden: no
 }
 

--- a/KPI/views/firefox_desktop_usage_forecast.view.lkml
+++ b/KPI/views/firefox_desktop_usage_forecast.view.lkml
@@ -429,6 +429,6 @@ view: key_in_cache {
 
   measure: is_cached {
     type: string
-    sql: if(MAX(row_count) > 0, "Retrieving cached value...", "Building forecast model, will take 2-3 minutes...") ;;
+    sql: if(MAX(row_count) > 0, "Forecast for current selection is cached.", "Building forecast model, will take 2-3 minutes...") ;;
   }
 }

--- a/KPI/views/firefox_desktop_usage_forecast.view.lkml
+++ b/KPI/views/firefox_desktop_usage_forecast.view.lkml
@@ -405,3 +405,30 @@ view: prediction {
     hidden: yes
   }
 }
+
+view: key_in_cache {
+  derived_table: {
+    sql:
+      SELECT COUNT(*) AS row_count
+      FROM mozdata.analysis.dou_forecasts
+      WHERE key = ARRAY_TO_STRING(REGEXP_EXTRACT_ALL("""
+      {% condition firefox_desktop_usage_2021.activity_segment %} activity_segment {% endcondition %}
+      {% condition firefox_desktop_usage_2021.campaign %} campaign {% endcondition %}
+      {% condition firefox_desktop_usage_2021.channel %} channel {% endcondition %}
+      {% condition firefox_desktop_usage_2021.content %} content {% endcondition %}
+      {% condition firefox_desktop_usage_2021.country %} country {% endcondition %}
+      {% condition firefox_desktop_usage_2021.country_name %} country_name {% endcondition %}
+      {% condition firefox_desktop_usage_2021.distribution_id %} distribution_id {% endcondition %}
+      {% condition firefox_desktop_usage_2021.id_bucket %} id_bucket {% endcondition %}
+      {% condition firefox_desktop_usage_2021.medium %} medium {% endcondition %}
+      {% condition firefox_desktop_usage_2021.os %} os {% endcondition %}
+      {% condition firefox_desktop_usage_2021.source %} source {% endcondition %}
+      {% condition firefox_desktop_usage_2021.attributed %} (attributed) {% endcondition %}
+      """, r"(\(.*\))"), '') ;;
+  }
+
+  measure: is_cached {
+    type: string
+    sql: if(MAX(row_count) > 0, "Retreiving cached value...", "Building forecast model, will take 2-3 minutes...") ;;
+  }
+}


### PR DESCRIPTION
This adds a new element that replaces the previous message (loads in 2-3 seconds after re-running). See below for a quick demo.

https://user-images.githubusercontent.com/20819040/114606323-23241b00-9c69-11eb-915b-023506fa31df.mov

