### PR TITLE
add total mobile kpis

### DIFF
--- a/KPI/dashboards/mobile_kpis.dashboard.lookml
+++ b/KPI/dashboards/mobile_kpis.dashboard.lookml
@@ -60,7 +60,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 17
+    row: 43
     col: 12
     width: 12
     height: 10
@@ -120,7 +120,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 72
+    row: 98
     col: 11
     width: 13
     height: 9
@@ -180,7 +180,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 45
+    row: 71
     col: 12
     width: 12
     height: 9
@@ -240,7 +240,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 98
+    row: 124
     col: 11
     width: 13
     height: 8
@@ -266,7 +266,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 0
+    row: 26
     col: 0
     width: 24
     height: 8
@@ -292,7 +292,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 54
+    row: 80
     col: 0
     width: 24
     height: 9
@@ -318,7 +318,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 27
+    row: 53
     col: 0
     width: 24
     height: 9
@@ -344,7 +344,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 81
+    row: 107
     col: 0
     width: 24
     height: 8
@@ -393,7 +393,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 8
+    row: 34
     col: 12
     width: 12
     height: 9
@@ -442,7 +442,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 36
+    row: 62
     col: 12
     width: 12
     height: 9
@@ -491,7 +491,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 89
+    row: 115
     col: 11
     width: 13
     height: 9
@@ -540,7 +540,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 63
+    row: 89
     col: 11
     width: 13
     height: 9
@@ -595,7 +595,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 8
+    row: 34
     col: 0
     width: 12
     height: 9
@@ -650,7 +650,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 89
+    row: 115
     col: 0
     width: 11
     height: 9
@@ -705,7 +705,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 63
+    row: 89
     col: 0
     width: 11
     height: 9
@@ -760,7 +760,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 36
+    row: 62
     col: 0
     width: 12
     height: 9
@@ -811,7 +811,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 19
+    row: 45
     col: 0
     width: 12
     height: 8
@@ -862,7 +862,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 47
+    row: 73
     col: 0
     width: 12
     height: 7
@@ -913,7 +913,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 100
+    row: 126
     col: 0
     width: 11
     height: 6
@@ -964,7 +964,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 74
+    row: 100
     col: 0
     width: 11
     height: 7
@@ -1032,7 +1032,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 17
+    row: 43
     col: 0
     width: 12
     height: 2
@@ -1100,7 +1100,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 45
+    row: 71
     col: 0
     width: 12
     height: 2
@@ -1168,7 +1168,7 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 72
+    row: 98
     col: 0
     width: 11
     height: 2
@@ -1236,9 +1236,318 @@
     listen:
       Date: mobile_usage_2021.date
       Country: mobile_usage_2021.country
-    row: 98
+    row: 124
     col: 0
     width: 11
+    height: 2
+  - title: All Mobile Browsers
+    name: All Mobile Browsers
+    model: kpi
+    explore: mobile_usage_2021
+    type: single_value
+    fields: [mobile_usage_2021.delta_from_forecast_format]
+    filters:
+      mobile_usage_2021.app_name: '"total_mobile"'
+    limit: 500
+    custom_color_enabled: true
+    show_single_value_title: false
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 0
+    col: 0
+    width: 24
+    height: 8
+  - title: Total Mobile CDOU Burn-Up
+    name: Total Mobile CDOU Burn-Up
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.cdou, mobile_prediction.cdou_forecast,
+      mobile_prediction.cdou_target]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"total_mobile"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.cdou: Cumulative Days of Use (CDOU)
+      mobile_prediction.cdou_forecast: CDOU Forecast
+      mobile_prediction.cdou_target: CDOU Target Pace
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 8
+    col: 12
+    width: 12
+    height: 9
+  - title: Total Mobile Daily Active Users (DAU)
+    name: Total Mobile Daily Active Users (DAU)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.dau_7day_ma, mobile_prediction.dau_forecast_7day_ma,
+      mobile_prediction.dau_forecast_lower_7day_ma, mobile_prediction.dau_forecast_upper_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"total_mobile"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.dau_7day_ma,
+            id: mobile_usage_2021.dau_7day_ma, name: DAU (7 Day Moving Average)},
+          {axisId: mobile_prediction.dau_forecast_7day_ma, id: mobile_prediction.dau_forecast_7day_ma,
+            name: DAU Forecast (7 Day MA)}, {axisId: mobile_prediction.dau_forecast_lower_7day_ma,
+            id: mobile_prediction.dau_forecast_lower_7day_ma, name: Forecast Lower
+              Bound}, {axisId: mobile_prediction.dau_forecast_upper_7day_ma, id: mobile_prediction.dau_forecast_upper_7day_ma,
+            name: Forecast Upper Bound}], showLabels: true, showValues: true, minValue: !!null '',
+        unpinAxis: true, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_colors:
+      mobile_prediction.dau_forecast_lower_7day_ma: "#80868B"
+      mobile_prediction.dau_forecast_upper_7day_ma: "#80868B"
+    series_labels:
+      mobile_prediction.dau_forecast_upper_7day_ma: Forecast Upper Bound
+      mobile_prediction.dau_forecast_lower_7day_ma: Forecast Lower Bound
+      mobile_prediction.dau_forecast_7day_ma: DAU Forecast (7 Day MA)
+      mobile_usage_2021.dau_7day_ma: DAU (7 Day Moving Average)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 17
+    col: 12
+    width: 12
+    height: 9
+  - title: Total Mobile New Profiles Per Day
+    name: Total Mobile New Profiles Per Day
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_7day_ma, mobile_usage_2021.year_over_year_new_profiles_7day_ma]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"total_mobile"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.new_profiles_7day_ma,
+            id: mobile_usage_2021.new_profiles_7day_ma, name: New Profiles 7day Ma}],
+        showLabels: true, showValues: true, unpinAxis: true, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    series_labels:
+      mobile_usage_2021.new_profiles_7day_ma: 2021 New Profiles (7 Day MA)
+      mobile_usage_2021.year_over_year_new_profiles_7day_ma: 2020 New Profiles (7
+        Day MA)
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 19
+    col: 0
+    width: 12
+    height: 7
+  - title: Cumulative Difference vs Target / Forecast
+    name: Cumulative Difference vs Target / Forecast (5)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_line
+    fields: [mobile_usage_2021.date, mobile_usage_2021.delta_from_target_count, mobile_usage_2021.delta_from_forecast_count]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"total_mobile"'
+    sorts: [mobile_usage_2021.date desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: mobile_usage_2021.delta_from_target_count,
+            id: mobile_usage_2021.delta_from_target_count, name: Difference From Target},
+          {axisId: mobile_usage_2021.delta_from_forecast_count, id: mobile_usage_2021.delta_from_forecast_count,
+            name: Difference From Forecast}], showLabels: true, showValues: true,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    series_types: {}
+    series_labels:
+      mobile_usage_2021.delta_from_target_count: Difference From Target
+      mobile_usage_2021.delta_from_forecast_count: Difference From Forecast
+    reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
+        margin_value: mean, margin_bottom: deviation, label_position: center, color: "#000000",
+        line_value: '0', label: At Target / Forecast}]
+    defaults_version: 1
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 8
+    col: 0
+    width: 12
+    height: 9
+  - title: 2021 Cumulative New Profiles (Copy 4)
+    name: 2021 Cumulative New Profiles (Copy 4)
+    model: kpi
+    explore: mobile_usage_2021
+    type: looker_grid
+    fields: [mobile_usage_2021.date, mobile_usage_2021.new_profiles_cumulative, mobile_usage_2021.year_over_year_new_profiles_cumulative,
+      mobile_usage_2021.year_over_year_new_profiles_delta]
+    fill_fields: [mobile_usage_2021.date]
+    filters:
+      mobile_usage_2021.app_name: '"total_mobile"'
+    sorts: [mobile_usage_2021.date]
+    limit: 500
+    show_view_names: false
+    show_row_numbers: false
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: true
+    enable_conditional_formatting: false
+    header_text_alignment: ''
+    header_font_size: '15'
+    rows_font_size: '30'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    series_labels:
+      mobile_usage_2021.new_profiles_cumulative: 2021  New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 2020 New Profiles
+      mobile_usage_2021.year_over_year_new_profiles_delta: YoY % Change
+    series_column_widths:
+      mobile_usage_2021.date: 197
+      mobile_usage_2021.year_over_year_new_profiles_cumulative: 183
+      mobile_usage_2021.new_profiles_cumulative: 185
+    series_cell_visualizations:
+      mobile_usage_2021.new_profiles_cumulative:
+        is_active: false
+    series_text_format:
+      mobile_usage_2021.new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_cumulative:
+        align: left
+      mobile_usage_2021.year_over_year_new_profiles_delta:
+        align: left
+    limit_displayed_rows_values:
+      show_hide: show
+      first_last: last
+      num_rows: '1'
+    series_types: {}
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    defaults_version: 1
+    title_hidden: true
+    listen:
+      Date: mobile_usage_2021.date
+      Country: mobile_usage_2021.country
+    row: 17
+    col: 0
+    width: 12
     height: 2
   filters:
   - name: Date

--- a/KPI/views/mobile_usage_fields.view.lkml
+++ b/KPI/views/mobile_usage_fields.view.lkml
@@ -5,7 +5,8 @@ view: mobile_usage_fields {
         * EXCEPT(app_name, canonical_app_name),
         CASE WHEN app_name IN ('fennec', 'fenix') THEN 'fennec_fenix' ELSE app_name END AS app_name,
         CASE WHEN canonical_app_name IN ('Firefox for Android (Fennec)', 'Firefox for Android (Fenix)') THEN 'Firefox for Android (Fennec + Fenix)' ELSE canonical_app_name END AS canonical_app_name
-      FROM `mozdata.telemetry.mobile_usage_2021` ;;
+      FROM `mozdata.telemetry.mobile_usage_2021`
+      WHERE app_name IN ('fennec', 'fenix', 'focus_ios', 'focus_android', 'firefox_ios');;
   }
 
   dimension: campaign {

--- a/KPI/views/mobile_usage_forecast.view.lkml
+++ b/KPI/views/mobile_usage_forecast.view.lkml
@@ -44,6 +44,7 @@ view: mobile_dau_model {
         ${mobile_usage_2021.SQL_TABLE_NAME}
       WHERE
         submission_date < '2021-01-19'
+      AND app_name IN (SELECT * FROM UNNEST(possible_apps))
       AND app_name NOT IN (SELECT * FROM UNNEST(intersection));
     END IF; ;;
   }
@@ -94,6 +95,7 @@ view: mobile_insert_stmnt {
         FROM
           ${mobile_usage_2021.SQL_TABLE_NAME}
         WHERE submission_date BETWEEN '2021-01-01' AND '2021-01-18'
+        AND app_name IN (SELECT * FROM UNNEST(possible_apps))
         AND app_name NOT IN (SELECT * FROM UNNEST(intersection))
       ), predicted_data AS (
         SELECT

--- a/KPI/views/mobile_usage_forecast.view.lkml
+++ b/KPI/views/mobile_usage_forecast.view.lkml
@@ -18,7 +18,7 @@ view: mobile_dau_model {
 
     SET row_count = (
       SELECT COUNT(*)
-      FROM mozdata.analysis.mobile_dou_forecasts
+      FROM mozdata.analysis.mobile_dou_forecasts_v2
       WHERE key = current_key);
 
     IF row_count = 0 THEN
@@ -60,15 +60,16 @@ view: mobile_insert_stmnt {
 
       SET row_count = (
         SELECT COUNT(*)
-        FROM mozdata.analysis.mobile_dou_forecasts
+        FROM mozdata.analysis.mobile_dou_forecasts_v2
         WHERE key = current_key);
 
       IF row_count = 0 THEN
-      INSERT INTO mozdata.analysis.mobile_dou_forecasts_cache
+      INSERT INTO mozdata.analysis.mobile_dou_forecasts_cache_v2
       WITH target_lifts AS (
         SELECT
             DISTINCT app_name, target_lift
-        FROM `moz-fx-data-shared-prod.static.mobile_forecasts_official_2021`
+        # need to move this modified table to static
+        FROM `mozdata.analysis.mobile_forecasts_official_v2`
       ), historic_data AS (
         SELECT
           CAST(submission_date AS TIMESTAMP) AS submission_date,
@@ -127,7 +128,7 @@ view: mobile_prediction {
       avg(dau_forecast_lower) over window_7day as dau_forecast_lower_7day_ma,
       avg(dau_forecast_upper) over window_7day as dau_forecast_upper_7day_ma
     FROM
-      mozdata.analysis.mobile_dou_forecasts
+      mozdata.analysis.mobile_dou_forecasts_v2
     WHERE -- Also requires ${mobile_insert_stmnt.SQL_TABLE_NAME}
       key = ARRAY_TO_STRING(REGEXP_EXTRACT_ALL("""
       {% condition mobile_usage_2021.campaign %} campaign {% endcondition %}


### PR DESCRIPTION
This adds in the total mobile KPIs (all 4 mobile browsers summed together).

Unfortunately this required me to re-do the underlying mobile forecast tables - I created new v2 versions but I'm realizing that I THINK I can just union with the old versions so we don't lose those forecasts. I'll do that tomorrow. 

Also this is on a shared branch so anyone should be able to make commits

edit, [here's the query](
https://console.cloud.google.com/bigquery?sq=630180991450:2a6b960ffd6d400b9123188b8f80d292
) that adds in the total mobile baseline forecast