### PR TITLE
Bug 1707576 - Add experiment dimensions to UJET explores

### DIFF
--- a/user_journey/views/event_counts/onboarding_v1.view.lkml
+++ b/user_journey/views/event_counts/onboarding_v1.view.lkml
@@ -75,6 +75,7 @@ view: onboarding_v1 {
     type: string
     sql: ${TABLE}.document_id ;;
     hidden: yes
+    primary_key: yes
   }
 
   dimension: event {
@@ -343,15 +344,26 @@ view: message_id_ranks {
 }
 
 view: onboarding_v1__experiments {
-  dimension: key {
+  sql_table_name: UNNEST(experiments) ;;
+
+  dimension: experiment {
     type: string
     sql: ${TABLE}.key ;;
+    description: "Experiment name"
+    suggest_explore: experiment_names
+    suggest_dimension: experiment_names.experiment
   }
 
-  dimension: value__branch {
+  dimension: branch {
     type: string
     sql: ${TABLE}.value.branch ;;
-    group_label: "Value"
-    group_item_label: "Branch"
+    description: "Experiment branch"
+    suggest_explore: experiment_names
+    suggest_dimension: experiment_names.branch
+  }
+
+  measure: count {
+    type: count
+    description: "Count of rows"
   }
 }

--- a/user_journey/views/funnel_analysis/funnel_analysis.view.lkml
+++ b/user_journey/views/funnel_analysis/funnel_analysis.view.lkml
@@ -117,3 +117,43 @@ view: funnel_analysis {
     type: number
   }
 }
+
+view: experiments {
+  sql_table_name: UNNEST(experiments) ;;
+
+  dimension: experiment {
+    type: string
+    sql: ${TABLE}.key ;;
+    description: "Experiment name"
+    suggest_explore: experiment_names
+    suggest_dimension: experiment_names.experiment
+  }
+
+  dimension: branch {
+    type: string
+    sql: ${TABLE}.value ;;
+    description: "Experiment branch"
+    suggest_explore: experiment_names
+    suggest_dimension: experiment_names.branch
+  }
+}
+
+view: experiment_names {
+  derived_table: {
+    sql:
+      SELECT key AS experiment, value AS branch
+      FROM mozdata.messaging_system.events_daily
+      CROSS JOIN UNNEST(experiments)
+      WHERE submission_date >= '2020-01-01';;
+  }
+
+  dimension: experiment {
+    type: string
+    description: "Experiment name"
+  }
+
+  dimension: branch {
+    type: string
+    description: "Experiment branch"
+  }
+}


### PR DESCRIPTION
- Adds `experiment_names` explore for suggestions
- Lies about the `one_to_one` relationship between `funnel_analysis` and `experiments`. Deals with this by requiring the user select both of those fields if one of them is filtered on, and requires experiment be selected if branch is selected.
- Does not lie about the `one_to_many` relationship in `event_counts`, because there users can use `client_count` (and it has a primary key to allow for symmetric aggregates)