### PR TITLE
use an array for mobile forecast

### DIFF
--- a/KPI/views/mobile_usage_fields.view.lkml
+++ b/KPI/views/mobile_usage_fields.view.lkml
@@ -5,7 +5,8 @@ view: mobile_usage_fields {
         * EXCEPT(app_name, canonical_app_name),
         CASE WHEN app_name IN ('fennec', 'fenix') THEN 'fennec_fenix' ELSE app_name END AS app_name,
         CASE WHEN canonical_app_name IN ('Firefox for Android (Fennec)', 'Firefox for Android (Fenix)') THEN 'Firefox for Android (Fennec + Fenix)' ELSE canonical_app_name END AS canonical_app_name
-      FROM `mozdata.telemetry.mobile_usage_2021` ;;
+      FROM `mozdata.telemetry.mobile_usage_2021`
+      WHERE app_name IN ('firefox_ios', 'fennec', 'fenix', 'focus_android', 'focus_ios');;
   }
 
   dimension: campaign {

--- a/burnham/burnham.model.lkml
+++ b/burnham/burnham.model.lkml
@@ -1,7 +1,4 @@
 connection: "telemetry"
 label: "Burnham"
 include: "//looker-hub/burnham/explores/*"
-include: "//looker-hub/burnham/dashboards/*"
-include: "views/*"
-include: "explores/*"
-include: "dashboards/*"
+include: "//looker-hub/burnham/views/*"


### PR DESCRIPTION
Sorry I couldn't figure out what was going on with burnham import from looker-hub, it seemed like I was even with production. So I just changed things so I could put up the PR for now. Apparently there's something going on here I don't understand. 

I did notice that the main branch of spoke tries to pull from a burnham/dashboards directory from the hub project, but there is no such directory on the main branch of hub.

Also, I noticed that the change to use arrays was causing bigquery to return a "rows too large" error, I *think* because there are too many possible values for `app_name`, i.e. too many forecasts being generated. So I hard-coded a filter on mobile_usage_fields to only return the app_names we care about. that seemed to resolve the problem, but i guess its another  argument for forecasting one app_name at a time based on a filter rather than using `time_series_id_col` to do all the forecasts at once. 