### PR TITLE
Add `client_counts` explore for client-counting-shaped analyses

### DIFF
--- a/firefox_ios/firefox_ios.model.lkml
+++ b/firefox_ios/firefox_ios.model.lkml
@@ -51,7 +51,7 @@ explore: client_counts {
   description: "Client counts across dimensions and cohorts."
   always_filter: {
     filters: [
-      client_counts.submission_date: "4 weeks ago",
+      client_counts.submission_date: "4 weeks",
       client_counts.channel: "mozdata.org^_mozilla^_ios^_firefox.baseline^_clients^_daily",
     ]
   }
@@ -64,8 +64,8 @@ explore: client_counts {
     measures: [client_counts.client_count]
     pivots: [client_counts.first_seen_week]
     filters: [
-      submission_date: "8 weeks ago",
-      first_seen_date: "8 weeks ago",
+      submission_date: "8 weeks",
+      first_seen_date: "8 weeks",
       client_counts.have_completed_period: "yes",
     ]
     sorts: [

--- a/firefox_ios/firefox_ios.model.lkml
+++ b/firefox_ios/firefox_ios.model.lkml
@@ -46,3 +46,45 @@ explore: counters {
     ]
   }
 }
+
+explore: client_counts {
+  description: "Client counts across dimensions and cohorts."
+  always_filter: {
+    filters: [
+      client_counts.submission_date: "4 weeks ago",
+      client_counts.channel: "mozdata.org^_mozilla^_ios^_firefox.baseline^_clients^_daily",
+    ]
+  }
+  query: cohort_analysis {
+    description: "Client Counts of weekly cohorts over the N days."
+    dimensions: [
+      client_counts.days_since_first_seen,
+      client_counts.first_seen_week
+    ]
+    measures: [client_counts.client_count]
+    pivots: [client_counts.first_seen_week]
+    filters: [
+      submission_date: "8 weeks ago",
+      first_seen_date: "8 weeks ago",
+      client_counts.have_completed_period: "yes",
+    ]
+    sorts: [
+      client_counts.days_since_first_seen: asc
+    ]
+  }
+  query: build_breakdown {
+    description: "Number of clients per build."
+    dimensions: [
+      client_counts.submission_date,
+      client_counts.app_build
+    ]
+    measures: [client_count]
+    pivots: [app_build]
+    filters: [
+      submission_date: "28 days"
+    ]
+    sorts: [
+      submission_date: asc
+    ]
+  }
+}

--- a/firefox_ios/views/client_counts.view.lkml
+++ b/firefox_ios/views/client_counts.view.lkml
@@ -1,0 +1,60 @@
+include: "//looker-hub/firefox_ios/views/baseline_clients_daily_table.view.lkml"
+
+view: client_counts {
+  extends: [baseline_clients_daily_table]
+
+  dimension_group: since_first_seen {
+    type: duration
+    description: "Amount of time that has passed since the client was first seen."
+    sql_start: ${TABLE}.first_seen_date ;;
+    sql_end: ${TABLE}.submission_date ;;
+    intervals: [
+      day, week, month, year
+    ]
+  }
+
+  dimension: have_completed_period {
+    type: yesno
+    description: "
+      Only for use with cohort analysis.
+      Filter on true to remove the tail of incomplete data from cohorts.
+      Indicates whether the cohort for this row have all had a chance to complete this interval.
+      For example, new clients from yesterday have not all had a chance to send a ping for today."
+    sql:
+      DATE_ADD(
+        {% if client_counts.first_seen_date._is_selected %}
+          DATE_ADD(DATE(${client_counts.first_seen_date}), INTERVAL 1 DAY)
+        {% elsif client_counts.first_seen_week._is_selected %}
+          DATE_ADD(DATE(${client_counts.first_seen_week}), INTERVAL 1 WEEK)
+        {% elsif client_counts.first_seen_month._is_selected %}
+          DATE_ADD(DATE(${client_counts.first_seen_month}), INTERVAL 1 MONTH)
+        {% elsif client_counts.first_seen_year._is_selected %}
+          DATE_ADD(DATE(${client_counts.first_seen_year}), INTERVAL 1 YEAR)
+        {% endif %}
+        ,
+        {% if client_counts.days_since_first_seen._is_selected %}
+          INTERVAL ${client_counts.days_since_first_seen} DAY
+        {% elsif client_counts.weeks_since_first_seen._is_selected %}
+          INTERVAL ${client_counts.weeks_since_first_seen} WEEK
+        {% elsif client_counts.months_since_first_seen._is_selected %}
+          INTERVAL ${client_counts.months_since_first_seen} MONTH
+        {% elsif client_counts.years_since_first_seen._is_selected %}
+          INTERVAL ${client_counts.months_since_first_seen} YEAR
+        {% endif %}
+      ) < current_date
+    ;;
+  }
+
+  measure: client_count {
+    type: number
+    description: "The number of clients, determined by whether they sent a baseline ping on the day in question."
+    sql:
+      {% if client_counts.submission_date._is_selected or client_counts.days_since_first_seen._is_selected %}
+        -- This query is grouping on a dimension known to have 1 row per-client
+        COUNT(*)
+      {% else %}
+        -- This query is not grouping on a dimension that is known to have 1 row per-client
+        COUNT(DISTINCT client_id)
+      {% endif %} ;;
+  }
+}

--- a/firefox_ios/views/client_counts.view.lkml
+++ b/firefox_ios/views/client_counts.view.lkml
@@ -6,8 +6,8 @@ view: client_counts {
   dimension_group: since_first_seen {
     type: duration
     description: "Amount of time that has passed since the client was first seen."
-    sql_start: ${TABLE}.first_seen_date ;;
-    sql_end: ${TABLE}.submission_date ;;
+    sql_start: CAST(${TABLE}.first_seen_date AS TIMESTAMP) ;;
+    sql_end: CAST(${TABLE}.submission_date AS TIMESTAMP) ;;
     intervals: [
       day, week, month, year
     ]

--- a/firefox_ios/views/client_counts.view.lkml
+++ b/firefox_ios/views/client_counts.view.lkml
@@ -27,9 +27,9 @@ view: client_counts {
         {% elsif client_counts.first_seen_week._is_selected %}
           DATE_ADD(DATE(${client_counts.first_seen_week}), INTERVAL 1 WEEK)
         {% elsif client_counts.first_seen_month._is_selected %}
-          DATE_ADD(DATE(${client_counts.first_seen_month}), INTERVAL 1 MONTH)
+          DATE_ADD(PARSE_DATE('%Y-%m', ${client_counts.first_seen_month}), INTERVAL 1 MONTH)
         {% elsif client_counts.first_seen_year._is_selected %}
-          DATE_ADD(DATE(${client_counts.first_seen_year}), INTERVAL 1 YEAR)
+          DATE_ADD(DATE(${client_counts.first_seen_year}, 1, 1), INTERVAL 1 YEAR)
         {% endif %}
         ,
         {% if client_counts.days_since_first_seen._is_selected %}


### PR DESCRIPTION
This is largely to support cohort analyses, see the first example query in the explore. Using a table calc gets us to a more traditional cohort retention curve, see below (since we need the max of each column).

Jeff, I thought you might be interested in reviewing this, so we can begin to think about good ways to utilize the `_daily` and `_last_seen` explores more fully.

<img width="1100" alt="Screen Shot 2021-05-03 at 9 29 58 PM" src="https://user-images.githubusercontent.com/20819040/116951784-c956b580-ac56-11eb-8c17-96d153e40443.png">
