### PR TITLE
[DS-1545] View, explore, and dashboard for ios numbers that matter

### DIFF
--- a/duet/dashboards/mobile_ios_country.dashboard.lookml
+++ b/duet/dashboards/mobile_ios_country.dashboard.lookml
@@ -15,8 +15,8 @@
     col: 0
     width: 24
     height: 4
-  - title: Android Funnel Per Day
-    name: Android Funnel Per Day
+  - title: iOS Funnel Per Day
+    name: iOS Funnel Per Day
     model: duet
     explore: mobile_ios_country
     type: looker_line
@@ -181,8 +181,8 @@
     col: 0
     width: 12
     height: 8
-  - name: First Time Visitor Count
-    title: First Time Visitor Count
+  - name: Product Page Views
+    title: Product Page Views
     merged_queries:
     - model: duet
       explore: mobile_ios_country
@@ -260,7 +260,7 @@
         source_field_name: mobile_ios_country.join_field
     custom_color_enabled: true
     show_single_value_title: true
-    single_value_title: stalls
+    single_value_title: First Time Installs
     show_comparison: true
     comparison_type: change
     comparison_reverse_colors: false

--- a/duet/dashboards/mobile_ios_country.dashboard.lookml
+++ b/duet/dashboards/mobile_ios_country.dashboard.lookml
@@ -21,7 +21,8 @@
     explore: mobile_ios_country
     type: looker_line
     fields: [mobile_ios_country.submission_date, mobile_ios_country.product_page_views,
-      mobile_ios_country.first_time_installs, mobile_ios_country.first_seen, mobile_ios_country.activated]
+      mobile_ios_country.first_time_installs, mobile_ios_country.installations_opt_in,
+      mobile_ios_country.first_seen, mobile_ios_country.activated]
     fill_fields: [mobile_ios_country.submission_date]
     sorts: [mobile_ios_country.first_seen desc]
     limit: 500
@@ -54,7 +55,7 @@
       History Days: mobile_ios_country.history_days
       App ID: mobile_ios_country.app_id
       Bucket: country_buckets.bucket
-    row: 12
+    row: 15
     col: 12
     width: 12
     height: 8
@@ -120,7 +121,8 @@
     explore: mobile_ios_country
     type: looker_column
     fields: [mobile_ios_country.product_page_views, mobile_ios_country.first_time_installs,
-      mobile_ios_country.first_seen, mobile_ios_country.activated]
+      mobile_ios_country.installations_opt_in, mobile_ios_country.first_seen, mobile_ios_country.activated]
+    filters: {}
     sorts: [mobile_ios_country.first_time_installs desc]
     limit: 500
     x_axis_gridlines: false
@@ -130,8 +132,8 @@
     show_y_axis_ticks: true
     y_axis_tick_density: default
     y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
+    show_x_axis_label: false
+    show_x_axis_ticks: false
     y_axis_scale_mode: linear
     x_axis_reversed: false
     y_axis_reversed: false
@@ -150,6 +152,13 @@
     show_totals_labels: false
     show_silhouette: false
     totals_color: "#808080"
+    color_application:
+      collection_id: mozilla
+      palette_id: mozilla-categorical-0
+      options:
+        steps: 5
+    series_types: {}
+    series_labels: {}
     leftAxisLabelVisible: false
     leftAxisLabel: ''
     rightAxisLabelVisible: false
@@ -162,22 +171,31 @@
     valuePosition: right
     labelColorEnabled: false
     labelColor: "#FFF"
-    color_application:
-      collection_id: mozilla
-      palette_id: mozilla-categorical-0
-      options:
-        steps: 5
-    series_types: {}
     defaults_version: 1
     show_null_points: true
     interpolation: linear
     value_labels: legend
     label_type: labPer
+    hidden_fields: []
+    hidden_points_if_no: []
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: 12
+    rows_font_size: 12
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
     listen:
       History Days: mobile_ios_country.history_days
       App ID: mobile_ios_country.app_id
       Bucket: country_buckets.bucket
-    row: 12
+    row: 15
     col: 0
     width: 12
     height: 8
@@ -286,6 +304,59 @@
     col: 12
     width: 12
     height: 3
+  - name: Installation Opt-In
+    title: Installation Opt-In
+    merged_queries:
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.installations_opt_in]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '0'
+      sorts: [mobile_ios_country.installations_opt_in desc]
+      limit: 500
+      join_fields: []
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.installations_opt_in]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '1'
+      sorts: [mobile_ios_country.installations_opt_in desc]
+      limit: 500
+      join_fields:
+      - field_name: mobile_ios_country.join_field
+        source_field_name: mobile_ios_country.join_field
+    custom_color_enabled: true
+    show_single_value_title: true
+    single_value_title: Installation Opt-In
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hidden_fields: [q1_mobile_ios_country.installations_opt_in]
+    type: single_value
+    series_types: {}
+    column_limit: 50
+    dynamic_fields: [{_kind_hint: measure, table_calculation: from_previous_time_period,
+        _type_hint: number, category: table_calculation, expression: "(${mobile_ios_country.installations_opt_in}-${q1_mobile_ios_country.installations_opt_in})/${q1_mobile_ios_country.installations_opt_in}",
+        label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
+    listen:
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    row: 9
+    col: 0
+    width: 12
+    height: 3
   - name: First Seen
     title: First Seen
     merged_queries:
@@ -335,7 +406,7 @@
       App ID: mobile_ios_country.app_id
       Bucket: country_buckets.bucket
     row: 9
-    col: 0
+    col: 12
     width: 12
     height: 3
   - name: Activated
@@ -386,8 +457,8 @@
     - History Days: mobile_ios_country.history_days
       App ID: mobile_ios_country.app_id
       Bucket: country_buckets.bucket
-    row: 9
-    col: 12
+    row: 12
+    col: 0
     width: 12
     height: 3
   - title: Last Valid Submission Date
@@ -446,6 +517,15 @@
     col: 12
     width: 12
     height: 2
+  - name: ''
+    type: text
+    title_text: ''
+    subtitle_text: ''
+    body_text: ''
+    row: 12
+    col: 12
+    width: 12
+    height: 3
   filters:
   - name: App ID
     title: App ID

--- a/duet/dashboards/mobile_ios_country.dashboard.lookml
+++ b/duet/dashboards/mobile_ios_country.dashboard.lookml
@@ -53,7 +53,7 @@
     defaults_version: 1
     listen:
       History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     row: 15
     col: 12
@@ -109,7 +109,7 @@
     series_types: {}
     listen:
       History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     row: 4
     col: 0
@@ -193,7 +193,7 @@
     conditional_formatting_include_nulls: false
     listen:
       History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     row: 15
     col: 0
@@ -242,10 +242,10 @@
         label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
     listen:
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     row: 6
     col: 0
@@ -295,10 +295,10 @@
         label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
     listen:
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     row: 6
     col: 12
@@ -348,10 +348,10 @@
         label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
     listen:
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     row: 9
     col: 0
@@ -400,10 +400,10 @@
         label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
     listen:
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     row: 9
     col: 12
@@ -452,10 +452,10 @@
         label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
     listen:
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     - History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     row: 12
     col: 0
@@ -511,7 +511,7 @@
     series_types: {}
     listen:
       History Days: mobile_ios_country.history_days
-      App ID: mobile_ios_country.app_id
+      App Name: mobile_ios_country.app_name
       Bucket: country_buckets.bucket
     row: 4
     col: 12
@@ -527,8 +527,8 @@
     width: 12
     height: 3
   filters:
-  - name: App ID
-    title: App ID
+  - name: App Name
+    title: App Name
     type: field_filter
     default_value: firefox
     allow_multiple_values: true
@@ -540,7 +540,7 @@
     model: duet
     explore: mobile_ios_country
     listens_to_filters: []
-    field: mobile_ios_country.app_id
+    field: mobile_ios_country.app_name
   - name: History Days
     title: History Days
     type: field_filter

--- a/duet/dashboards/mobile_ios_country.dashboard.lookml
+++ b/duet/dashboards/mobile_ios_country.dashboard.lookml
@@ -1,0 +1,491 @@
+- dashboard: ios_numbers_that_matter
+  title: iOS Numbers that Matter
+  layout: newspaper
+  preferred_viewer: dashboards-next
+  elements:
+  - name: Attribution Funnel for iOS
+    type: text
+    title_text: Attribution Funnel for iOS
+    subtitle_text: ''
+    body_text: |-
+      This dashboard contains figures for new installations of Firefox products on iOS.
+
+      Data is source from the Apple Store and the clients last seen tables for the respective applications. See [DS-1541](https://jira.mozilla.com/browse/DS-1541) for tracking.
+    row: 0
+    col: 0
+    width: 24
+    height: 4
+  - title: Android Funnel Per Day
+    name: Android Funnel Per Day
+    model: duet
+    explore: mobile_ios_country
+    type: looker_line
+    fields: [mobile_ios_country.submission_date, mobile_ios_country.product_page_views,
+      mobile_ios_country.first_time_installs, mobile_ios_country.first_seen, mobile_ios_country.activated]
+    fill_fields: [mobile_ios_country.submission_date]
+    sorts: [mobile_ios_country.first_seen desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    defaults_version: 1
+    listen:
+      History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    row: 12
+    col: 12
+    width: 12
+    height: 8
+  - title: Last Play Store Update
+    name: Last Play Store Update
+    model: duet
+    explore: mobile_ios_country
+    type: single_value
+    fields: [mobile_ios_country.ios_store_updated]
+    fill_fields: [mobile_ios_country.ios_store_updated]
+    sorts: [mobile_ios_country.ios_store_updated desc]
+    limit: 500
+    dynamic_fields: [{measure: count_of_latest_date, based_on: mobile_ios_country.latest_date,
+        expression: '', label: Count of Latest Date, type: count_distinct, _kind_hint: measure,
+        _type_hint: number}]
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    single_value_title: Last Play Store Update
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    defaults_version: 1
+    series_types: {}
+    listen:
+      History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    row: 4
+    col: 0
+    width: 12
+    height: 2
+  - title: Funnel Overview
+    name: Funnel Overview
+    model: duet
+    explore: mobile_ios_country
+    type: looker_column
+    fields: [mobile_ios_country.product_page_views, mobile_ios_country.first_time_installs,
+      mobile_ios_country.first_seen, mobile_ios_country.activated]
+    sorts: [mobile_ios_country.first_time_installs desc]
+    limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    leftAxisLabelVisible: false
+    leftAxisLabel: ''
+    rightAxisLabelVisible: false
+    rightAxisLabel: ''
+    smoothedBars: false
+    orientation: automatic
+    labelPosition: left
+    percentType: total
+    percentPosition: inline
+    valuePosition: right
+    labelColorEnabled: false
+    labelColor: "#FFF"
+    color_application:
+      collection_id: mozilla
+      palette_id: mozilla-categorical-0
+      options:
+        steps: 5
+    series_types: {}
+    defaults_version: 1
+    show_null_points: true
+    interpolation: linear
+    value_labels: legend
+    label_type: labPer
+    listen:
+      History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    row: 12
+    col: 0
+    width: 12
+    height: 8
+  - name: First Time Visitor Count
+    title: First Time Visitor Count
+    merged_queries:
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.product_page_views]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '0'
+      limit: 500
+      join_fields: []
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.product_page_views]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '1'
+      sorts: [mobile_ios_country.product_page_views desc]
+      limit: 500
+      join_fields:
+      - field_name: mobile_ios_country.join_field
+        source_field_name: mobile_ios_country.join_field
+    custom_color_enabled: true
+    show_single_value_title: true
+    single_value_title: Product Page Views
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hidden_fields: [q1_mobile_ios_country.product_page_views]
+    series_types: {}
+    type: single_value
+    column_limit: 50
+    dynamic_fields: [{_kind_hint: measure, table_calculation: from_previous_time_period,
+        _type_hint: number, category: table_calculation, expression: "(${mobile_ios_country.product_page_views}-${q1_mobile_ios_country.product_page_views})/${q1_mobile_ios_country.product_page_views}",
+        label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
+    listen:
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    row: 6
+    col: 0
+    width: 12
+    height: 3
+  - name: First Time Installs
+    title: First Time Installs
+    merged_queries:
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.first_time_installs]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '0'
+      sorts: [mobile_ios_country.first_time_installs desc]
+      limit: 500
+      join_fields: []
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.first_time_installs]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '1'
+      sorts: [mobile_ios_country.first_time_installs desc]
+      limit: 500
+      join_fields:
+      - field_name: mobile_ios_country.join_field
+        source_field_name: mobile_ios_country.join_field
+    custom_color_enabled: true
+    show_single_value_title: true
+    single_value_title: stalls
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hidden_fields: [q1_mobile_ios_country.first_time_installs]
+    type: single_value
+    series_types: {}
+    column_limit: 50
+    dynamic_fields: [{_kind_hint: measure, table_calculation: from_previous_time_period,
+        _type_hint: number, category: table_calculation, expression: "(${mobile_ios_country.first_time_installs}-${q1_mobile_ios_country.first_time_installs})/${q1_mobile_ios_country.first_time_installs}",
+        label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
+    listen:
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    row: 6
+    col: 12
+    width: 12
+    height: 3
+  - name: First Seen
+    title: First Seen
+    merged_queries:
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.first_seen]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '0'
+      limit: 500
+      join_fields: []
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.first_seen]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '1'
+      limit: 500
+      join_fields:
+      - field_name: mobile_ios_country.join_field
+        source_field_name: mobile_ios_country.join_field
+    custom_color_enabled: true
+    show_single_value_title: true
+    single_value_title: First Seen
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    comparison_label: From Previous Time Period
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    series_types: {}
+    type: single_value
+    hidden_fields: [q1_mobile_ios_country.first_seen]
+    column_limit: 50
+    dynamic_fields: [{_kind_hint: measure, table_calculation: from_previous_time_period,
+        _type_hint: number, category: table_calculation, expression: "(${mobile_ios_country.first_seen}-${q1_mobile_ios_country.first_seen})/${q1_mobile_ios_country.first_seen}",
+        label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
+    listen:
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    row: 9
+    col: 0
+    width: 12
+    height: 3
+  - name: Activated
+    title: Activated
+    merged_queries:
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.activated]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '0'
+      sorts: [mobile_ios_country.activated desc]
+      limit: 500
+      join_fields: []
+    - model: duet
+      explore: mobile_ios_country
+      type: table
+      fields: [mobile_ios_country.join_field, mobile_ios_country.activated]
+      fill_fields: [mobile_ios_country.join_field]
+      filters:
+        mobile_ios_country.period_offset: '1'
+      limit: 500
+      join_fields:
+      - field_name: mobile_ios_country.join_field
+        source_field_name: mobile_ios_country.join_field
+    custom_color_enabled: true
+    show_single_value_title: true
+    single_value_title: 7 Day Activated
+    show_comparison: true
+    comparison_type: change
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hidden_fields: [q1_mobile_ios_country.activated]
+    type: single_value
+    series_types: {}
+    column_limit: 50
+    dynamic_fields: [{_kind_hint: measure, table_calculation: from_previous_time_period,
+        _type_hint: number, category: table_calculation, expression: "(${mobile_ios_country.activated}-${q1_mobile_ios_country.activated})/${q1_mobile_ios_country.activated}",
+        label: From Previous Time Period, value_format: !!null '', value_format_name: percent_1}]
+    listen:
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    - History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    row: 9
+    col: 12
+    width: 12
+    height: 3
+  - title: Last Valid Submission Date
+    name: Last Valid Submission Date
+    model: duet
+    explore: mobile_ios_country
+    type: single_value
+    fields: [mobile_ios_country.latest_date]
+    fill_fields: [mobile_ios_country.latest_date]
+    sorts: [mobile_ios_country.latest_date desc]
+    limit: 500
+    dynamic_fields: [{measure: count_of_latest_date, based_on: mobile_ios_country.latest_date,
+        expression: '', label: Count of Latest Date, type: count_distinct, _kind_hint: measure,
+        _type_hint: number}]
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    single_value_title: Most Recent Submission Date for Analysis
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    defaults_version: 1
+    series_types: {}
+    listen:
+      History Days: mobile_ios_country.history_days
+      App ID: mobile_ios_country.app_id
+      Bucket: country_buckets.bucket
+    row: 4
+    col: 12
+    width: 12
+    height: 2
+  filters:
+  - name: App ID
+    title: App ID
+    type: field_filter
+    default_value: firefox
+    allow_multiple_values: true
+    required: true
+    ui_config:
+      type: button_toggles
+      display: inline
+      options: []
+    model: duet
+    explore: mobile_ios_country
+    listens_to_filters: []
+    field: mobile_ios_country.app_id
+  - name: History Days
+    title: History Days
+    type: field_filter
+    default_value: '7'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: button_toggles
+      display: inline
+      options: []
+    model: duet
+    explore: mobile_ios_country
+    listens_to_filters: []
+    field: mobile_ios_country.history_days
+  - name: Bucket
+    title: Bucket
+    type: field_filter
+    default_value: tier-1
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: button_toggles
+      display: popover
+      options: []
+    model: duet
+    explore: country_buckets
+    listens_to_filters: []
+    field: country_buckets.bucket

--- a/duet/explores/mobile_ios_country.explore.lkml
+++ b/duet/explores/mobile_ios_country.explore.lkml
@@ -2,7 +2,8 @@ include: "../views/*.view.lkml"
 
 explore: mobile_ios_country {
   label: "Mobile iOS Funnel"
-  description: "Consolidated view of the Android acquisition funnel by country."
+  view_label: "iOS Funnel Steps"
+  description: "Consolidated view of the iOS acquisition funnel by country."
   join: country_buckets {
     type: inner
     relationship: many_to_one

--- a/duet/explores/mobile_ios_country.explore.lkml
+++ b/duet/explores/mobile_ios_country.explore.lkml
@@ -11,4 +11,73 @@ explore: mobile_ios_country {
       country_buckets.bucket: "Overall"
     ]
   }
+
+  aggregate_table: rollup__submission_date__0 {
+    query: {
+      dimensions: [
+        # "app_id" is filtered on in the dashboard.
+        # Uncomment to allow all possible filters to work with aggregate awareness.
+        # app_id,
+        # "country_buckets.bucket" is filtered on in the dashboard.
+        # Uncomment to allow all possible filters to work with aggregate awareness.
+        # country_buckets.bucket,
+        # "history_days" is filtered on in the dashboard.
+        # Uncomment to allow all possible filters to work with aggregate awareness.
+        # history_days,
+        submission_date
+      ]
+      measures: [activated, first_seen, first_time_installs, installations_opt_in, product_page_views]
+      filters: [
+        # "country_buckets.bucket" is filtered on by the dashboard. The filter
+        # value below may not optimize with other filter values.
+        country_buckets.bucket: "tier-1",
+        # "mobile_ios_country.app_id" is filtered on by the dashboard. The filter
+        # value below may not optimize with other filter values.
+        mobile_ios_country.app_id: "firefox",
+        # "mobile_ios_country.history_days" is filtered on by the dashboard. The filter
+        # value below may not optimize with other filter values.
+        mobile_ios_country.history_days: "7"
+      ]
+    }
+
+    # Please specify a datagroup_trigger or sql_trigger_value
+    # See https://looker.com/docs/r/lookml/types/aggregate_table/materialization
+    materialization: {
+      sql_trigger_value: SELECT CURRENT_DATE();;
+    }
+  }
+
+  aggregate_table: rollup__activated__first_seen__first_time_installs__installations_opt_in__product_page_views__1 {
+    query: {
+      dimensions: [
+        # "app_id" is filtered on in the dashboard.
+        # Uncomment to allow all possible filters to work with aggregate awareness.
+        # app_id,
+        # "country_buckets.bucket" is filtered on in the dashboard.
+        # Uncomment to allow all possible filters to work with aggregate awareness.
+        # country_buckets.bucket,
+        # "history_days" is filtered on in the dashboard.
+        # Uncomment to allow all possible filters to work with aggregate awareness.
+        # history_days
+      ]
+      measures: [activated, first_seen, first_time_installs, installations_opt_in, product_page_views]
+      filters: [
+        # "country_buckets.bucket" is filtered on by the dashboard. The filter
+        # value below may not optimize with other filter values.
+        country_buckets.bucket: "tier-1",
+        # "mobile_ios_country.app_id" is filtered on by the dashboard. The filter
+        # value below may not optimize with other filter values.
+        mobile_ios_country.app_id: "firefox",
+        # "mobile_ios_country.history_days" is filtered on by the dashboard. The filter
+        # value below may not optimize with other filter values.
+        mobile_ios_country.history_days: "7"
+      ]
+    }
+
+    # Please specify a datagroup_trigger or sql_trigger_value
+    # See https://looker.com/docs/r/lookml/types/aggregate_table/materialization
+    materialization: {
+      sql_trigger_value: SELECT CURRENT_DATE();;
+    }
+  }
 }

--- a/duet/explores/mobile_ios_country.explore.lkml
+++ b/duet/explores/mobile_ios_country.explore.lkml
@@ -1,5 +1,14 @@
 include: "../views/*.view.lkml"
 
 explore: mobile_ios_country {
-
+  join: country_buckets {
+    type: inner
+    relationship: many_to_one
+    sql_on:  ${country_buckets.code} = ${mobile_ios_country.country} ;;
+  }
+  always_filter: {
+    filters: [
+      country_buckets.bucket: "Overall"
+    ]
+  }
 }

--- a/duet/explores/mobile_ios_country.explore.lkml
+++ b/duet/explores/mobile_ios_country.explore.lkml
@@ -1,0 +1,5 @@
+include: "../views/*.view.lkml"
+
+explore: mobile_ios_country {
+
+}

--- a/duet/explores/mobile_ios_country.explore.lkml
+++ b/duet/explores/mobile_ios_country.explore.lkml
@@ -18,9 +18,9 @@ explore: mobile_ios_country {
   aggregate_table: rollup__submission_date__0 {
     query: {
       dimensions: [
-        # "app_id" is filtered on in the dashboard.
+        # "app_name" is filtered on in the dashboard.
         # Uncomment to allow all possible filters to work with aggregate awareness.
-        # app_id,
+        # app_name,
         # "country_buckets.bucket" is filtered on in the dashboard.
         # Uncomment to allow all possible filters to work with aggregate awareness.
         # country_buckets.bucket,
@@ -34,9 +34,9 @@ explore: mobile_ios_country {
         # "country_buckets.bucket" is filtered on by the dashboard. The filter
         # value below may not optimize with other filter values.
         country_buckets.bucket: "tier-1",
-        # "mobile_ios_country.app_id" is filtered on by the dashboard. The filter
+        # "mobile_ios_country.app_name" is filtered on by the dashboard. The filter
         # value below may not optimize with other filter values.
-        mobile_ios_country.app_id: "firefox",
+        mobile_ios_country.app_name: "firefox",
         # "mobile_ios_country.history_days" is filtered on by the dashboard. The filter
         # value below may not optimize with other filter values.
         mobile_ios_country.history_days: "7"
@@ -53,9 +53,9 @@ explore: mobile_ios_country {
   aggregate_table: rollup__activated__first_seen__first_time_installs__installations_opt_in__product_page_views__1 {
     query: {
       dimensions: [
-        # "app_id" is filtered on in the dashboard.
+        # "app_name" is filtered on in the dashboard.
         # Uncomment to allow all possible filters to work with aggregate awareness.
-        # app_id,
+        # app_name,
         # "country_buckets.bucket" is filtered on in the dashboard.
         # Uncomment to allow all possible filters to work with aggregate awareness.
         # country_buckets.bucket,
@@ -68,9 +68,9 @@ explore: mobile_ios_country {
         # "country_buckets.bucket" is filtered on by the dashboard. The filter
         # value below may not optimize with other filter values.
         country_buckets.bucket: "tier-1",
-        # "mobile_ios_country.app_id" is filtered on by the dashboard. The filter
+        # "mobile_ios_country.app_name" is filtered on by the dashboard. The filter
         # value below may not optimize with other filter values.
-        mobile_ios_country.app_id: "firefox",
+        mobile_ios_country.app_name: "firefox",
         # "mobile_ios_country.history_days" is filtered on by the dashboard. The filter
         # value below may not optimize with other filter values.
         mobile_ios_country.history_days: "7"

--- a/duet/explores/mobile_ios_country.explore.lkml
+++ b/duet/explores/mobile_ios_country.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/*.view.lkml"
 
 explore: mobile_ios_country {
+  label: "Mobile iOS Funnel"
+  description: "Consolidated view of the Android acquisition funnel by country."
   join: country_buckets {
     type: inner
     relationship: many_to_one

--- a/duet/views/mobile_ios_country.view.lkml
+++ b/duet/views/mobile_ios_country.view.lkml
@@ -223,16 +223,16 @@ view: mobile_ios_country {
        ;;
   }
 
-  parameter: app_id {
-    description: "The name of the application in the `org.mozilla` namespace."
+  parameter: app_name {
+    description: "The name of the application."
     type:  unquoted
     default_value: "firefox"
     allowed_value: {
-      label: "Firefox"
+      label: "Firefox for iOS"
       value: "firefox"
     }
     allowed_value: {
-      label: "Focus"
+      label: "Focus for iOS"
       value: "focus"
     }
     allowed_value: {

--- a/duet/views/mobile_ios_country.view.lkml
+++ b/duet/views/mobile_ios_country.view.lkml
@@ -228,12 +228,15 @@ view: mobile_ios_country {
     type:  unquoted
     default_value: "firefox"
     allowed_value: {
+      label: "Firefox"
       value: "firefox"
     }
     allowed_value: {
+      label: "Focus"
       value: "focus"
     }
     allowed_value: {
+      label: "Klar (Focus)"
       value: "klar"
     }
   }
@@ -300,33 +303,39 @@ view: mobile_ios_country {
   }
 
   dimension: country {
+    description: "The country code for the aggregates"
     type: string
     sql: ${TABLE}.country ;;
   }
 
   dimension: ios_store_updated {
+    description: "The date of the last apple store import"
     type: date
     datatype: date
     sql: ${TABLE}.ios_store_updated ;;
   }
 
   dimension: latest_date {
+    description: "The most recent submission date used for analysis"
     type: date
     datatype: date
     sql: ${TABLE}.latest_date ;;
   }
 
   measure: product_page_views {
+    description: "The number of page visits to a particular apple storefront"
     type: sum
     sql: ${TABLE}.product_page_views ;;
   }
 
   measure: first_time_installs {
+    description: "The number of first time installs reported by the apple store"
     type: sum
     sql: ${TABLE}.first_time_installs ;;
   }
 
   measure: installations_opt_in {
+    description: "The number of opt-in first time runs reported by the apple store"
     type: sum
     sql: ${TABLE}.installations_opt_in ;;
   }

--- a/duet/views/mobile_ios_country.view.lkml
+++ b/duet/views/mobile_ios_country.view.lkml
@@ -273,7 +273,7 @@ view: mobile_ios_country {
   }
 
   dimension: bucket {
-    description: "The geographical bucket that the lies under. Do not combine with country unless this is set to overall."
+    description: "The geographical bucket that the country lies under. Do not combine with country unless this is set to overall."
     type: "string"
     hidden: yes
     suggest_explore: country_buckets
@@ -341,13 +341,13 @@ view: mobile_ios_country {
   }
 
   measure: first_seen {
-    description: "The number of client ids seen for the first time in the baseline clients last seen table."
+    description: "The number of client ids that sent a baseline ping (and accounted for at least 1 DOU)."
     type: sum
     sql: ${TABLE}.first_seen ;;
   }
 
   measure: activated {
-    description: "The number of clients that have used the app for 5/7 days."
+    description: "The number of clients that have used the app for at least 5 of their first 7 days."
     type: sum
     sql: ${TABLE}.activated ;;
   }

--- a/duet/views/mobile_ios_country.view.lkml
+++ b/duet/views/mobile_ios_country.view.lkml
@@ -277,6 +277,12 @@ view: mobile_ios_country {
     suggest_dimension: country_buckets.bucket
   }
 
+  dimension: join_field {
+    type: yesno
+    description: "Always set to true. Allows to merge explores."
+    sql: TRUE ;;
+  }
+
   dimension_group: submission {
     description: "The submission date of the data."
     type: time

--- a/duet/views/mobile_ios_country.view.lkml
+++ b/duet/views/mobile_ios_country.view.lkml
@@ -28,86 +28,18 @@ view: mobile_ios_country {
       AS
         (
           SELECT
-            date,
+            date as submission_date,
             app_name,
-            CASE
-            WHEN
-              storefront LIKE '%St.%'
-            THEN
-              REPLACE(storefront, 'St.', 'Saint')
-            WHEN
-              storefront = 'China mainland'
-            THEN
-              'China'
-            WHEN
-              storefront = 'Russia'
-            THEN
-              'Russian Federation'
-            WHEN
-              storefront = 'Tanzania'
-            THEN
-              'Tanzania, United Republic of'
-            WHEN
-              storefront = 'North Macedonia'
-            THEN
-              'Macedonia, the Former Yugoslav Republic of'
-            WHEN
-              storefront = 'São Tomé and Príncipe'
-            THEN
-              'Sao Tome and Principe'
-            WHEN
-              storefront = 'Micronesia'
-            THEN
-              'Micronesia, Federated States of'
-            WHEN
-              storefront = 'Moldova'
-            THEN
-              'Moldova, Republic of'
-            WHEN
-              storefront = 'Venezuela'
-            THEN
-              'Venezuela, Bolivarian Republic of'
-            WHEN
-              storefront = 'Taiwan'
-            THEN
-              'Taiwan, Province of China'
-            WHEN
-              storefront = 'British Virgin Islands'
-            THEN
-              'Virgin Islands, British'
-            WHEN
-              storefront = 'Brunei'
-            THEN
-              'Brunei Darussalam'
-            WHEN
-              storefront = 'Congo, Democratic Republic of the'
-            THEN
-              'Congo, the Democratic Republic of the'
-            WHEN
-              storefront = 'Congo, Republic of the'
-            THEN
-              'Congo'
-            WHEN
-              storefront = 'Bolivia'
-            THEN
-              'Bolivia, Plurinational State of'
-            WHEN
-              storefront = 'Vietnam'
-            THEN
-              'Viet Nam'
-            WHEN
-              storefront = "Cote d'Ivoire"
-            THEN
-              "Côte d'Ivoire"
-            ELSE
-              storefront
-            END
-            AS name,
+            code as country,
             product_page_views,
             app_units AS first_time_installs,
             installations_opt_in
           FROM
             `moz-fx-data-marketing-prod.apple_app_store.metrics_by_storefront`
+          LEFT JOIN
+            `moz-fx-data-shared-prod.static.country_names_v1`
+          ON
+            storefront = name
           CROSS JOIN
             period
           WHERE
@@ -121,43 +53,11 @@ view: mobile_ios_country {
               {% endif %}
             )
         ),
-        apple_country_metrics AS (
-          SELECT
-            date AS submission_date,
-            app_name,
-           -- Macau, Eswatini, Laos
-            CASE
-            WHEN
-              name = 'Macau'
-            THEN
-              'MO'
-            WHEN
-              name = 'Eswatini'
-            THEN
-              'SZ'
-            WHEN
-              name = 'Laos'
-            THEN
-              'LA'
-            ELSE
-              code
-            END
-            AS country,
-            product_page_views,
-            first_time_installs,
-            installations_opt_in
-          FROM
-            apple_storefront_metrics
-          LEFT JOIN
-            `mozdata.static.country_codes_v1`
-          USING
-            (name)
-        ),
         apple_countries AS (
           SELECT DISTINCT
             country
           FROM
-            apple_country_metrics
+            apple_storefront_metrics
         ),
         last_seen AS (
           SELECT
@@ -203,7 +103,7 @@ view: mobile_ios_country {
         sum(first_seen) AS first_seen,
         sum(activated) AS activated
       FROM
-        apple_country_metrics
+        apple_storefront_metrics
       JOIN
         last_seen
       USING

--- a/duet/views/mobile_ios_country.view.lkml
+++ b/duet/views/mobile_ios_country.view.lkml
@@ -115,9 +115,9 @@ view: mobile_ios_country {
             BETWEEN start_date
             AND end_date
             AND app_name IN (
-              {% if app_id._parameter_value == "firefox" %} "Firefox"
-              {% elsif app_id._parameter_value == "focus" %} "Focus"
-              {% elsif app_id._parameter_value == "klar" %} "Klar"
+              {% if app_name._parameter_value == "firefox" %} "Firefox"
+              {% elsif app_name._parameter_value == "focus" %} "Focus"
+              {% elsif app_name._parameter_value == "klar" %} "Klar"
               {% endif %}
             )
         ),
@@ -174,7 +174,7 @@ view: mobile_ios_country {
               END
             ) AS activated
           FROM
-            `moz-fx-data-shared-prod.org_mozilla_ios_{% parameter.app_id %}.baseline_clients_last_seen`
+            `moz-fx-data-shared-prod.org_mozilla_ios_{% parameter.app_name %}.baseline_clients_last_seen`
           LEFT JOIN
             apple_countries
           USING

--- a/duet/views/mobile_ios_country.view.lkml
+++ b/duet/views/mobile_ios_country.view.lkml
@@ -1,0 +1,284 @@
+view: mobile_ios_country {
+  derived_table: {
+    sql: WITH last_updated AS (
+        -- this table has rows that lag ~3 days plus/minus several days
+        SELECT DISTINCT
+          max(date) AS ios_store_updated,
+          -- We need a full week to see activated client; ignore the current day of partial data
+          date_sub(current_date(), INTERVAL 7 + 1 day) AS latest_date
+        FROM
+          `moz-fx-data-marketing-prod.apple_app_store.metrics_by_storefront`
+        WHERE
+          date >= date_sub(current_date(), INTERVAL 28 day)
+      ),
+      period AS (
+        SELECT
+          ios_store_updated,
+          latest_date,
+          date_sub(latest_date, INTERVAL 7 * 1 day) AS start_date,
+          date_sub(latest_date, INTERVAL 7 * 0 day) AS end_date
+        FROM
+          last_updated
+      ),
+      apple_storefront_metrics
+      AS
+        (
+          SELECT
+            date,
+            app_name,
+            CASE
+            WHEN
+              storefront LIKE '%St.%'
+            THEN
+              REPLACE(storefront, 'St.', 'Saint')
+            WHEN
+              storefront = 'China mainland'
+            THEN
+              'China'
+            WHEN
+              storefront = 'Russia'
+            THEN
+              'Russian Federation'
+            WHEN
+              storefront = 'Tanzania'
+            THEN
+              'Tanzania, United Republic of'
+            WHEN
+              storefront = 'North Macedonia'
+            THEN
+              'Macedonia, the Former Yugoslav Republic of'
+            WHEN
+              storefront = 'São Tomé and Príncipe'
+            THEN
+              'Sao Tome and Principe'
+            WHEN
+              storefront = 'Micronesia'
+            THEN
+              'Micronesia, Federated States of'
+            WHEN
+              storefront = 'Moldova'
+            THEN
+              'Moldova, Republic of'
+            WHEN
+              storefront = 'Venezuela'
+            THEN
+              'Venezuela, Bolivarian Republic of'
+            WHEN
+              storefront = 'Taiwan'
+            THEN
+              'Taiwan, Province of China'
+            WHEN
+              storefront = 'British Virgin Islands'
+            THEN
+              'Virgin Islands, British'
+            WHEN
+              storefront = 'Brunei'
+            THEN
+              'Brunei Darussalam'
+            WHEN
+              storefront = 'Congo, Democratic Republic of the'
+            THEN
+              'Congo, the Democratic Republic of the'
+            WHEN
+              storefront = 'Congo, Republic of the'
+            THEN
+              'Congo'
+            WHEN
+              storefront = 'Bolivia'
+            THEN
+              'Bolivia, Plurinational State of'
+            WHEN
+              storefront = 'Vietnam'
+            THEN
+              'Viet Nam'
+            WHEN
+              storefront = "Cote d'Ivoire"
+            THEN
+              "Côte d'Ivoire"
+            ELSE
+              storefront
+            END
+            AS name,
+            product_page_views,
+            app_units AS first_time_installs,
+            installations_opt_in
+          FROM
+            `moz-fx-data-marketing-prod.apple_app_store.metrics_by_storefront`
+          CROSS JOIN
+            period
+          WHERE
+            date
+            BETWEEN start_date
+            AND end_date
+            AND app_name IN ('Firefox')
+          -- or focus
+        ),
+        apple_country_metrics AS (
+          SELECT
+            date AS submission_date,
+            app_name,
+           -- Macau, Eswatini, Laos
+            CASE
+            WHEN
+              name = 'Macau'
+            THEN
+              'MO'
+            WHEN
+              name = 'Eswatini'
+            THEN
+              'SZ'
+            WHEN
+              name = 'Laos'
+            THEN
+              'LA'
+            ELSE
+              code
+            END
+            AS country,
+            product_page_views,
+            first_time_installs,
+            installations_opt_in
+          FROM
+            apple_storefront_metrics
+          LEFT JOIN
+            `mozdata.static.country_codes_v1`
+          USING
+            (name)
+        ),
+        apple_countries AS (
+          SELECT DISTINCT
+            country
+          FROM
+            apple_country_metrics
+        ),
+        last_seen AS (
+          SELECT
+            first_seen_date AS submission_date,
+            coalesce(apple_countries.country, "OTHER") AS country,
+            count(DISTINCT client_id) AS first_seen,
+            count(
+              DISTINCT
+              CASE
+              WHEN
+                coalesce(BIT_COUNT(days_seen_bits), 0) >= 5
+              THEN
+                client_id
+              END
+            ) AS activated
+          FROM
+            `moz-fx-data-shared-prod.org_mozilla_ios_firefox.baseline_clients_last_seen`
+          LEFT JOIN
+            apple_countries
+          USING
+            (country)
+          CROSS JOIN
+            period
+          WHERE
+            submission_date
+            BETWEEN date_sub(current_date(), INTERVAL 7 * 1 + 7 day)
+            AND date_sub(current_date(), INTERVAL 7 day)
+            AND first_run_date
+            BETWEEN start_date
+            AND period.end_date
+          GROUP BY
+            1,
+            2
+        )
+      SELECT
+        submission_date,
+        country,
+        max(ios_store_updated) AS ios_store_updated,
+        max(latest_date) AS latest_date,
+        sum(product_page_views) AS product_page_views,
+        sum(first_time_installs) AS first_time_installs,
+        sum(installations_opt_in) AS installations_opt_in,
+        sum(first_seen) AS first_seen,
+        sum(activated) AS activated
+      FROM
+        apple_country_metrics
+      JOIN
+        last_seen
+      USING
+        (submission_date, country)
+      CROSS JOIN
+        period
+      WHERE
+        submission_date
+        BETWEEN start_date
+        AND end_date
+      GROUP BY
+        1,
+        2
+      ORDER BY
+        1,
+        2
+       ;;
+  }
+
+  measure: count {
+    type: count
+    drill_fields: [detail*]
+  }
+
+  dimension: submission_date {
+    type: date
+    datatype: date
+    sql: ${TABLE}.submission_date ;;
+  }
+
+  dimension: country {
+    type: string
+    sql: ${TABLE}.country ;;
+  }
+
+  dimension: ios_store_updated {
+    type: date
+    datatype: date
+    sql: ${TABLE}.ios_store_updated ;;
+  }
+
+  dimension: latest_date {
+    type: date
+    datatype: date
+    sql: ${TABLE}.latest_date ;;
+  }
+
+  dimension: product_page_views {
+    type: number
+    sql: ${TABLE}.product_page_views ;;
+  }
+
+  dimension: first_time_installs {
+    type: number
+    sql: ${TABLE}.first_time_installs ;;
+  }
+
+  dimension: installations_opt_in {
+    type: number
+    sql: ${TABLE}.installations_opt_in ;;
+  }
+
+  dimension: first_seen {
+    type: number
+    sql: ${TABLE}.first_seen ;;
+  }
+
+  dimension: activated {
+    type: number
+    sql: ${TABLE}.activated ;;
+  }
+
+  set: detail {
+    fields: [
+      submission_date,
+      country,
+      ios_store_updated,
+      latest_date,
+      product_page_views,
+      first_time_installs,
+      installations_opt_in,
+      first_seen,
+      activated
+    ]
+  }
+}


### PR DESCRIPTION
This is a followup to #52 for [DS-1545](https://jira.mozilla.com/browse/DS-1545). This will follow the same general shape as the dashboard there.

This was actually straightforward to implement since the dashboard definition was easy to edit from android to ios. The metric definitions are different in the apple store than they are in the play store, so this will need to be documented.
