### PR TITLE
Add measures for Activity Stream, Search, and Contextual Services

### DIFF
--- a/activity_stream/activity_stream.model.lkml
+++ b/activity_stream/activity_stream.model.lkml
@@ -1,7 +1,4 @@
 connection: "telemetry"
 label: "Activity Stream"
 include: "//looker-hub/activity_stream/explores/*"
-include: "//looker-hub/activity_stream/dashboards/*"
 include: "views/*"
-include: "explores/*"
-include: "dashboards/*"

--- a/activity_stream/views/events.view.lkml
+++ b/activity_stream/views/events.view.lkml
@@ -1,0 +1,8 @@
+include: "//looker-hub/activity_stream/views/events.view.lkml"
+
+view: +events {
+  measure: event_count {
+    type: count
+    description: "Count of the number of events."
+  }
+}

--- a/activity_stream/views/impression_stats_flat.view.lkml
+++ b/activity_stream/views/impression_stats_flat.view.lkml
@@ -1,0 +1,33 @@
+include: "//looker-hub/activity_stream/views/impression_stats_flat.view.lkml"
+
+view: +impression_stats_flat {
+  measure: block_count {
+    type: sum
+    sql: ${blocked} ;;
+    description: "The number of blocks of a tile."
+  }
+
+  measure: click_count {
+    type: sum
+    sql: ${clicks} ;;
+    description: "The number of clicks on a tile."
+  }
+
+  measure: impression_count {
+    type: sum
+    sql: ${impressions} ;;
+    description: "The number of impressions of a tile."
+  }
+
+  measure: loaded_count {
+    type: sum
+    sql: ${loaded} ;;
+    description: "The number of loads of a tile."
+  }
+
+  measure: pocketed_count {
+    type: sum
+    sql: ${pocketed} ;;
+    description: "The number of times pocketed."
+  }
+}

--- a/activity_stream/views/sessions.view.lkml
+++ b/activity_stream/views/sessions.view.lkml
@@ -1,0 +1,8 @@
+include: "//looker-hub/activity_stream/views/sessions.view.lkml"
+
+view: +sessions {
+  measure: session_count {
+    type: count
+    description: "Count of the number of sessions."
+  }
+}

--- a/contextual_services/contextual_services.model.lkml
+++ b/contextual_services/contextual_services.model.lkml
@@ -1,7 +1,4 @@
 connection: "bigquery-oauth"
 label: "Contextual Services"
 include: "//looker-hub/contextual_services/explores/*"
-include: "//looker-hub/contextual_services/dashboards/*"
 include: "views/*"
-include: "explores/*"
-include: "dashboards/*"

--- a/contextual_services/views/event_aggregates.view.lkml
+++ b/contextual_services/views/event_aggregates.view.lkml
@@ -6,9 +6,22 @@ view: +event_aggregates {
     sql: ${TABLE}.user_count ;;
   }
 
-  measure: total_users {
+  dimension: event_count {
+    hidden: yes
+    sql: ${TABLE}.event_count ;;
+  }
+
+  measure: user_counts {
+    label: "User Count"
     type: sum
-    sql: ${user_count} ;;
-    description: "Count of Users."
+    sql: ${TABLE}.user_count ;;
+    description: "Count of users."
+  }
+
+  measure: event_counts {
+    label: "Event Count"
+    type: sum
+    sql: ${TABLE}.event_count ;;
+    description: "Count of events."
   }
 }

--- a/contextual_services/views/event_aggregates.view.lkml
+++ b/contextual_services/views/event_aggregates.view.lkml
@@ -1,0 +1,14 @@
+include: "//looker-hub/contextual_services/views/event_aggregates.view.lkml"
+
+view: +event_aggregates {
+  dimension: user_count {
+    hidden: yes
+    sql: ${TABLE}.user_count ;;
+  }
+
+  measure: total_users {
+    type: sum
+    sql: ${user_count} ;;
+    description: "Count of Users."
+  }
+}

--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -1,7 +1,4 @@
 connection: "telemetry"
 label: "Search"
 include: "//looker-hub/search/explores/*"
-include: "//looker-hub/search/dashboards/*"
 include: "views/*"
-include: "explores/*"
-include: "dashboards/*"

--- a/search/views/mobile_search_clients_engines_sources_daily.view.lkml
+++ b/search/views/mobile_search_clients_engines_sources_daily.view.lkml
@@ -1,0 +1,52 @@
+include: "//looker-hub/search/views/mobile_search_clients_engines_sources_daily.view.lkml"
+
+view: +mobile_search_clients_engines_sources_daily {
+  measure: total_searches {
+    type: sum
+    sql: ${sap} ;;
+    description: "Total searches from all Search Access Points (SAPs), not including follow-ons.
+    These may or may not be tagged."
+  }
+
+  measure: total_tagged_sap_searches {
+    type: sum
+    sql: ${tagged_sap} ;;
+    description: "Total tagged searches from all Search Access Points (SAPs)."
+  }
+
+  measure: total_tagged_searches {
+    type: sum
+    sql: ${tagged_sap} + ${tagged_follow_on} ;;
+    description: "Total tagged searches from all Search Access Points (SAPs) and follow-ons."
+  }
+
+  measure: total_tagged_follow_on_searches {
+    type: sum
+    sql: ${tagged_follow_on} ;;
+    description: "Total follow-on searches, which occur after a search from a Search Access Point (SAP)."
+  }
+
+  measure: total_organic_searches {
+    type: sum
+    sql: ${organic} ;;
+    description: "Total organic searches, made directly at the engine's website."
+  }
+
+  measure: total_searches_with_ads {
+    type: sum
+    sql: ${search_with_ads} ;;
+    description: "Total searches with ads. Does not include organic searches."
+  }
+
+  measure: total_ad_clicks {
+    type: sum
+    sql: ${ad_click} ;;
+    description: "Total ad clicks. Does not include ad clicks resulting from organic searches."
+  }
+
+  measure: total_organic_ad_clicks {
+    type: sum
+    sql: ${ad_click_organic} ;;
+    description: "Total organic ad clicks."
+  }
+}

--- a/search/views/search_clients_engine_sources_daily.view.lkml
+++ b/search/views/search_clients_engine_sources_daily.view.lkml
@@ -1,0 +1,58 @@
+include: "//looker-hub/search/views/search_clients_engines_sources_daily.view.lkml"
+
+view: +search_clients_engines_sources_daily {
+  measure: total_searches {
+    type: sum
+    sql: ${sap} ;;
+    description: "Total searches from all Search Access Points (SAPs), not including follow-ons.
+     These may or may not be tagged."
+  }
+
+  measure: total_tagged_sap_searches {
+    type: sum
+    sql: ${tagged_sap} ;;
+    description: "Total tagged searches from all Search Access Points (SAPs)."
+  }
+
+  measure: total_tagged_searches {
+    type: sum
+    sql: ${tagged_sap} + ${tagged_follow_on} ;;
+    description: "Total tagged searches from all Search Access Points (SAPs) and follow-ons."
+  }
+
+  measure: total_tagged_follow_on_searches {
+    type: sum
+    sql: ${tagged_follow_on} ;;
+    description: "Total follow-on searches, which occur after a search from a Search Access Point (SAP)."
+  }
+
+  measure: total_organic_searches {
+    type: sum
+    sql: ${organic} ;;
+    description: "Total organic searches, made directly at the engine's website."
+  }
+
+  measure: total_searches_with_ads {
+    type: sum
+    sql: ${search_with_ads} ;;
+    description: "Total searches with ads. Does not include organic searches."
+  }
+
+  measure: total_organic_searches_with_ads {
+    type: sum
+    sql: ${search_with_ads_organic} ;;
+    description: "Total organic searches with ads. "
+  }
+
+  measure: total_ad_clicks {
+    type: sum
+    sql: ${ad_click} ;;
+    description: "Total ad clicks. Does not include ad clicks resulting from organic searches."
+  }
+
+  measure: total_organic_ad_clicks {
+    type: sum
+    sql: ${ad_click_organic} ;;
+    description: "Total organic ad clicks."
+  }
+}


### PR DESCRIPTION
This covers the tables we outlined in bug 1711955. We will probably follow this up with additional tables for both CS and AS.