### PR TITLE
Add script to sync user-defined dashboards with LookML dashboards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 ---
-version: 2
+version: 2.1
+orbs:
+  python: circleci/python@1.4.0
+
 jobs:
   deploy-prod:
     docker:
@@ -16,6 +19,16 @@ jobs:
       - image: cimg/base:2020.01
     steps:
       - run: curl https://mozilladev.cloud.looker.com/webhooks/projects/spoke-default/deploy
+  sync-dashboards-prod:
+    executor: python/default
+    steps:
+      - checkout
+      - python/install-packages:
+          pip-dependency-file: src/sync_dashboards/requirements.txt
+          pkg-manager: pip
+      - run:
+          command: |
+            python ./src/sync_dashboards/main.py lookml_dashboards.yaml
 workflows:
   version: 2
   build:
@@ -36,5 +49,14 @@ workflows:
           filters:
             branches:
               only: main-nonprod
+            tags:
+              only: /.*/
+      - sync-dashboards-prod:
+          context: data-eng-looker
+          requires:
+            - deploy-prod
+          filters:
+            branches:
+              only: main
             tags:
               only: /.*/

--- a/lookml_dashboards.yaml
+++ b/lookml_dashboards.yaml
@@ -1,3 +1,14 @@
+# Listing of synced dashboards.
+# A synced dashboard is a User-Defined dashboard that
+# a  LookML Dashboard is copied to. It will match the
+# LookML Dashboard exactly.
+# 
+# Usage:
+#   1. Create a LookML dashboard.
+#   2. Create a User-Defined dashboard
+#   3. Below, add an entry syncing the two. Syncs will happen on merge to `main`.
+#
+# Format:
 # user_defined_dashboard_id: "lookml_dashboard_id"
 ---
 52: "kpi::firefox_corporate_kpis"

--- a/lookml_dashboards.yaml
+++ b/lookml_dashboards.yaml
@@ -12,4 +12,4 @@
 # user_defined_dashboard_id: "lookml_dashboard_id"
 ---
 101: "kpi::firefox_corporate_kpis"
-101: "duet::desktop_numbers_that_matter"
+66: "duet::desktop_numbers_that_matter"

--- a/lookml_dashboards.yaml
+++ b/lookml_dashboards.yaml
@@ -1,0 +1,4 @@
+# user_defined_dashboard_id: "lookml_dashboard_id"
+---
+52: "kpi::firefox_corporate_kpis"
+101: "duet::desktop_numbers_that_matter"

--- a/lookml_dashboards.yaml
+++ b/lookml_dashboards.yaml
@@ -11,5 +11,5 @@
 # Format:
 # user_defined_dashboard_id: "lookml_dashboard_id"
 ---
-52: "kpi::firefox_corporate_kpis"
+101: "kpi::firefox_corporate_kpis"
 101: "duet::desktop_numbers_that_matter"

--- a/src/sync_dashboards/README.md
+++ b/src/sync_dashboards/README.md
@@ -1,0 +1,3 @@
+# Sync Dashboards
+
+A simple script that links and sync user-defined dashboards with LookML dashboards.

--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -31,19 +31,10 @@ def sync_dashboards(sdk: methods.Looker31SDK, config: dict) -> None:
         try:
             dashboard = sdk.dashboard(str(dashboard_id))
             sdk.dashboard_lookml(lookml_dashboard_id)
-            if dashboard.lookml_link_id is None:
-                sdk.update_dashboard(
-                    str(dashboard_id),
-                    models.WriteDashboard(lookml_link_id=lookml_dashboard_id),
-                )
-            elif dashboard.lookml_link_id != lookml_dashboard_id:
-                logging.warning(
-                    f"Dashboard {dashboard_id} lookml_link_id changing from {dashboard.lookml_link_id} to {lookml_dashboard_id}"
-                )
-                sdk.update_dashboard(
-                    str(dashboard_id),
-                    models.WriteDashboard(lookml_link_id=lookml_dashboard_id),
-                )
+            sdk.update_dashboard(
+                str(dashboard_id),
+                models.WriteDashboard(lookml_link_id=lookml_dashboard_id),
+            )
 
             sdk.sync_lookml_dashboard(lookml_dashboard_id, models.WriteDashboard())
             logging.info(

--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -1,0 +1,75 @@
+import logging
+import os
+import yaml
+
+import click
+import looker_sdk
+
+from looker_sdk import methods, models
+
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)-8s %(message)s",
+    level=logging.INFO,
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+
+def setup_sdk(client_id, client_secret, instance) -> methods.Looker31SDK:
+    os.environ["LOOKERSDK_BASE_URL"] = instance
+    os.environ["LOOKERSDK_API_VERSION"] = "3.1"
+    os.environ["LOOKERSDK_VERIFY_SSL"] = "true"
+    os.environ["LOOKERSDK_TIMEOUT"] = "120"
+    os.environ["LOOKERSDK_CLIENT_ID"] = client_id
+    os.environ["LOOKERSDK_CLIENT_SECRET"] = client_secret
+
+    return looker_sdk.init31()
+
+
+def sync_dashboards(sdk: methods.Looker31SDK, config: dict) -> None:
+    for dashboard_id, lookml_dashboard_id in config.items():
+        try:
+            dashboard = sdk.dashboard(str(dashboard_id))
+            sdk.dashboard_lookml(lookml_dashboard_id)
+            if dashboard.lookml_link_id is None:
+                sdk.update_dashboard(
+                    str(dashboard_id),
+                    models.WriteDashboard(lookml_link_id=lookml_dashboard_id),
+                )
+            elif dashboard.lookml_link_id != lookml_dashboard_id:
+                logging.warning(
+                    f"Dashboard {dashboard_id} lookml_link_id changing from {dashboard.lookml_link_id} to {lookml_dashboard_id}"
+                )
+                sdk.update_dashboard(
+                    str(dashboard_id),
+                    models.WriteDashboard(lookml_link_id=lookml_dashboard_id),
+                )
+
+            sdk.sync_lookml_dashboard(lookml_dashboard_id, models.WriteDashboard())
+            logging.info(
+                f"Dashboard {dashboard_id} synced with LookML dashboard {lookml_dashboard_id}"
+            )
+        except looker_sdk.error.SDKError as e:
+            logging.error(f"Dashboard {dashboard_id} dashboard sync failed with {e}")
+
+
+def load_config(filename: str) -> dict:
+    with open(filename) as f:
+        config = yaml.load(f, Loader=yaml.SafeLoader)
+
+    return config
+
+
+@click.command()
+@click.option("--client_id", envvar="LOOKER_API_CLIENT_ID", required=True)
+@click.option("--client_secret", envvar="LOOKER_API_CLIENT_SECRET", required=True)
+@click.option("--instance_uri", envvar="LOOKER_INSTANCE_URI", required=True)
+@click.argument("config", type=click.Path(exists=True))
+def main(client_id: str, client_secret: str, instance_uri: str, config: str):
+    sdk = setup_sdk(client_id, client_secret, instance_uri)
+    config = load_config(config)
+    sync_dashboards(sdk, config)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/sync_dashboards/requirements.txt
+++ b/src/sync_dashboards/requirements.txt
@@ -1,0 +1,4 @@
+PyYAML==5.4.1
+click==7.1.2
+looker-sdk==21.4.1
+pip-tools==5.5.0


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1713204.

I've tested this a bit on dev and works as expected. I am assuming we only want to link and sync dashboards on our 'production' instance, but we could potentially do it for all our instances.

I've tried to keep this minimal since we want to move this (and potentially other management type code) into another repo.

r?