### PR TITLE
Don't allow building of new forecasts (temporary fix)

### DIFF
--- a/KPI/views/firefox_desktop_usage_forecast.view.lkml
+++ b/KPI/views/firefox_desktop_usage_forecast.view.lkml
@@ -215,7 +215,7 @@ view: prediction {
       avg(new_profiles_forecast_upper) over window_7day as new_profiles_forecast_upper_7day_ma
     FROM
       mozdata.analysis.dou_forecasts
-    WHERE -- Also requires ${insert_stmnt.SQL_TABLE_NAME}
+    WHERE
       key = ARRAY_TO_STRING(REGEXP_EXTRACT_ALL("""
       {% condition firefox_desktop_usage_2021.activity_segment %} activity_segment {% endcondition %}
       {% condition firefox_desktop_usage_2021.campaign %} campaign {% endcondition %}

--- a/KPI/views/mobile_usage_forecast.view.lkml
+++ b/KPI/views/mobile_usage_forecast.view.lkml
@@ -137,7 +137,7 @@ view: mobile_prediction {
       avg(dau_forecast_upper) over window_7day as dau_forecast_upper_7day_ma
     FROM
       mozdata.analysis.mobile_dou_forecasts
-    WHERE -- Also requires ${mobile_insert_stmnt.SQL_TABLE_NAME}
+    WHERE
       key = ARRAY_TO_STRING(REGEXP_EXTRACT_ALL("""
       {% condition mobile_usage_2021.campaign %} campaign {% endcondition %}
       {% condition mobile_usage_2021.channel %} channel {% endcondition %}

--- a/mozilla_vpn/mozilla_vpn.model.lkml
+++ b/mozilla_vpn/mozilla_vpn.model.lkml
@@ -1,7 +1,5 @@
 connection: "telemetry"
 label: "Mozilla VPN"
-include: "//looker-hub/mozilla_vpn/explores/*"
-include: "//looker-hub/mozilla_vpn/dashboards/*"
 include: "views/*"
 include: "explores/*"
 include: "dashboards/*"


### PR DESCRIPTION
This lets the KPI dashboard load, by not requiring that the PDT rebuild. I'm going to work with Looker support on figuring out why this change in behavior happened.