### PR TITLE
Add views for Desktop H2 Forecast / KRs

### DIFF
--- a/KPI/kpi.model.lkml
+++ b/KPI/kpi.model.lkml
@@ -61,6 +61,7 @@ explore: mobile_usage_fields {
 explore: h2_desktop_actuals {
   label: "H2 Desktop"
   group_label: "KPIs"
+  hidden: no
   from: h2_desktop_actuals
   join: h2_desktop_forecast {
     view_label: "H2 Forecast"
@@ -68,6 +69,13 @@ explore: h2_desktop_actuals {
     sql_on: ${h2_desktop_actuals.date} = ${h2_desktop_forecast.date} ;;
     relationship: one_to_one
   }
-  hidden: no
+  join: h2_desktop_actuals_2020 {
+    from: h2_desktop_actuals
+    fields: []
+    view_label: "H2 Desktop 2020"
+    type: left_outer
+    sql_on: DATE_SUB(${h2_desktop_actuals.date}, INTERVAL 1 YEAR) = ${h2_desktop_actuals_2020.date} ;;
+    relationship: one_to_one
   # sql_always_where: ${date} >= "2021-07-01" ;;
+  }
 }

--- a/KPI/kpi.model.lkml
+++ b/KPI/kpi.model.lkml
@@ -57,3 +57,17 @@ explore: mobile_usage_2021 {
 explore: mobile_usage_fields {
   hidden: yes
 }
+
+explore: h2_desktop_actuals {
+  label: "H2 Desktop"
+  group_label: "KPIs"
+  from: h2_desktop_actuals
+  join: h2_desktop_forecast {
+    view_label: "H2 Forecast"
+    type: left_outer
+    sql_on: ${h2_desktop_actuals.date} = ${h2_desktop_forecast.date} ;;
+    relationship: one_to_one
+  }
+  hidden: no
+  # sql_always_where: ${date} >= "2021-07-01" ;;
+}

--- a/KPI/kpi.model.lkml
+++ b/KPI/kpi.model.lkml
@@ -59,7 +59,7 @@ explore: mobile_usage_fields {
 }
 
 explore: h2_desktop_actuals {
-  label: "H2 Desktop"
+  label: "H2 Desktop (Preliminary)"
   group_label: "KPIs"
   hidden: no
   from: h2_desktop_actuals

--- a/KPI/views/h2_desktop_actuals.view.lkml
+++ b/KPI/views/h2_desktop_actuals.view.lkml
@@ -4,15 +4,16 @@ view: h2_desktop_actuals {
       WITH base AS (
         SELECT
           submission_date AS date,
+          CASE WHEN EXTRACT(QUARTER FROM submission_date) IN (1,2) THEN 1 ELSE 2 END AS half,
           SUM(dau) AS dau
           FROM `mozdata.telemetry.firefox_desktop_usage_2021`
           -- WHERE submission_date >= "2021-07-01"
-          GROUP BY 1 ORDER BY 1
+          GROUP BY 1,2 ORDER BY 1
       )
 
       SELECT
         *,
-        SUM(dau) OVER (ORDER BY date) AS cdou,
+        SUM(dau) OVER (PARTITION BY EXTRACT(YEAR FROM date), half ORDER BY date) AS cdou,
         AVG(dau) OVER window_7day as dau_7day_ma
       FROM base
       WINDOW window_7day AS (order by date rows between 6 preceding and current row);;
@@ -40,6 +41,97 @@ view: h2_desktop_actuals {
     type: number
     label: "CDOU Actual"
     sql: ANY_VALUE(${TABLE}.cdou) ;;
+  }
+
+  measure: delta_from_forecast {
+    label: "Cdou: Relative Delta from Forecast"
+    type: number
+    value_format: "0.000%"
+    sql: (${recent_cdou} / ${h2_desktop_forecast.recent_cdou_forecast} ) - 1 ;;
+    description: "Relative (given as a fraction) difference between actual CDOU and forecasted CDOU."
+  }
+
+  measure: delta_from_target {
+    label: "Cdou: Relative Delta from Target"
+    type: number
+    value_format: "0.000%"
+    sql: (${recent_cdou} / (${h2_desktop_forecast.recent_cdou_target}) ) - 1 ;;
+    description: "Relative (given as a fraction) difference between actual CDOU and targeted CDOU."
+  }
+
+  measure: delta_from_target_count {
+    label: "Cdou: Absolute Delta from Target"
+    type: number
+    value_format: "#,##0"
+    sql: ${cdou} - ${h2_desktop_forecast.cdou_target} ;;
+    description: "Absolute (given as a whole number) difference between actual CDOU and targeted CDOU."
+  }
+
+  measure: delta_from_forecast_count {
+    label: "Cdou: Absolute Delta from Forecast"
+    type: number
+    value_format: "#,##0"
+    sql: ${cdou} - ${h2_desktop_forecast.yhat_cumulative}  ;;
+    description: "Absolute (given as a whole number) difference between actual CDOU and targeted CDOU."
+  }
+
+  measure: recent_cdou {
+    hidden: no
+    type: max
+    value_format: "0.00,,, \"Billion\""
+    sql: ${TABLE}.cdou ;;
+  }
+
+  measure: recent_date {
+    hidden: no
+    type: date
+    sql: MAX(CAST(${TABLE}.date AS TIMESTAMP)) ;;
+  }
+
+  # YoY
+
+  measure: year_over_year_dau {
+    label: "2020 Dau"
+    type: number
+    sql: ${h2_desktop_actuals_2020.dau} ;;
+    description: "Daily Active Users on this day in 2020."
+  }
+
+  measure: year_over_year_dau_7day_ma {
+    label: "2020 Dau MA"
+    type: number
+    sql: ${h2_desktop_actuals_2020.dau_7day_ma} ;;
+    hidden: no
+  }
+
+  measure: year_over_year_cdou {
+    label: "2020 Cdou"
+    type: number
+    sql: ${h2_desktop_actuals_2020.cdou} ;;
+    description: "Cumulative Days of Use on this day in 2020."
+  }
+
+  measure: year_over_year_cdou_delta_count {
+    label: "Cdou: Absolute Delta from 2020"
+    type: number
+    value_format: "#,##0"
+    sql: ${cdou} - ${year_over_year_cdou} ;;
+    description: "Absolute (given as a whole number) difference between 2020's CDOU and 2021's CDOU."
+  }
+
+  measure: year_over_year_cdou_delta_percent {
+    label: "Cdou: Relative Delta from 2020"
+    type: number
+    value_format: "0.000%"
+    sql: ${recent_cdou} / ${recent_cdou_2020} - 1;;
+    description: "Relative difference between 2020's CDOU and 2021's CDOU."
+  }
+
+  measure: recent_cdou_2020 {
+    hidden: no
+    type: number
+    value_format: "0.00,,, \"Billion\""
+    sql: ${h2_desktop_actuals_2020.recent_cdou} ;;
   }
 
 }

--- a/KPI/views/h2_desktop_actuals.view.lkml
+++ b/KPI/views/h2_desktop_actuals.view.lkml
@@ -1,0 +1,45 @@
+view: h2_desktop_actuals {
+  derived_table: {
+    sql:
+      WITH base AS (
+        SELECT
+          submission_date AS date,
+          SUM(dau) AS dau
+          FROM `mozdata.telemetry.firefox_desktop_usage_2021`
+          -- WHERE submission_date >= "2021-07-01"
+          GROUP BY 1 ORDER BY 1
+      )
+
+      SELECT
+        *,
+        SUM(dau) OVER (ORDER BY date) AS cdou,
+        AVG(dau) OVER window_7day as dau_7day_ma
+      FROM base
+      WINDOW window_7day AS (order by date rows between 6 preceding and current row);;
+  }
+
+  dimension: date {
+    type: date
+    convert_tz: no
+    sql: CAST(${TABLE}.date AS TIMESTAMP) ;;
+  }
+
+  measure: dau {
+    type: number
+    label: "DAU Actual"
+    sql: ANY_VALUE(${TABLE}.dau) ;;
+  }
+
+  measure: dau_7day_ma {
+    type: number
+    label: "DAU Actual 7 Day MA"
+    sql: ANY_VALUE(${TABLE}.dau_7day_ma) ;;
+  }
+
+  measure: cdou {
+    type: number
+    label: "CDOU Actual"
+    sql: ANY_VALUE(${TABLE}.cdou) ;;
+  }
+
+}

--- a/KPI/views/h2_desktop_forecast.view.lkml
+++ b/KPI/views/h2_desktop_forecast.view.lkml
@@ -8,7 +8,10 @@ view: h2_desktop_forecast {
         AVG(yhat) OVER window_7day AS dau_forecast_7day_ma,
         AVG(yhat * 1.05) OVER window_7day AS dau_target_7day_ma,
         AVG(yhat_lower) OVER window_7day AS dau_forecast_lower_7day_ma,
-        AVG(yhat_upper) OVER window_7day AS dau_forecast_upper_7day_ma
+        AVG(yhat_upper) OVER window_7day AS dau_forecast_upper_7day_ma,
+        AVG(jan_dau_forecast) OVER window_7day AS jan_forecast_7day_ma,
+        AVG(jan_dau_forecast_upper) OVER window_7day AS jan_forecast_upper_7day_ma,
+        AVG(jan_dau_forecast_lower) OVER window_7day AS jan_forecast_lower_7day_ma
       FROM `mozdata.analysis.loines_desktop_dau_forecast_2021-06-30`
       WINDOW window_7day AS (order by date rows between 6 preceding and current row)
       ;;
@@ -38,16 +41,16 @@ view: h2_desktop_forecast {
     hidden: no
   }
 
+  measure: yhat_cumulative {
+    type: number
+    label: "CDOU Forecast"
+    sql: ANY_VALUE(${TABLE}.yhat_cumulative) ;;
+  }
+
   measure: cdou_target {
     type: number
     label: "CDOU Target"
     sql: ANY_VALUE(${TABLE}.cdou_target) ;;
-  }
-
-  measure: yhat_cumulative {
-    type: number
-    label: "CDOU Forecast (H2)"
-    sql: ANY_VALUE(${TABLE}.yhat_cumulative) ;;
   }
 
   measure: dau_forecast_7day_ma {
@@ -68,6 +71,27 @@ view: h2_desktop_forecast {
     type: number
     value_format: "#,##0"
     sql: ANY_VALUE(${TABLE}.dau_forecast_upper_7day_ma) ;;
+    hidden: no
+  }
+
+  measure: jan_forecast_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.jan_forecast_7day_ma) ;;
+    hidden: no
+  }
+
+  measure: jan_forecast_lower_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.jan_forecast_lower_7day_ma) ;;
+    hidden: no
+  }
+
+  measure: jan_forecast_upper_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.jan_forecast_upper_7day_ma) ;;
     hidden: no
   }
 
@@ -97,6 +121,26 @@ view: h2_desktop_forecast {
     type: number
     label: "CDOU Forecast Upper Bound"
     sql: ANY_VALUE(${TABLE}.yhat_upper_cumulative) ;;
+  }
+
+  measure: recent_cdou_forecast {
+    type: max
+    value_format: "0.00,,, \"Billion\""
+    sql: ${TABLE}.yhat_cumulative ;;
+    filters: [
+      date: "after 2021-01-01"
+    ]
+    hidden: no
+  }
+
+  measure: recent_cdou_target {
+    type: max
+    value_format: "0.00,,, \"Billion\""
+    sql: ${TABLE}.cdou_target ;;
+    filters: [
+      date: "after 2021-01-01"
+    ]
+    hidden: no
   }
 
 }

--- a/KPI/views/h2_desktop_forecast.view.lkml
+++ b/KPI/views/h2_desktop_forecast.view.lkml
@@ -1,0 +1,102 @@
+view: h2_desktop_forecast {
+  derived_table: {
+    sql:
+      SELECT
+        *,
+        yhat * 1.05 AS dau_target,
+        yhat_cumulative * 1.05 AS cdou_target,
+        AVG(yhat) OVER window_7day AS dau_forecast_7day_ma,
+        AVG(yhat * 1.05) OVER window_7day AS dau_target_7day_ma,
+        AVG(yhat_lower) OVER window_7day AS dau_forecast_lower_7day_ma,
+        AVG(yhat_upper) OVER window_7day AS dau_forecast_upper_7day_ma
+      FROM `mozdata.analysis.loines_desktop_dau_forecast_2021-06-30`
+      WINDOW window_7day AS (order by date rows between 6 preceding and current row)
+      ;;
+  }
+
+  dimension: date {
+    type: date
+    convert_tz: no
+    sql: CAST(${TABLE}.date AS TIMESTAMP) ;;
+  }
+
+  measure: yhat {
+    type: number
+    label: "DAU Forecast"
+    sql: ANY_VALUE(${TABLE}.yhat) ;;
+  }
+
+  measure: dau_target {
+    type: number
+    label: "DAU Target"
+    sql: ANY_VALUE(${TABLE}.dau_target) ;;
+  }
+
+  measure: dau_target_7day_ma {
+    type: number
+    sql: ANY_VALUE(${TABLE}.dau_target_7day_ma) ;;
+    hidden: no
+  }
+
+  measure: cdou_target {
+    type: number
+    label: "CDOU Target"
+    sql: ANY_VALUE(${TABLE}.cdou_target) ;;
+  }
+
+  measure: yhat_cumulative {
+    type: number
+    label: "CDOU Forecast (H2)"
+    sql: ANY_VALUE(${TABLE}.yhat_cumulative) ;;
+  }
+
+  measure: dau_forecast_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.dau_forecast_7day_ma) ;;
+    hidden: no
+  }
+
+  measure: dau_forecast_lower_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.dau_forecast_lower_7day_ma) ;;
+    hidden: no
+  }
+
+  measure: dau_forecast_upper_7day_ma {
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.dau_forecast_upper_7day_ma) ;;
+    hidden: no
+  }
+
+  measure: yhat_lower {
+    label: "DAU Forecast Lower Bound"
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.yhat_lower) ;;
+    description: "Lower bound (10th percentile) of forecasted value for Cumulative Days of Use. Only relevant for 2021."
+  }
+
+  measure: yhat_upper {
+    label: "DAU Forecast Upper Bound"
+    type: number
+    value_format: "#,##0"
+    sql: ANY_VALUE(${TABLE}.yhat_upper) ;;
+    description: "Upper bound (90th percentile) of forecasted value for Cumulative Days of Use. Only relevant for 2021."
+  }
+
+  measure: yhat_lower_cumulative {
+    type: number
+    label: "CDOU Forecast Lower Bound"
+    sql: ANY_VALUE(${TABLE}.yhat_lower_cumulative) ;;
+  }
+
+  measure: yhat_upper_cumulative {
+    type: number
+    label: "CDOU Forecast Upper Bound"
+    sql: ANY_VALUE(${TABLE}.yhat_upper_cumulative) ;;
+  }
+
+}


### PR DESCRIPTION
I built a dashboard based on these views, which can be viewed [here](https://mozilla.cloud.looker.com/dashboards-next/146) after switching to the `h2-kps` branch on spoke default. 

For now, this is just intended to facilitate a the above dashboard that product can use to pitch an update forecast / stretch goal for CDOU. This may not be the final H2 forecast, but we can swap in another one (by changing the underlying table) without touching anything in the code here. 

Briefly: 

`h2_desktop_forecast.view` contains an updated desktop forecast for H2
`h2_desktop_actuals.view` is a simplification of what's already in `firefox_desktop_usage_2021` but without the support for per-segment forecasts. This may not have been strictly necessary, but (1) it makes things load much faster and (2) illustrates how much simpler things could be if we decided to pitch per-segment forecasts for our KPI data model.

We may decide to pull this out or hide it or change it if we decide to refactor the KPIs - I've tried to make it clear by adding (Preliminary) in the explore view. 