### PR TITLE
Sync mozilla vpn dashboard to user defined dash

### DIFF
--- a/lookml_dashboards.yaml
+++ b/lookml_dashboards.yaml
@@ -13,3 +13,4 @@
 ---
 101: "kpi::firefox_corporate_kpis"
 66: "duet::desktop_numbers_that_matter"
+155: "mozilla_vpn::mozilla_vpn"


### PR DESCRIPTION
target dashboard https://mozilla.cloud.looker.com/dashboards-next/155 also needs to be moved from https://mozilla.cloud.looker.com/folders/46 to https://mozilla.cloud.looker.com/folders/352