### PR TITLE
add revised forecast for mobile h2

### DIFF
--- a/KPI/kpi.model.lkml
+++ b/KPI/kpi.model.lkml
@@ -79,3 +79,25 @@ explore: h2_desktop_actuals {
   # sql_always_where: ${date} >= "2021-07-01" ;;
   }
 }
+
+explore: h2_mobile_actuals {
+  label: "H2 Mobile (Preliminary)"
+  group_label: "KPIs"
+  hidden: no
+  from: h2_mobile_actuals
+  join: h2_mobile_forecast {
+    view_label: "H2 Forecast"
+    type: left_outer
+    sql_on: ${h2_mobile_actuals.date} = ${h2_mobile_forecast.date} AND ${h2_mobile_actuals.app_name} = ${h2_mobile_forecast.app_name};;
+    relationship: one_to_one
+  }
+  join: h2_mobile_actuals_2020 {
+    from: h2_mobile_actuals
+    fields: []
+    view_label: "H2 mobile 2020"
+    type: left_outer
+    sql_on: DATE_SUB(${h2_mobile_actuals.date}, INTERVAL 1 YEAR) = ${h2_mobile_actuals_2020.date} AND ${h2_mobile_actuals.app_name} = ${h2_mobile_actuals_2020.app_name};;
+    relationship: one_to_one
+    # sql_always_where: ${date} >= "2021-07-01" ;;
+  }
+}

--- a/KPI/views/h2_mobile_actuals.view.lkml
+++ b/KPI/views/h2_mobile_actuals.view.lkml
@@ -1,0 +1,147 @@
+view: h2_mobile_actuals {
+  derived_table: {
+    sql:
+      with
+        base as (
+          select
+              submission_date as date,
+              app_name,
+              canonical_app_name,
+              CASE WHEN EXTRACT(QUARTER FROM submission_date) IN (1,2) THEN 1 ELSE 2 END AS half,
+              sum(dau) as dau
+          from
+              ${mobile_usage_fields.SQL_TABLE_NAME} AS mobile_usage_fields
+          group by 1,2,3,4
+          )
+
+      SELECT
+        *,
+        SUM(dau) OVER (PARTITION BY EXTRACT(YEAR FROM date), half, app_name ORDER BY date) AS cdou,
+        AVG(dau) OVER window_7day as dau_7day_ma
+      FROM base
+      WINDOW window_7day AS (PARTITION BY app_name order by date rows between 6 preceding and current row)
+      ;;
+  }
+
+  dimension: date {
+    type: date
+    convert_tz: no
+    sql: CAST(${TABLE}.date AS TIMESTAMP) ;;
+  }
+
+  dimension: app_name {
+    type: string
+    sql: ${TABLE}.app_name ;;
+  }
+
+  measure: dau {
+    type: sum
+    label: "DAU Actual"
+    sql: ${TABLE}.dau ;;
+  }
+
+  measure: dau_7day_ma {
+    type: sum
+    label: "DAU Actual 7 Day MA"
+    sql: ${TABLE}.dau_7day_ma ;;
+  }
+
+  measure: cdou {
+    type: sum
+    label: "CDOU Actual"
+    sql: ${TABLE}.cdou ;;
+  }
+
+  measure: delta_from_forecast {
+    label: "Cdou: Relative Delta from Forecast"
+    type: number
+    value_format: "0.000%"
+    sql: (${recent_cdou} / ${h2_mobile_forecast.recent_cdou_forecast} ) - 1 ;;
+    description: "Relative (given as a fraction) difference between actual CDOU and forecasted CDOU."
+  }
+
+  measure: delta_from_target {
+    label: "Cdou: Relative Delta from Target"
+    type: number
+    value_format: "0.000%"
+    sql: (${recent_cdou} / (${h2_mobile_forecast.recent_cdou_target}) ) - 1 ;;
+    description: "Relative (given as a fraction) difference between actual CDOU and targeted CDOU."
+  }
+
+  measure: delta_from_target_count {
+    label: "Cdou: Absolute Delta from Target"
+    type: number
+    value_format: "#,##0"
+    sql: ${cdou} - ${h2_mobile_forecast.cdou_target} ;;
+    description: "Absolute (given as a whole number) difference between actual CDOU and targeted CDOU."
+  }
+
+  measure: delta_from_forecast_count {
+    label: "Cdou: Absolute Delta from Forecast"
+    type: number
+    value_format: "#,##0"
+    sql: ${cdou} - ${h2_mobile_forecast.yhat_cumulative}  ;;
+    description: "Absolute (given as a whole number) difference between actual CDOU and targeted CDOU."
+  }
+
+  measure: recent_cdou {
+    hidden: no
+    type: max
+    value_format: "0.00,,, \"Billion\""
+    sql: ${TABLE}.cdou ;;
+  }
+
+  measure: recent_date {
+    hidden: no
+    type: date
+    sql: MAX(CAST(${TABLE}.date AS TIMESTAMP)) ;;
+  }
+
+  # YoY
+
+  measure: year_over_year_dau {
+    label: "2020 Dau"
+    type: number
+    sql: ${h2_mobile_actuals_2020.dau} ;;
+    description: "Daily Active Users on this day in 2020."
+  }
+
+  measure: year_over_year_dau_7day_ma {
+    label: "2020 Dau MA"
+    type: number
+    sql: ${h2_mobile_actuals_2020.dau_7day_ma} ;;
+    hidden: no
+  }
+
+  measure: year_over_year_cdou {
+    label: "2020 Cdou"
+    type: number
+    sql: ${h2_mobile_actuals_2020.cdou} ;;
+    description: "Cumulative Days of Use on this day in 2020."
+  }
+
+  measure: year_over_year_cdou_delta_count {
+    label: "Cdou: Absolute Delta from 2020"
+    type: number
+    value_format: "#,##0"
+    sql: ${cdou} - ${year_over_year_cdou} ;;
+    description: "Absolute (given as a whole number) difference between 2020's CDOU and 2021's CDOU."
+  }
+
+  measure: year_over_year_cdou_delta_percent {
+    label: "Cdou: Relative Delta from 2020"
+    type: number
+    value_format: "0.000%"
+    sql: ${recent_cdou} / ${recent_cdou_2020} - 1;;
+    description: "Relative difference between 2020's CDOU and 2021's CDOU."
+  }
+
+  measure: recent_cdou_2020 {
+    hidden: no
+    type: number
+    value_format: "0.00,,, \"Billion\""
+    sql: ${h2_mobile_actuals_2020.recent_cdou} ;;
+  }
+
+
+}

--- a/KPI/views/h2_mobile_forecast.view.lkml
+++ b/KPI/views/h2_mobile_forecast.view.lkml
@@ -1,0 +1,151 @@
+view: h2_mobile_forecast {
+  derived_table: {
+    sql:
+      SELECT
+        *,
+        yhat * 1.0429 AS dau_target,
+        yhat_cumulative * 1.0429 AS cdou_target,
+        AVG(yhat) OVER window_7day AS dau_forecast_7day_ma,
+        AVG(yhat * 1.0429) OVER window_7day AS dau_target_7day_ma,
+        AVG(yhat_lower) OVER window_7day AS dau_forecast_lower_7day_ma,
+        AVG(yhat_upper) OVER window_7day AS dau_forecast_upper_7day_ma,
+        AVG(jan_dau_forecast) OVER window_7day AS jan_forecast_7day_ma,
+        AVG(jan_dau_forecast_upper) OVER window_7day AS jan_forecast_upper_7day_ma,
+        AVG(jan_dau_forecast_lower) OVER window_7day AS jan_forecast_lower_7day_ma
+      FROM `mozdata.analysis.loines_mobile_forecast_2021-06-30`
+      WINDOW window_7day AS (partition by app_name order by date rows between 6 preceding and current row)
+      ;;
+  }
+
+  dimension: date {
+    type: date
+    convert_tz: no
+    sql: CAST(${TABLE}.date AS TIMESTAMP) ;;
+  }
+
+  dimension: app_name {
+    type: string
+    sql: ${TABLE}.app_name ;;
+  }
+
+  measure: yhat {
+    type: sum
+    label: "DAU Forecast"
+    sql: ${TABLE}.yhat ;;
+  }
+
+  measure: dau_target {
+    type: sum
+    label: "DAU Target"
+    sql: ${TABLE}.dau_target ;;
+  }
+
+  measure: dau_target_7day_ma {
+    type: sum
+    sql: ${TABLE}.dau_target_7day_ma ;;
+    hidden: no
+  }
+
+  measure: yhat_cumulative {
+    type: sum
+    label: "CDOU Forecast"
+    sql: ${TABLE}.yhat_cumulative ;;
+  }
+
+  measure: cdou_target {
+    type: sum
+    label: "CDOU Target"
+    sql: ${TABLE}.cdou_target ;;
+  }
+
+  measure: dau_forecast_7day_ma {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.dau_forecast_7day_ma ;;
+    hidden: no
+  }
+
+  measure: recent_cdou_forecast {
+    type: max
+    value_format: "0.00,,, \"Billion\""
+    sql: ${TABLE}.yhat_cumulative ;;
+    filters: [
+      date: "after 2021-01-01"
+    ]
+    hidden: no
+  }
+
+  measure: dau_forecast_lower_7day_ma {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.dau_forecast_lower_7day_ma ;;
+    hidden: no
+  }
+
+  measure: dau_forecast_upper_7day_ma {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.dau_forecast_upper_7day_ma ;;
+    hidden: no
+  }
+
+  measure: jan_forecast_7day_ma {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.jan_forecast_7day_ma ;;
+    hidden: no
+  }
+
+  measure: jan_forecast_lower_7day_ma {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.jan_forecast_lower_7day_ma ;;
+    hidden: no
+  }
+
+  measure: jan_forecast_upper_7day_ma {
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.jan_forecast_upper_7day_ma ;;
+    hidden: no
+  }
+
+  measure: yhat_lower {
+    label: "DAU Forecast Lower Bound"
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.yhat_lower ;;
+    description: "Lower bound (10th percentile) of forecasted value for Cumulative Days of Use. Only relevant for 2021."
+  }
+
+  measure: yhat_upper {
+    label: "DAU Forecast Upper Bound"
+    type: sum
+    value_format: "#,##0"
+    sql: ${TABLE}.yhat_upper ;;
+    description: "Upper bound (90th percentile) of forecasted value for Cumulative Days of Use. Only relevant for 2021."
+  }
+
+  measure: yhat_lower_cumulative {
+    type: sum
+    label: "CDOU Forecast Lower Bound"
+    sql: ${TABLE}.yhat_lower_cumulative ;;
+  }
+
+  measure: yhat_upper_cumulative {
+    type: sum
+    label: "CDOU Forecast Upper Bound"
+    sql: ${TABLE}.yhat_upper_cumulative ;;
+  }
+
+  measure: recent_cdou_target {
+    type: max
+    value_format: "0.00,,, \"Billion\""
+    sql: ${TABLE}.cdou_target ;;
+    filters: [
+      date: "after 2021-01-01"
+    ]
+    hidden: no
+  }
+
+}

--- a/KPI/views/h2_mobile_forecast.view.lkml
+++ b/KPI/views/h2_mobile_forecast.view.lkml
@@ -1,12 +1,14 @@
+
+
 view: h2_mobile_forecast {
   derived_table: {
     sql:
       SELECT
         *,
-        yhat * 1.0429 AS dau_target,
-        yhat_cumulative * 1.0429 AS cdou_target,
+        yhat * 1.05 AS dau_target,
+        yhat_cumulative * 1.05 AS cdou_target,
         AVG(yhat) OVER window_7day AS dau_forecast_7day_ma,
-        AVG(yhat * 1.0429) OVER window_7day AS dau_target_7day_ma,
+        AVG(yhat * 1.05) OVER window_7day AS dau_target_7day_ma,
         AVG(yhat_lower) OVER window_7day AS dau_forecast_lower_7day_ma,
         AVG(yhat_upper) OVER window_7day AS dau_forecast_upper_7day_ma,
         AVG(jan_dau_forecast) OVER window_7day AS jan_forecast_7day_ma,


### PR DESCRIPTION
Similar to last week's PR for desktop, this adds a preliminary new forecast for mobile in H2. 

For now, this only powers [this dashboard](https://mozilla.cloud.looker.com/dashboards-next/156), which is not yet official - product will confirm that we are OK with these forecasts / stretch goals.

Once we get the signal that these forecasts will / will not be adopted, I will work on integrating them into the existing KPI looker framework, and potentially re-factor it so those views are simpler (closer to what's in this PR, potentially with the on-the-fly forecasting capacity pulled out). 