### PR TITLE
Update FxA Views and Explores

### DIFF
--- a/firefox_accounts/firefox_accounts.model.lkml
+++ b/firefox_accounts/firefox_accounts.model.lkml
@@ -1,7 +1,23 @@
 connection: "telemetry"
 label: "Firefox Accounts"
+include: "//looker-hub/firefox_accounts/views/fxa_first_seen_table.view.lkml"
 include: "//looker-hub/firefox_accounts/explores/*"
-include: "//looker-hub/firefox_accounts/dashboards/*"
 include: "views/*"
-include: "explores/*"
-include: "dashboards/*"
+
+explore: +growth_accounting {
+  description: "Weekly growth numbers for Firefox Accounts."
+  join: fxa_first_seen_table {
+    fields: []
+    relationship: many_to_one
+    sql_on: ${growth_accounting.user_id} = ${fxa_first_seen_table.user_id} ;;
+  }
+  always_filter: {
+    filters: [growth_accounting.submission_date: "14 days"]
+  }
+}
+
+explore: +event_counts {
+  always_filter: {
+    filters: [events.submission_date: "14 days"]
+  }
+}

--- a/firefox_accounts/views/events.view.lkml
+++ b/firefox_accounts/views/events.view.lkml
@@ -1,0 +1,25 @@
+include: "//looker-hub/firefox_accounts/views/events.view.lkml"
+
+view: +events {
+  dimension_group: submission {
+    type: time
+    sql: ${TABLE}.timestamp ;;
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+  }
+
+  dimension_group: timestamp {
+    hidden: yes
+  }
+
+  measure: user_count {
+    type: count_distinct
+    sql: ${user_id} ;;
+  }
+}

--- a/firefox_accounts/views/growth_accounting.view.lkml
+++ b/firefox_accounts/views/growth_accounting.view.lkml
@@ -1,0 +1,27 @@
+include: "//looker-hub/firefox_accounts/views/growth_accounting.view.lkml"
+
+view: +growth_accounting {
+  dimension_group: first_run {
+    type: time
+    sql: ${fxa_first_seen_table.first_seen_raw} ;;
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      year,
+    ]
+  }
+
+  dimension: new_this_week {
+    sql: DATE_DIFF(${submission_date}, ${first_run_date}, DAY) BETWEEN 0 AND 6 ;;
+    type: yesno
+    hidden: yes
+  }
+
+  dimension: new_last_week {
+    sql: DATE_DIFF(${submission_date}, ${first_run_date}, DAY) BETWEEN 7 AND 13 ;;
+    type: yesno
+    hidden: yes
+  }
+}


### PR DESCRIPTION
- Include first_seen_date for Growth Accounting
- Add submission field for events analysis (instead of timestamp field)

I think it makes sense to keep these explore extensions in the model file, but open to moving them to their own explores if we think it's a better path.