### PR TITLE
Remove lookml_link_id from user-defined dashboards that are not defin…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           pkg-manager: pip
       - run:
           command: |
-            python ./src/sync_dashboards/main.py lookml_dashboards.yaml
+            python ./src/sync_dashboards/main.py --config lookml_dashboards.yaml sync
 workflows:
   version: 2
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           pkg-manager: pip
       - run:
           command: |
-            python ./src/sync_dashboards/main.py --config lookml_dashboards.yaml sync
+            python ./src/sync_dashboards/main.py sync --config lookml_dashboards.yaml
 workflows:
   version: 2
   build:

--- a/src/sync_dashboards/README.md
+++ b/src/sync_dashboards/README.md
@@ -1,3 +1,19 @@
 # Sync Dashboards
 
 A simple script that links and sync user-defined dashboards with LookML dashboards.
+
+## Usage
+
+### `sync`
+
+`main.py --config ../../lookml_dashboards.yaml sync`
+
+* Updates user-defined dashboards `lookml_link_id` references to the  config definition.
+* Unlinks any user-defined dashboards that are not defined in the config, if the linked LookML dashboard is present in the config.
+* Executes sync to sync content from LookML dashboards to linked user-defined dashboards.
+
+### `current_mappings`
+
+`main.py current_mappings`
+
+* Returns all user-defined dashboards on the looker instance that have a `lookml_link_id` set.

--- a/src/sync_dashboards/README.md
+++ b/src/sync_dashboards/README.md
@@ -6,14 +6,14 @@ A simple script that links and sync user-defined dashboards with LookML dashboar
 
 ### `sync`
 
-`main.py --config ../../lookml_dashboards.yaml sync`
+`main.py sync --config ../../lookml_dashboards.yaml`
 
 * Updates user-defined dashboards `lookml_link_id` references to the  config definition.
 * Unlinks any user-defined dashboards that are not defined in the config, if the linked LookML dashboard is present in the config.
 * Executes sync to sync content from LookML dashboards to linked user-defined dashboards.
 
-### `current_mappings`
+### `current-mappings`
 
-`main.py current_mappings`
+`main.py current-mappings`
 
 * Returns all user-defined dashboards on the looker instance that have a `lookml_link_id` set.

--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -26,29 +26,83 @@ def setup_sdk(client_id, client_secret, instance) -> methods.Looker31SDK:
     return looker_sdk.init31()
 
 
-def sync_dashboards(sdk: methods.Looker31SDK, config: dict) -> None:
-    for dashboard_id, lookml_dashboard_id in config.items():
-        try:
-            dashboard = sdk.dashboard(str(dashboard_id))
-            sdk.dashboard_lookml(lookml_dashboard_id)
-            sdk.update_dashboard(
-                str(dashboard_id),
-                models.WriteDashboard(lookml_link_id=lookml_dashboard_id),
-            )
+def lookml_uud_mapping(config: dict) -> dict:
+    """
+    Transforms local config and remote config for comparison purposes.
 
-            sdk.sync_lookml_dashboard(lookml_dashboard_id, models.WriteDashboard())
-            logging.info(
-                f"Dashboard {dashboard_id} synced with LookML dashboard {lookml_dashboard_id}"
-            )
-        except looker_sdk.error.SDKError as e:
-            logging.error(f"Dashboard {dashboard_id} dashboard sync failed with {e}")
+    {"lookml_link_id": ["dashboard_id1", "dashboard_id2"]}
+
+    """
+    mappings = {}
+
+    for dashboard_id, lookml_dashboard_id in config.items():
+        if mappings.get(lookml_dashboard_id):
+            mappings[lookml_dashboard_id].append(str(dashboard_id))
+        else:
+            mappings[lookml_dashboard_id] = [str(dashboard_id)]
+
+    return mappings
+
+
+def get_all_linked_dashboards(sdk: methods.Looker31SDK) -> dict:
+    """
+    Get all dashboards that contain a lookml_link_id.
+    """
+    config = {}
+
+    dashboards = sdk.search_dashboards(deleted=False)
+
+    for dashboard in dashboards:
+        if dashboard.model is None and dashboard.lookml_link_id:
+            config[dashboard.id] = dashboard.lookml_link_id
+
+    remote_mappings = lookml_uud_mapping(config)
+
+    return remote_mappings
+
+
+def sync_dashboards(
+    sdk: methods.Looker31SDK, mappings: dict, remote_mappings: dict
+) -> None:
+    try:
+        for lookml_dashboard_id, dashboard_ids in mappings.items():
+            # unlink any UUDs that are not included in the local mapping
+            if remote_mappings.get(lookml_dashboard_id):
+                unlink_dashboard_ids = set(remote_mappings[lookml_dashboard_id]) - set(
+                    dashboard_ids
+                )
+                for unlink_dashboard_id in unlink_dashboard_ids:
+                    sdk.update_dashboard(
+                        unlink_dashboard_id, models.WriteDashboard(lookml_link_id="")
+                    )
+                    logging.warning(
+                        f"Dashboard {unlink_dashboard_id} unlinked from LookML dashboard {lookml_dashboard_id}"
+                    )
+
+            # link and sync UUDs based on local mappings
+            for dashboard_id in dashboard_ids:
+                dashboard = sdk.dashboard(dashboard_id)
+                sdk.dashboard_lookml(lookml_dashboard_id)
+                sdk.update_dashboard(
+                    str(dashboard_id),
+                    models.WriteDashboard(lookml_link_id=lookml_dashboard_id),
+                )
+
+                sdk.sync_lookml_dashboard(lookml_dashboard_id, models.WriteDashboard())
+                logging.info(
+                    f"Dashboard {dashboard_id} synced with LookML dashboard {lookml_dashboard_id}"
+                )
+    except looker_sdk.error.SDKError as e:
+        logging.error(f"Dashboard {dashboard_id} dashboard sync failed with {e}")
 
 
 def load_config(filename: str) -> dict:
-    with open(filename) as f:
-        config = yaml.load(f, Loader=yaml.SafeLoader)
 
-    return config
+    with open(filename) as f:
+        load = yaml.load(f, Loader=yaml.SafeLoader)
+        mappings = lookml_uud_mapping(load)
+
+    return mappings
 
 
 @click.command()
@@ -58,8 +112,9 @@ def load_config(filename: str) -> dict:
 @click.argument("config", type=click.Path(exists=True))
 def main(client_id: str, client_secret: str, instance_uri: str, config: str):
     sdk = setup_sdk(client_id, client_secret, instance_uri)
-    config = load_config(config)
-    sync_dashboards(sdk, config)
+    mappings = load_config(config)
+    remote_mappings = get_all_linked_dashboards(sdk)
+    sync_dashboards(sdk, mappings, remote_mappings)
 
 
 if __name__ == "__main__":

--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -109,12 +109,23 @@ def load_config(filename: str) -> dict:
 @click.option("--client_id", envvar="LOOKER_API_CLIENT_ID", required=True)
 @click.option("--client_secret", envvar="LOOKER_API_CLIENT_SECRET", required=True)
 @click.option("--instance_uri", envvar="LOOKER_INSTANCE_URI", required=True)
-@click.argument("config", type=click.Path(exists=True))
-def main(client_id: str, client_secret: str, instance_uri: str, config: str):
+@click.option("--config", type=click.Path(exists=True))
+@click.argument("operation", default="currernt_mappings")
+def main(
+    client_id: str, client_secret: str, instance_uri: str, config: str, operation: str
+):
     sdk = setup_sdk(client_id, client_secret, instance_uri)
-    mappings = load_config(config)
-    remote_mappings = get_all_linked_dashboards(sdk)
-    sync_dashboards(sdk, mappings, remote_mappings)
+    if operation == "sync":
+        mappings = load_config(config)
+        remote_mappings = get_all_linked_dashboards(sdk)
+        sync_dashboards(sdk, mappings, remote_mappings)
+    elif operation == "currernt_mappings":
+        remote_mappings = get_all_linked_dashboards(sdk)
+        for lookml_dashboard_id, dashboard_ids in remote_mappings.items():
+            for dashboard_id in dashboard_ids:
+                print(f"{dashboard_id}: {lookml_dashboard_id}")
+    else:
+        raise NotImplementedError()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…ed in the config. DSRE-86

Running `current_mappings` on prod looker instance returns:

```
 python main.py currernt_mappings
2021-08-02 10:06:25 INFO     POST(https://mozilla.cloud.looker.com/api/3.1/login)
2021-08-02 10:06:26 INFO     GET(https://mozilla.cloud.looker.com/api/3.1/dashboards/search)

152: duet::android_numbers_that_matter
137: duet::android_numbers_that_matter
76: kpi::desktop_kpi_dashboard
51: kpi::desktop_kpi_dashboard
90: kpi::desktop_kpi_dashboard
52: kpi::desktop_kpi_dashboard
46: kpi::desktop_kpi_dashboard
44: kpi::desktop_kpi_dashboard
43: kpi::desktop_kpi_dashboard
83: kpi::desktop_kpi_dashboard
88: kpi::desktop_kpi_dashboard
93: kpi::desktop_kpi_dashboard
27: kpi::desktop_kpi_dashboard__with_filters
32: kpi::desktop_kpi_dashboard_with_filters__editable
37: kpi::desktop_kpi_dashboard_with_filters_alternate
38: kpi::desktop_kpi_dashboard_with_filters_alternate
41: kpi::desktop_kpi_dashboard_with_filters_alternate
35: kpi::desktop_kpi_dashboard_with_filters
66: duet::desktop_numbers_that_matter
75: duet::desktop_numbers_that_matter
101: kpi::firefox_corporate_kpis
115: kpi::firefox_corporate_kpis
146: kpi::firefox_corporate_kpis
97: kpi::firefox_corporate_kpis
78: fenix::fenix_growth_accounting
3: firefox_ios::firefox_ios_gud
2: firefox_ios::growth
12: firefox_ios::growth
13: firefox_ios::growth
29: firefox_ios::growth
105: duet::firefox_mr1_launch
106: duet::firefox_mr1_launch
117: duet::firefox_mr1_launch
138: duet::ios_numbers_that_matter
162: duet::ios_numbers_that_matter
86: kpi::mobile_kpis
92: kpi::mobile_kpis
49: kpi::mobile_kpis
57: kpi::mobile_kpis
104: kpi::mobile_kpi_dashboard
155: mozilla_vpn::mozilla_vpn

```


Do we need to update https://github.com/mozilla/looker-spoke-default/blob/main/lookml_dashboards.yaml to include any of these?