### PR TITLE
Verify LookML dashboard exists using dashboard method instead

### DIFF
--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -80,7 +80,7 @@ def sync_dashboards(
             # link and sync UUDs based on local mappings
             for dashboard_id in dashboard_ids:
                 dashboard = sdk.dashboard(dashboard_id)
-                sdk.dashboard_lookml(lookml_dashboard_id)
+                sdk.dashboard(lookml_dashboard_id)
                 sdk.update_dashboard(
                     str(dashboard_id),
                     models.WriteDashboard(lookml_link_id=lookml_dashboard_id),

--- a/src/sync_dashboards/requirements.txt
+++ b/src/sync_dashboards/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==5.4.1
 click==7.1.2
-looker-sdk==21.4.1
+looker-sdk==21.10.1
 pip-tools==5.5.0


### PR DESCRIPTION
Fixes errors around `error.SDKError(response.value.decode(encoding=encoding))` when attempting to check for existence of LookML dashboards. 

r?