### PR TITLE
Add distinct ids to headers on Corporate KPI dashboard

### DIFF
--- a/KPI/dashboards/corporate_kpis.dashboard.lookml
+++ b/KPI/dashboards/corporate_kpis.dashboard.lookml
@@ -146,7 +146,7 @@
     title_text: ''
     subtitle_text: ''
     body_text: |-
-      <h1 style="margin-top:0px; padding: 5px; border-bottom: solid 1px #412399; height: 50px; color: #412399; text-align: left;" id="dou">Desktop Days of Use and DAU</h1>
+      <h1 style="margin-top:0px; padding: 5px; border-bottom: solid 1px #412399; height: 50px; color: #412399; text-align: left;" id="desktop_dou">Desktop Days of Use and DAU</h1>
       <div><a style="font-weight: bold;" href="https://mozilla.cloud.looker.com/dashboards-next/kpi::desktop_kr_dashboard?Date=after+2021%2F01%2F01&Channel=&Activity+Segment=&OS=&Attributed+%28Yes+%2F+No%29=&Country+Name=">☰
 
             Go Here for a More Detail on Desktop KPIs</a></div>
@@ -315,7 +315,7 @@
     title_text: ''
     subtitle_text: ''
     body_text: |-
-      <h1 style="margin-top:0px; padding: 5px; border-bottom: solid 1px #412399; height: 50px; color: #412399; text-align: left;" id="dou">Mobile Days of Use and DAU</h1>
+      <h1 style="margin-top:0px; padding: 5px; border-bottom: solid 1px #412399; height: 50px; color: #412399; text-align: left;" id="mobile_dou">Mobile Days of Use and DAU</h1>
       <div><a style="font-weight: bold;" href="https://mozilla.cloud.looker.com/dashboards-next/kpi::mobile_kr_dashboard?Date=after+2021%2F01%2F01&Country=">☰
 
             Go Here for a Breakdown of Mobile Products</a></div>


### PR DESCRIPTION
The idea here is that we could provide a link on https://mana.mozilla.org/wiki/pages/viewpage.action?pageId=130932724 that would jump directly to the mobile part of this dashboard

The link would look like: https://mozilla.cloud.looker.com/dashboards-next/101?Date=after%202021%2F01%2F01#mobile_dou

I was not able to get this change to render for me in Looker, and I'm not sure why.