### PR TITLE
Fix off-by-one error in is_end_of_<period>

### DIFF
--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -192,17 +192,17 @@ view: subscriptions__active {
   
   dimension: is_end_of_month {
     type: yesno
-    sql: ${active_raw} = LAST_DAY(${active_raw}, MONTH) OR ${active_raw} = DATE(${metadata.last_modified_date});;
+    sql: ${active_raw} = LAST_DAY(${active_raw}, MONTH) OR ${active_raw} = DATE(${metadata.last_modified_date}) - 1;;
   }
   
   dimension: is_end_of_quarter {
     type: yesno
-    sql: ${active_raw} = LAST_DAY(${active_raw}, QUARTER) OR ${active_raw} = DATE(${metadata.last_modified_date});;
+    sql: ${active_raw} = LAST_DAY(${active_raw}, QUARTER) OR ${active_raw} = DATE(${metadata.last_modified_date}) - 1;;
   }
   
   dimension: is_end_of_year {
     type: yesno
-    sql: ${active_raw} = LAST_DAY(${active_raw}, YEAR) OR ${active_raw} = DATE(${metadata.last_modified_date});;
+    sql: ${active_raw} = LAST_DAY(${active_raw}, YEAR) OR ${active_raw} = DATE(${metadata.last_modified_date}) - 1;;
   }
 }
 


### PR DESCRIPTION
the maximum active date is the day before the last table update