### PR TITLE
Fix subscription events sum(delta) calculation

### DIFF
--- a/mozilla_vpn/explores/subscriptions.explore.lkml
+++ b/mozilla_vpn/explores/subscriptions.explore.lkml
@@ -8,6 +8,9 @@ explore: subscriptions {
     from: information_schema_partitions
     view_label: "Metadata"
     sql_on: ${metadata.table_name} = "all_subscriptions_v1" AND ${metadata.partition_id} IS NULL;;
+    # Using a one_to_one relationship here, instead of the technically correct many_to_one, makes
+    # Looker understand that this join does not impact aggregation, which only works because this
+    # view does not contain any aggregates.
     relationship: one_to_one
   }
 

--- a/mozilla_vpn/explores/subscriptions.explore.lkml
+++ b/mozilla_vpn/explores/subscriptions.explore.lkml
@@ -8,7 +8,7 @@ explore: subscriptions {
     from: information_schema_partitions
     view_label: "Metadata"
     sql_on: ${metadata.table_name} = "all_subscriptions_v1" AND ${metadata.partition_id} IS NULL;;
-    relationship: many_to_one
+    relationship: one_to_one
   }
 
   join: devices {


### PR DESCRIPTION
subscription events join now references `${metadata.last_modified_date}`, which caused a conflict between the many_to_one and one_to_many joins and broke aggregation. Using a one_to_one join here makes Looker understand that the `metadata` join does not impact aggregation. This only works because the `metadata` join does not contain any aggregates.

cc @wwyc 