### PR TITLE
Add max active date to create pie charts

### DIFF
--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -228,6 +228,18 @@ view: subscriptions__active {
     type: yesno
     sql: ${active_raw} = LAST_DAY(${active_raw}, YEAR) OR ${active_raw} = DATE(${metadata.last_modified_date}) - 1;;
   }
+
+  dimension: max_active_date {
+    description: "Get max active date from end date in active date filter.  If null, use last modified date."
+    hidden: yes
+    type: date
+    sql: COALESCE({% date_end active_date %}, ${metadata.last_modified_date})-1;;
+  }
+
+  dimension: is_max_active_date {
+    type: yesno
+    sql:  ${active_raw}=${max_active_date};;
+  }
 }
 
 view: subscriptions__events {


### PR DESCRIPTION
- Currently the [VPN SaaSboard - Active Subscriptions](https://mozilla.cloud.looker.com/dashboards-next/147?Country=&Provider=&Pricing%20Plan=&Active%20Date=2020%2F07%2F20%20to%20today) dashboard has donut charts.

- Created max active date filter for generating pie charts (to replace donut charts) where all percentage labels are visible
