### PR TITLE
Update sql trigger value for VPN SaaSboard - Active Subscriptions

### DIFF
--- a/mozilla_vpn/explores/subscriptions.explore.lkml
+++ b/mozilla_vpn/explores/subscriptions.explore.lkml
@@ -73,7 +73,14 @@ explore: +subscriptions {
     }
 
     materialization: {
-      sql_trigger_value: SELECT CURRENT_DATE();;
+      sql_trigger_value: SELECT (subscriptions__active) AS subscriptions__active_active_date,COUNT(DISTINCT subscriptions.subscription_id ) AS subscriptions_count
+      FROM `mozdata.mozilla_vpn.all_subscriptions`  AS subscriptions
+      LEFT JOIN UNNEST((GENERATE_DATE_ARRAY((DATE(subscriptions.subscription_start_date )), (DATE(subscriptions.end_date )) - 1))) AS subscriptions__active
+      GROUP BY
+          1
+      ORDER BY
+          1 DESC
+      LIMIT 1;;
     }
   }
 

--- a/mozilla_vpn/explores/subscriptions.explore.lkml
+++ b/mozilla_vpn/explores/subscriptions.explore.lkml
@@ -73,14 +73,12 @@ explore: +subscriptions {
     }
 
     materialization: {
-      sql_trigger_value: SELECT (subscriptions__active) AS subscriptions__active_active_date,COUNT(DISTINCT subscriptions.subscription_id ) AS subscriptions_count
-      FROM `mozdata.mozilla_vpn.all_subscriptions`  AS subscriptions
-      LEFT JOIN UNNEST((GENERATE_DATE_ARRAY((DATE(subscriptions.subscription_start_date )), (DATE(subscriptions.end_date )) - 1))) AS subscriptions__active
-      GROUP BY
-          1
-      ORDER BY
-          1 DESC
-      LIMIT 1;;
+      sql_trigger_value: SELECT
+        MAX(last_modified_time)
+      FROM
+        moz-fx-data-shared-prod.mozilla_vpn_derived.INFORMATION_SCHEMA.PARTITIONS
+      WHERE
+        table_name = "all_subscriptions_v1";;
     }
   }
 


### PR DESCRIPTION
The SELECT CURRENT_DATE() sql trigger is not sufficient for updating the PDT required for active subscriptions views in Looker.  The new sql trigger value included should check for changes in the latest count of active subscriptions.