### PR TITLE
Bug(LOOK-117): Incorrect install count in "Numbers that matter" for 2021-11-01

### DIFF
--- a/duet/explores/desktop_activation.explore.lkml
+++ b/duet/explores/desktop_activation.explore.lkml
@@ -7,8 +7,8 @@ explore: desktop_activation {
     DATE_DIFF(  -- Only use builds from the last month
       ${submission_timestamp_date},
       SAFE.PARSE_DATE('%Y%m%d', SUBSTR(${build_id}, 0, 8)),
-      MONTH
-    ) <= 1 AND
+      WEEK
+    ) <= 6 AND
     ${os} = "Windows" AND
     ${attribution_source} IS NOT NULL AND
     ${distribution_id} IS NULL AND

--- a/duet/explores/desktop_install.explore.lkml
+++ b/duet/explores/desktop_install.explore.lkml
@@ -10,8 +10,8 @@ explore: desktop_install  {
     DATE_DIFF(  -- Only use builds from the last month
         ${submission_date},
         SAFE.PARSE_DATE('%Y%m%d', SUBSTR(${build_id}, 0, 8)),
-        MONTH
-    ) <= 1 AND
+        WEEK
+    ) <= 6 AND
     ${attribution} IN ("chrome", "ie", "edge") AND
     DATE(${submission_date}) <= DATE_SUB(
       IF({% parameter desktop_install.previous_time_period %},

--- a/duet/explores/desktop_new_profile.explore.lkml
+++ b/duet/explores/desktop_new_profile.explore.lkml
@@ -63,8 +63,8 @@ explore: desktop_new_profile {
     DATE_DIFF(  -- Only use builds from the last month
       ${submission_date},
       SAFE.PARSE_DATE('%Y%m%d', SUBSTR(${application__build_id}, 0, 8)),
-      MONTH
-    ) <= 1 AND
+      WEEK
+    ) <= 6 AND
     ${environment__settings__attribution__source} IS NOT NULL AND
     ${normalized_os} = "Windows" AND
     ${environment__partner__distribution_id} IS NULL AND


### PR DESCRIPTION
# Bug(LOOK-117): Incorrect install count in "Numbers that matter" for 2021-11-01

Bug ticket: https://mozilla-hub.atlassian.net/browse/LOOK-117

## Description
"Numbers that matter" dashboard incorrectly shows a near-zero install count for 2021-11-01. This is due to the time gap between builds `93.0` and `94.0` being longer than 1 month.

## Change
Grabbing build from the last 6 weeks instead of 1 month to avoid counting issues if longer time between builds.

This is what the graph looks like after the change:
![image](https://user-images.githubusercontent.com/42538694/142224988-a1e90ed7-7950-4518-8df7-97a67346c3bc.png)


