### PR TITLE
Use samples for Android MR2 event funnels

### DIFF
--- a/fenix/dashboards/Mobile_MR2_Product_Dashboard_[Release_Channel].dashboard.lookml
+++ b/fenix/dashboards/Mobile_MR2_Product_Dashboard_[Release_Channel].dashboard.lookml
@@ -1057,6 +1057,7 @@
       step_2.category: '"customize_home"'
       step_2.event: '"preference_toggled"'
       funnel_analysis.app_channel: release
+      funnel_analysis.sample_id: '1'
     sorts: [funnel_analysis.submission_date desc]
     limit: 500
     x_axis_gridlines: false
@@ -1091,9 +1092,9 @@
     defaults_version: 1
     note_state: expanded
     note_display: above
-    note_text: Percentage of daily users that toggled a preference regarding customizing
+    note_text: Percentage of sampled daily users that toggled a preference regarding customizing
       the home page (jump back in, most visited sites, recently saved, recently visited,
-      pocket). Multiply by 100 for percentages.
+      pocket). Multiply by 10,000 for percentages.
     listen: {}
     row: 37
     col: 0
@@ -1113,7 +1114,7 @@
       step_2.category: preferences
       step_2.event: '"inactive_tabs_enabled"'
       funnel_analysis.app_channel: release
-      funnel_analysis.sample_id: '10'
+      funnel_analysis.sample_id: '1'
     sorts: [funnel_analysis.submission_date desc]
     limit: 500
     x_axis_gridlines: false


### PR DESCRIPTION
This is a follow-up to https://mozilla.slack.com/archives/C01KYMFTWEN/p1637256354049400

It looks like there are some queries on the https://mozilla.cloud.looker.com/dashboards-next/270 dashboard that exceed complexity limits. I opened a [bug for optimizing](https://github.com/mozilla/lookml-generator/issues/304) the generated queries, but as a quick fix it probably makes sense to use samples.

The user-facing dashboards haven't been updated for now.