### PR TITLE
Add aggregate tables to speed up newtab dashboard

### DIFF
--- a/activity_stream/activity_stream.model.lkml
+++ b/activity_stream/activity_stream.model.lkml
@@ -2,3 +2,80 @@ connection: "telemetry"
 label: "Activity Stream"
 include: "//looker-hub/activity_stream/explores/*"
 include: "views/*"
+include: "dashboards/*"
+
+explore: +session_counts {
+  aggregate_table: rollup__sessions_submission_date__0 {
+    query: {
+      dimensions: [sessions.submission_date]
+      measures: [sessions.clients]
+      filters: [sessions.submission_date: "28 days"]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+
+  aggregate_table: rollup__sessions_submission_date__1 {
+    query: {
+      dimensions: [sessions.submission_date]
+      measures: [sessions.session_count]
+      filters: [sessions.submission_date: "28 days"]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+
+  aggregate_table: rollup__sessions_session_count__2 {
+    query: {
+      measures: [sessions.session_count]
+      filters: [sessions.submission_date: "7 days"]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+}
+
+
+explore: +pocket_tile_impressions {
+  aggregate_table: rollup__impression_stats_flat_submission_date__0 {
+    query: {
+      dimensions: [impression_stats_flat.submission_date]
+      measures: [impression_stats_flat.impression_count]
+      filters: [impression_stats_flat.submission_date: "28 days"]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+
+  aggregate_table: rollup__impression_stats_flat_submission_date__1 {
+    query: {
+      dimensions: [impression_stats_flat.submission_date]
+      measures: [impression_stats_flat.click_count]
+      filters: [impression_stats_flat.submission_date: "28 days"]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+
+  aggregate_table: rollup__impression_stats_flat_submission_date__2 {
+    query: {
+      dimensions: [impression_stats_flat.submission_date]
+      measures: [impression_stats_flat.click_count, impression_stats_flat.impression_count, impression_stats_flat.loaded_count, impression_stats_flat.pocketed_count]
+      filters: [impression_stats_flat.submission_date: "28 days"]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+}

--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -17,3 +17,49 @@ explore: +mobile_search_counts {
     SAP, and organic searches are those that occur directly on a search webpage (e.g. www.google.com).
     Warning: Firefox iOS is not able to implement all metrics, like ad clicks."
 }
+
+explore: +desktop_search_counts {
+  aggregate_table: rollup__search_clients_engines_sources_daily_submission_date__0 {
+    query: {
+      dimensions: [search_clients_engines_sources_daily.submission_date]
+      measures: [search_clients_engines_sources_daily.total_searches]
+      filters: [
+        search_clients_engines_sources_daily.source: "newtab",
+        search_clients_engines_sources_daily.submission_date: "28 days"
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+
+  aggregate_table: rollup__search_clients_engines_sources_daily_normalized_engine__search_clients_engines_sources_daily_submission_date__1 {
+    query: {
+      dimensions: [search_clients_engines_sources_daily.normalized_engine, search_clients_engines_sources_daily.submission_date]
+      measures: [search_clients_engines_sources_daily.total_searches]
+      filters: [
+        search_clients_engines_sources_daily.source: "%newtab%",
+        search_clients_engines_sources_daily.submission_date: "28 days"
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+
+  aggregate_table: rollup__search_clients_engines_sources_daily_total_searches__2 {
+    query: {
+      measures: [search_clients_engines_sources_daily.total_searches]
+      filters: [
+        search_clients_engines_sources_daily.source: "%newtab%",
+        search_clients_engines_sources_daily.submission_date: "7 days"
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+}


### PR DESCRIPTION
To address [this issue](https://mozilla-hub.atlassian.net/browse/DO-636) of the new tab dashboard being slow to load, I added the recommended aggregate tables from Looker.

I think the dashboard in the New Tab folder might be a copy of the one in `looker-spoke-private`? But I think these changes should still work then.

Tagging Megan since it's your dashboard and Anna in case this isn't set up in the right place.