### PR TITLE
Remove date filters from aggregate tables so they are picked up. Add additional aggregate table

### DIFF
--- a/activity_stream/activity_stream.model.lkml
+++ b/activity_stream/activity_stream.model.lkml
@@ -9,7 +9,6 @@ explore: +session_counts {
     query: {
       dimensions: [sessions.submission_date]
       measures: [sessions.clients]
-      filters: [sessions.submission_date: "28 days ago for 28 days"]
     }
 
     materialization: {
@@ -21,7 +20,6 @@ explore: +session_counts {
     query: {
       dimensions: [sessions.submission_date]
       measures: [sessions.clients]
-      filters: [sessions.submission_date: "28 days"]
     }
 
     materialization: {
@@ -33,7 +31,6 @@ explore: +session_counts {
     query: {
       dimensions: [sessions.submission_date]
       measures: [sessions.session_count]
-      filters: [sessions.submission_date: "28 days"]
     }
 
     materialization: {
@@ -44,7 +41,6 @@ explore: +session_counts {
   aggregate_table: rollup__sessions_session_count__2 {
     query: {
       measures: [sessions.session_count]
-      filters: [sessions.submission_date: "7 days"]
     }
 
     materialization: {
@@ -58,7 +54,6 @@ explore: +pocket_tile_impressions {
     query: {
       dimensions: [impression_stats_flat.submission_date]
       measures: [impression_stats_flat.impression_count]
-      filters: [impression_stats_flat.submission_date: "28 days ago for 28 days"]
     }
 
     materialization: {
@@ -70,7 +65,6 @@ explore: +pocket_tile_impressions {
     query: {
       dimensions: [impression_stats_flat.submission_date]
       measures: [impression_stats_flat.click_count]
-      filters: [impression_stats_flat.submission_date: "28 days ago for 28 days"]
     }
 
     materialization: {
@@ -82,7 +76,6 @@ explore: +pocket_tile_impressions {
     query: {
       dimensions: [impression_stats_flat.submission_date]
       measures: [impression_stats_flat.click_count, impression_stats_flat.impression_count, impression_stats_flat.loaded_count, impression_stats_flat.pocketed_count]
-      filters: [impression_stats_flat.submission_date: "28 days ago for 28 days"]
     }
 
     materialization: {
@@ -95,7 +88,6 @@ explore: +pocket_tile_impressions {
       dimensions: [impression_stats_flat.submission_date]
       measures: [impression_stats_flat.click_count]
       filters: [
-        impression_stats_flat.submission_date: "28 days ago for 28 days",
         impression_stats_flat.tile_type: "spoc"
       ]
     }
@@ -110,7 +102,6 @@ explore: +pocket_tile_impressions {
       dimensions: [impression_stats_flat.submission_date]
       measures: [impression_stats_flat.impression_count]
       filters: [
-        impression_stats_flat.submission_date: "28 days ago for 28 days",
         impression_stats_flat.tile_type: "spoc"
       ]
     }

--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -19,13 +19,26 @@ explore: +mobile_search_counts {
 }
 
 explore: +desktop_search_counts {
-  aggregate_table: rollup__search_clients_engines_sources_daily_submission_date {
+  aggregate_table: rollup__search_clients_engines_sources_daily_submission_date_0 {
+    query: {
+      dimensions: [search_clients_engines_sources_daily.submission_date]
+      measures: [search_clients_engines_sources_daily.clients, search_clients_engines_sources_daily.total_searches]
+      filters: [
+        search_clients_engines_sources_daily.source: "%newtab%",
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+    }
+  }
+
+  aggregate_table: rollup__search_clients_engines_sources_daily_submission_date_1 {
     query: {
       dimensions: [search_clients_engines_sources_daily.submission_date]
       measures: [search_clients_engines_sources_daily.total_searches]
       filters: [
         search_clients_engines_sources_daily.source: "newtab",
-        search_clients_engines_sources_daily.submission_date: "28 days ago for 28 days"
       ]
     }
 
@@ -40,7 +53,6 @@ explore: +desktop_search_counts {
       measures: [search_clients_engines_sources_daily.total_searches]
       filters: [
         search_clients_engines_sources_daily.source: "%newtab%",
-        search_clients_engines_sources_daily.submission_date: "28 days ago for 28 days"
       ]
     }
 
@@ -54,7 +66,6 @@ explore: +desktop_search_counts {
       measures: [search_clients_engines_sources_daily.total_searches]
       filters: [
         search_clients_engines_sources_daily.source: "%newtab%",
-        search_clients_engines_sources_daily.submission_date: "7 days"
       ]
     }
 


### PR DESCRIPTION
This seems to fix the remaining issues where some graphs were not using their relevant aggregate tables