### PR TITLE
Bug(1742509): Distinct docid (decoded, stable, live) - telemetry + structured

### DIFF
--- a/monitoring/explores/distinct_docids.explore.lkml
+++ b/monitoring/explores/distinct_docids.explore.lkml
@@ -3,7 +3,6 @@ include: "../views/distinct_docids.view.lkml"
 
 explore: distinct_docids {
   sql_always_where: ${distinct_docids.submission_date} >= '2010-01-01' ;;
-  # view_name: distinct_docids
   description:
   "
   The table lists all doctypes where the number

--- a/monitoring/explores/distinct_docids.explore.lkml
+++ b/monitoring/explores/distinct_docids.explore.lkml
@@ -1,0 +1,32 @@
+include: "../views/distinct_docids.view.lkml"
+
+
+explore: distinct_docids {
+  sql_always_where: ${distinct_docids.submission_date} >= '2010-01-01' ;;
+  # view_name: distinct_docids
+  description:
+  "
+  The table lists all doctypes where the number
+  of distinct doc ids doesn't match between decoded, live, and stable.
+  non_matching_count is the number of non-matching doctypes on the given day.
+
+  As of 2021-05-02, we filter out all pings containing
+  \"automation\" in the X-Source-Tags header, so these counts
+  may appear lower in some cases compared to a direct
+  COUNT(DISTINCT document_id) on the relevant table partition.
+  Prior to adding this filtering, document types under
+  org_mozilla_fenix would consistently show mismatches due
+  to test pings present in the decoded and live tables.
+  "
+
+  join: non_matching {
+    relationship: one_to_one
+    sql: LEFT JOIN non_matching USING(submission_date) ;;
+  }
+
+  always_filter: {
+    filters: [
+      submission_date: "28 days",
+    ]
+  }
+}

--- a/monitoring/explores/distinct_docids.explore.lkml
+++ b/monitoring/explores/distinct_docids.explore.lkml
@@ -20,13 +20,14 @@ explore: distinct_docids {
   "
 
   join: non_matching {
-    relationship: one_to_one
+    relationship: one_to_many
     sql: LEFT JOIN non_matching USING(submission_date) ;;
   }
 
   always_filter: {
     filters: [
-      submission_date: "28 days",
+      submission_date: "3 years",
+      non_matching.non_matching_count: "> 0",
     ]
   }
 }

--- a/monitoring/monitoring.model.lkml
+++ b/monitoring/monitoring.model.lkml
@@ -3,7 +3,7 @@ label: "Monitoring (Data Pipeline)"
 include: "//looker-hub/monitoring/explores/*"
 # include: "//looker-hub/monitoring/dashboards/*"
 # include: "views/*"
-# include: "explores/*"
+include: "explores/*"
 # include: "dashboards/*"
 
 # todo: hide explores once dashboard has been implemented

--- a/monitoring/views/distinct_docids.view.lkml
+++ b/monitoring/views/distinct_docids.view.lkml
@@ -25,26 +25,6 @@ view: distinct_docids {
     ;;
   }
 
-  dimension: decoded {
-    sql: ${TABLE}.decoded ;;
-    type: number
-  }
-
-  dimension: doc_type {
-    sql: ${TABLE}.doc_type ;;
-    type: string
-  }
-
-  dimension: live {
-    sql: ${TABLE}.live ;;
-    type: number
-  }
-
-  dimension: stable {
-    sql: ${TABLE}.stable ;;
-    type: number
-  }
-
   dimension_group: submission {
     sql: ${TABLE}.submission_date ;;
     type: time
@@ -59,6 +39,33 @@ view: distinct_docids {
     convert_tz: no
     datatype: date
   }
+
+  dimension: namespace {
+    sql: ${TABLE}.namespace ;;
+    type: string
+  }
+
+  dimension: doc_type {
+    sql: ${TABLE}.doc_type ;;
+    type: string
+  }
+
+  dimension: decoded {
+    sql: ${TABLE}.decoded ;;
+    type: number
+  }
+
+  dimension: live {
+    sql: ${TABLE}.live ;;
+    type: number
+  }
+
+  dimension: stable {
+    sql: ${TABLE}.stable ;;
+    type: number
+  }
+
+
 }
 
 view: non_matching {

--- a/monitoring/views/distinct_docids.view.lkml
+++ b/monitoring/views/distinct_docids.view.lkml
@@ -1,7 +1,3 @@
-# include: "//looker-hub/monitoring/views/structured_distinct_docids.view.lkml"
-# include: "//looker-hub/monitoring/views/telemetry_distinct_docids.view.lkml"
-
-
 view: distinct_docids {
   derived_table: {
     sql:

--- a/monitoring/views/distinct_docids.view.lkml
+++ b/monitoring/views/distinct_docids.view.lkml
@@ -1,0 +1,95 @@
+# include: "//looker-hub/monitoring/views/structured_distinct_docids.view.lkml"
+# include: "//looker-hub/monitoring/views/telemetry_distinct_docids.view.lkml"
+
+
+view: distinct_docids {
+  derived_table: {
+    sql:
+      SELECT
+        submission_date,
+        namespace,
+        doc_type,
+        decoded,
+        live,
+        stable,
+      FROM `moz-fx-data-shared-prod.monitoring.structured_distinct_docids`
+      UNION ALL
+      SELECT
+        submission_date,
+        'telemetry',
+        doc_type,
+        decoded,
+        live,
+        stable,
+      FROM `moz-fx-data-shared-prod.monitoring.telemetry_distinct_docids`
+    ;;
+  }
+
+  dimension: decoded {
+    sql: ${TABLE}.decoded ;;
+    type: number
+  }
+
+  dimension: doc_type {
+    sql: ${TABLE}.doc_type ;;
+    type: string
+  }
+
+  dimension: live {
+    sql: ${TABLE}.live ;;
+    type: number
+  }
+
+  dimension: stable {
+    sql: ${TABLE}.stable ;;
+    type: number
+  }
+
+  dimension_group: submission {
+    sql: ${TABLE}.submission_date ;;
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+}
+
+view: non_matching {
+  derived_table: {
+    sql: SELECT
+    submission_date,
+    COUNTIF(
+      decoded != live OR decoded != stable
+    ) AS non_matching_count,
+    FROM distinct_docids
+    GROUP BY
+    submission_date;;
+  }
+
+  dimension_group: submission {
+    sql: ${TABLE}.submission_date ;;
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+
+  dimension: non_matching_count {
+    sql: ${TABLE}.non_matching_count ;;
+    type: number
+  }
+}


### PR DESCRIPTION
# [Bug(1742509)](https://bugzilla.mozilla.org/show_bug.cgi?id=1742509): Data Platform dashboard migration.

Distinct docid (decoded, stable, live) - telemetry + structured dashboard migration to central data platform healthcheck dashboard.

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/42538694/146818201-df56b7e7-2315-4f58-82f2-4ab2366e2ee3.png">

Seems to be aligning with the original dashboard: https://sql.telemetry.mozilla.org/queries/69317
