### PR TITLE
Added dimensions to support renewal analysis

### DIFF
--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -63,7 +63,7 @@ view: +subscriptions {
   dimension: plan_interval_type {
     description: "Indicates the plan interval type (1 year, 6 month, 1 month, etc)"
     type: string
-    sql: CONCAT(CAST(${TABLE}.plan_interval_count AS STRING),"_",  ${TABLE}.plan_interval);;
+    sql: CONCAT(${plan_interval_count},"_",  ${TABLE}.plan_interval);;
   }
 
   dimension: normalized_source {

--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -37,7 +37,9 @@ view: +subscriptions {
   }
 
   dimension: cancel_at_period_end {
-    hidden: yes
+    description: "Indicates if autorenewal was cancelled and subscription is to be cancelled at period end"
+    type: yesno
+    sql: ${TABLE}.cancel_at_period_end;;
   }
 
   dimension: canceled_for_customer_at {
@@ -51,6 +53,18 @@ view: +subscriptions {
   dimension_group: canceled_at {
     hidden: yes
   }
+
+  dimension: is_ended {
+    description: "Indicates if subscription has ended"
+    type: yesno
+    sql: ${TABLE}.ended_at IS NOT NULL;;
+  }
+
+  dimension: plan_interval_type {
+    description: "Indicates the plan interval type (1 year, 6 month, 1 month, etc)"
+    type: string
+    sql: CONCAT(CAST(${TABLE}.plan_interval_count AS STRING),"_",  ${TABLE}.plan_interval);;
+    }
 
   dimension: normalized_source {
     group_label: "Attribution"

--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -63,7 +63,7 @@ view: +subscriptions {
   dimension: plan_interval_type {
     description: "Indicates the plan interval type (1 year, 6 month, 1 month, etc)"
     type: string
-    sql: CONCAT(${plan_interval_count},"_",  ${TABLE}.plan_interval);;
+    sql: CONCAT(${plan_interval_count},"_",  ${plan_interval});;
   }
 
   dimension: normalized_source {

--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -37,7 +37,7 @@ view: +subscriptions {
   }
 
   dimension: cancel_at_period_end {
-    description: "Indicates if autorenewal was cancelled and subscription is to be cancelled at period end"
+    description: "Indicates if auto-renewal was cancelled and subscription is to be cancelled at period end"
     type: yesno
     sql: ${TABLE}.cancel_at_period_end;;
   }

--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -64,7 +64,7 @@ view: +subscriptions {
     description: "Indicates the plan interval type (1 year, 6 month, 1 month, etc)"
     type: string
     sql: CONCAT(CAST(${TABLE}.plan_interval_count AS STRING),"_",  ${TABLE}.plan_interval);;
-    }
+  }
 
   dimension: normalized_source {
     group_label: "Attribution"


### PR DESCRIPTION
Three dimensions were ended:
- cancel_at_period_end:  Indicates if auto-renewal was cancelled and subscription is to be cancelled at period end
- is_ended:  Indicates if subscription has ended
- plan_interval_type:  Indicates the plan interval type (1 year, 6 month, 1 month, etc)