### PR TITLE
Added plan_interval_type to active subs and sub events views

### DIFF
--- a/mozilla_vpn/views/active_subscriptions_table.view.lkml
+++ b/mozilla_vpn/views/active_subscriptions_table.view.lkml
@@ -35,6 +35,12 @@ view: +active_subscriptions_table {
     sql:  ${active_raw}=${max_active_date};;
   }
 
+  dimension: plan_interval_type {
+    description: "Indicates the plan interval type (1 year, 6 month, 1 month, etc)"
+    type: string
+    sql: CONCAT(${plan_interval_count},"_",  ${plan_interval});;
+  }
+
   dimension: count {
     hidden: yes
   }

--- a/mozilla_vpn/views/subscription_events_table.view.lkml
+++ b/mozilla_vpn/views/subscription_events_table.view.lkml
@@ -8,6 +8,12 @@ view: +subscription_events_table {
     type: string
   }
 
+  dimension: plan_interval_type {
+    description: "Indicates the plan interval type (1 year, 6 month, 1 month, etc)"
+    type: string
+    sql: CONCAT(${plan_interval_count},"_",  ${plan_interval});;
+  }
+
   dimension: count {
     hidden: yes
   }


### PR DESCRIPTION
This will allow a plan interval type filter to be added to VPN SaaSboards.