### PR TITLE
Adjusted ARR value format

### DIFF
--- a/mozilla_vpn/views/active_subscriptions_table.view.lkml
+++ b/mozilla_vpn/views/active_subscriptions_table.view.lkml
@@ -64,6 +64,6 @@ view: +active_subscriptions_table {
           THEN
             12 / ${plan_interval_count}
           END * ${count} * ${plan_amount} * (1 - IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
-    value_format: "$0.00"
+    value_format: "$#,##0.00"
   }
 }


### PR DESCRIPTION
There was a [request](https://mozilla.slack.com/archives/C018SNLQP6C/p1644540493427879) to adjust the ARR value format in vpn saasboard revenue tooltip.