### PR TITLE
Remove quotes in sql_trigger_value (for search and activity_stream PDTs)

### DIFF
--- a/activity_stream/activity_stream.model.lkml
+++ b/activity_stream/activity_stream.model.lkml
@@ -12,7 +12,7 @@ explore: +session_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -23,7 +23,7 @@ explore: +session_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -34,7 +34,7 @@ explore: +session_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -44,7 +44,7 @@ explore: +session_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 }
@@ -57,7 +57,7 @@ explore: +pocket_tile_impressions {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -68,7 +68,7 @@ explore: +pocket_tile_impressions {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -79,7 +79,7 @@ explore: +pocket_tile_impressions {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -93,7 +93,7 @@ explore: +pocket_tile_impressions {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -107,7 +107,7 @@ explore: +pocket_tile_impressions {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 }

--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -85,7 +85,7 @@ explore: +desktop_search_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -99,7 +99,7 @@ explore: +desktop_search_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -113,7 +113,7 @@ explore: +desktop_search_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -126,7 +126,7 @@ explore: +desktop_search_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
     }
   }
 
@@ -155,7 +155,7 @@ explore: +desktop_search_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT CURRENT_DATE()" ;;
+      sql_trigger_value:SELECT CURRENT_DATE() ;;
       increment_key: search_clients_engines_sources_daily.submission_date
       increment_offset: 1
     }
@@ -186,7 +186,7 @@ explore: +desktop_search_counts {
     }
 
     materialization: {
-      sql_trigger_value: "SELECT DATE_TRUNC(CURRENT_DATE(), MONTH)" ;;
+      sql_trigger_value: SELECT DATE_TRUNC(CURRENT_DATE(), MONTH) ;;
       increment_key: search_clients_engines_sources_daily.submission_month
       increment_offset: 1
     }


### PR DESCRIPTION
Values for `sql_trigger_value` don't need quotes. Should fix [RS-250](https://mozilla-hub.atlassian.net/browse/RS-250). 

Addendum: some helpful PDT debugging pages: https://docs.looker.com/data-modeling/learning-lookml/incremental-pdts , https://help.looker.com/hc/en-us/articles/360001027867-Troubleshooting-PDT-Regeneration , https://docs.looker.com/admin-options/database/pdts. I'll add some of this info to DTMO