### PR TITLE
allow revised mobile forecast

### DIFF
--- a/kpi/views/loines_browser_2022_forecasts.view.lkml
+++ b/kpi/views/loines_browser_2022_forecasts.view.lkml
@@ -32,7 +32,7 @@ view: loines_browser_2022_forecasts {
 
   dimension: platform {
     type: string
-    sql: CASE WHEN ${TABLE}.platform = 'desktop' THEN 'Firefox Desktop' ELSE 'Firefox Mobile' END;;
+    sql: CASE WHEN ${TABLE}.platform = 'desktop' THEN 'Firefox Desktop' WHEN ${TABLE}.platform = 'mobile' THEN 'Firefox Mobile' ELSE 'Firefox Mobile (REVISED)' END;;
     label: "Platform (Firefox Desktop or Mobile)"
   }
 


### PR DESCRIPTION
The mobile targets are in the midst of being reviewed. In the meantime for reference I have written some tentative revised targets to the forecasting table. In order for them to be able to be shown in looker, I need to make this one line change. 