### PR TITLE
create derived view for browser KPIs

### DIFF
--- a/kpi/kpi.model.lkml
+++ b/kpi/kpi.model.lkml
@@ -104,17 +104,17 @@ explore: recent_mobile_forecast {
 
 explore: browser_kpis {
   label: "2022 Browser KPIs"
-  group_label: "Core Browser Metrics and KPIs"
-
-  always_filter: {
-    filters: [
-      browser_kpis.active_today: "yes"
-    ]
+  group_label: "Official Browser KPIs"
+  description: "For Official Accounting. To drill down into other dimensions (e.g. Country) please use the 'Browsers Daily Active Users' Explore."
+  join: loines_browser_2022_forecasts {
+    type: left_outer
+    sql_on: ${browser_kpis.submission_date} = ${loines_browser_2022_forecasts.date_date} AND ${browser_kpis.platform} = ${loines_browser_2022_forecasts.platform};;
+    relationship: one_to_one
   }
 }
 
 explore: +unified_metrics {
-  group_label: "Core Browser Metrics and KPIs"
+  group_label: "Core Browser Metrics"
   label: "Unified Browser Metrics"
   sql_always_where: ${submission_date}  >= DATE(2017,1,1);;
   conditionally_filter: {
@@ -123,7 +123,18 @@ explore: +unified_metrics {
   }
 }
 
+explore: browser_dau {
+  label: "Browsers Daily Active Users"
+  group_label: "Core Browser Metrics"
+  description: "Easiest to use for answering most common questions about (Q)CDOU."
+  always_filter: {
+    filters: [
+      browser_dau.active_today: "yes"
+    ]
+  }
+}
+
 explore: loines_browser_2022_forecasts {
-  group_label: "Core Browser Metrics and KPIs"
-  label: "2022 Browser Forecasts"
+  group_label: "Official Browser KPIs"
+  label: "Official Browser KPI Forecasts and Targets"
 }

--- a/kpi/views/browser_dau.view.lkml
+++ b/kpi/views/browser_dau.view.lkml
@@ -1,0 +1,70 @@
+include: "./unified_metrics.view.lkml"
+
+view: browser_dau {
+  extends: [unified_metrics]
+
+  dimension: days_since_first_seen {
+    hidden: yes
+  }
+
+  dimension: first_seen {
+    hidden: yes
+  }
+
+  dimension: uri_count {
+    hidden: yes
+  }
+
+  dimension: active_hours_sum {
+    hidden: yes
+  }
+
+  dimension: ad_click {
+    hidden: yes
+  }
+
+  dimension: search_count {
+    hidden: yes
+  }
+
+  dimension: organic_search_count {
+    hidden: yes
+  }
+
+  dimension: search_with_ads {
+    hidden: yes
+  }
+
+  dimension: durations {
+    hidden: yes
+  }
+
+  measure: total_search_count {
+    hidden: yes
+  }
+
+  measure: total_uri_count {
+    hidden: yes
+  }
+
+  measure: total_ad_click {
+    hidden: yes
+  }
+
+  measure: total_organic_search_count {
+    hidden: yes
+  }
+
+  measure: total_durations {
+    hidden: yes
+  }
+
+  measure: total_active_hours_sum {
+    hidden: yes
+  }
+
+  measure: total_search_with_ads {
+    hidden: yes
+  }
+
+}

--- a/kpi/views/browser_kpis.view.lkml
+++ b/kpi/views/browser_kpis.view.lkml
@@ -33,12 +33,14 @@ view: browser_kpis {
 
   dimension: platform {
     sql: ${TABLE}.platform ;;
-    description: "Firefox Desktop or Mobile"
+    label: "Platform (Firefox Desktop or Mobile)"
+    description: "'Firefox Desktop' or 'Firefox Mobile'"
   }
 
   measure: dau {
     type: sum
     label: "Qualified Days of Use (Daily Active Users)"
+    description: "This counts QCDOU for Desktop and CDOU for Mobile."
     sql: ${TABLE}.dau ;;
   }
 }

--- a/kpi/views/browser_kpis.view.lkml
+++ b/kpi/views/browser_kpis.view.lkml
@@ -1,66 +1,44 @@
-include: "./unified_metrics.view.lkml"
+# derived table for simplified tracking of (Q)CDOU. Users looking to drill down should use the upstream explore, `browser_dau`
 
 view: browser_kpis {
-  extends: [unified_metrics]
-
-  dimension: days_since_first_seen {
-    hidden: yes
+  derived_table: {
+    explore_source: browser_dau {
+      column: submission {
+        field: browser_dau.submission_date
+      }
+      column: platform {
+        field: browser_dau.platform
+      }
+      column: dau {
+        field: browser_dau.total_user_count
+      }
+    filters: [browser_dau.client_qualifies: "yes"]
+    }
   }
 
-  dimension: first_seen {
-    hidden: yes
+  dimension_group: submission {
+    sql: DATE(${TABLE}.submission) ;;
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
   }
 
-  dimension: uri_count {
-    hidden: yes
+  dimension: platform {
+    sql: ${TABLE}.platform ;;
+    description: "Firefox Desktop or Mobile"
   }
 
-  dimension: active_hours_sum {
-    hidden: yes
+  measure: dau {
+    type: sum
+    label: "Qualified Days of Use (Daily Active Users)"
+    sql: ${TABLE}.dau ;;
   }
-
-  dimension: ad_click {
-    hidden: yes
-  }
-
-  dimension: search_count {
-    hidden: yes
-  }
-
-  dimension: organic_search_count {
-    hidden: yes
-  }
-
-  dimension: search_with_ads {
-    hidden: yes
-  }
-
-  dimension: durations {
-    hidden: yes
-  }
-
-  measure: total_search_count {
-    hidden: yes
-  }
-
-  measure: total_ad_click {
-    hidden: yes
-  }
-
-  measure: total_organic_search_count {
-    hidden: yes
-  }
-
-  measure: total_durations {
-    hidden: yes
-  }
-
-  measure: total_active_hours_sum {
-    hidden: yes
-  }
-
-  measure: total_search_with_ads {
-    hidden: yes
-  }
-
 }

--- a/kpi/views/unified_metrics.view.lkml
+++ b/kpi/views/unified_metrics.view.lkml
@@ -22,13 +22,12 @@ view: +unified_metrics {
   }
 
   dimension: platform {
-    label: "Platform (Desktop or Mobile)"
-    sql: CASE WHEN ${TABLE}.normalized_app_name = 'Firefox Desktop' THEN 'Desktop' ELSE 'Mobile' END ;;
+    label: "Platform (Firefox Desktop or Mobile)"
+    sql: CASE WHEN ${TABLE}.normalized_app_name = 'Firefox Desktop' THEN 'Firefox Desktop' ELSE 'Firefox Mobile' END ;;
   }
 
   measure: total_user_count {
     type: count
-    drill_fields: [normalized_app_name]
   }
 
   measure: total_uri_count {


### PR DESCRIPTION
This creates a looker-native derived table for tracking the browser KPIs. It only contains three fields:

1. submission_date
2. platform
3. DAU / Days of use

The derived table is joined day-by-day onto the forecast / target explore so comparing to forecast / targets does not require a merge.

What was previously the `browser_kpis` explore now is called the `browser_dau` explore and can be used for segmenting, drilling down etc. The important thing here is that we are successfully able to direct people to the dau explore if they want to explore DAU on their own after viewing the KPI dashboard. 

This will temporarily break the temp dashboard for browser CDOU that I have been pointing people to, so I will need to fix that shortly after this being merged (I will stage some charts in some looks that I can copy over so that the breakage shouldn't last too long).