### PR TITLE
Sort x-axis on VPN churn chart

### DIFF
--- a/mozilla_vpn/dashboards/vpn_saasboard_churn.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_churn.dashboard.lookml
@@ -56,7 +56,7 @@
     filters:
       subscriptions__retention.months_since_subscription_start: ">0"
       subscriptions__retention.is_cohort_complete: 'Yes'
-    sorts: [subscriptions__retention.churned desc]
+    sorts: [subscriptions__retention.months_since_subscription_start]
     dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}",
         label: Churn Rate, value_format: !!null '', value_format_name: percent_1,
         _kind_hint: measure, table_calculation: churn_rate, _type_hint: number}, {


### PR DESCRIPTION
On the [VPN SaasBoard - Churn](https://mozilla.cloud.looker.com/dashboards/mozilla_vpn::vpn_saasboard__churn) dashboard the "Churn by Months Since Subscription Start" chart's data is sorted by churn counts, which sometimes results in the x-axis (months since subscription start) being in non-contiguous order when the churn count doesn't drop off in a regular way.  This was noticed by @zerokarmaleft and mentioned in [Slack](https://mozilla.slack.com/archives/G018F8NUQKD/p1650493398177429).

This PR changes the sorting so the "Churn by Months Since Subscription Start" chart's x-axis should be contiguous.