### PR TITLE
Updated VPN SaaSboard dashboards

### DIFF
--- a/mozilla_vpn/dashboards/vpn_saasboard_active_subs.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_active_subs.dashboard.lookml
@@ -3,6 +3,7 @@
   layout: newspaper
   preferred_viewer: dashboards-next
   crossfilter_enabled: true
+  description: ''
   elements:
   - title: Active Subscriptions (Daily)
     name: Active Subscriptions (Daily)
@@ -47,6 +48,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 8
     col: 8
     width: 16
@@ -105,6 +107,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 8
     col: 0
     width: 8
@@ -188,6 +191,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 2
     col: 19
     width: 5
@@ -202,7 +206,8 @@
     fill_fields: [active_subscriptions.active_month]
     filters:
       active_subscriptions.is_end_of_month: 'Yes'
-    sorts: [active_subscriptions.country_name desc, active_subscriptions.count_sum desc 0]
+    sorts: [active_subscriptions.country_name desc, active_subscriptions.count_sum
+        desc 0]
     limit: 500
     x_axis_gridlines: false
     y_axis_gridlines: true
@@ -279,6 +284,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 31
     col: 0
     width: 8
@@ -366,6 +372,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 31
     col: 8
     width: 8
@@ -455,6 +462,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 31
     col: 16
     width: 8
@@ -532,6 +540,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 15
     col: 0
     width: 4
@@ -609,6 +618,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 15
     col: 4
     width: 4
@@ -621,7 +631,7 @@
     fields: [active_subscriptions.count_sum, active_subscriptions.country_name]
     filters:
       active_subscriptions.is_max_active_date: 'Yes'
-    sorts: [active_subscriptions.country_name desc]
+    sorts: [active_subscriptions.count_sum desc]
     limit: 1000
     column_limit: 50
     value_labels: labels
@@ -722,6 +732,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 22
     col: 0
     width: 8
@@ -734,7 +745,7 @@
     fields: [active_subscriptions.pricing_plan, active_subscriptions.count_sum]
     filters:
       active_subscriptions.is_max_active_date: 'Yes'
-    sorts: [active_subscriptions.pricing_plan]
+    sorts: [active_subscriptions.count_sum desc]
     limit: 1000
     column_limit: 50
     value_labels: labels
@@ -828,6 +839,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 22
     col: 8
     width: 8
@@ -840,7 +852,7 @@
     fields: [active_subscriptions.count_sum, active_subscriptions.provider]
     filters:
       active_subscriptions.is_max_active_date: 'Yes'
-    sorts: [active_subscriptions.provider desc]
+    sorts: [active_subscriptions.count_sum desc]
     limit: 1000
     column_limit: 50
     value_labels: labels
@@ -913,6 +925,7 @@
       Pricing Plan: active_subscriptions.pricing_plan
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 22
     col: 16
     width: 8
@@ -927,19 +940,19 @@
 
         <img style="color: #efefef; padding: 5px 25px; float: left; height: 40px;" src="https://wwwstatic.lookercdn.com/logos/looker_all_white.svg"/>
 
-        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__active_subscriptions?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">
+        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards/412?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">
 
        Active Subs</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__subscriptions_growth?Provider=&Pricing+Plan=&Country=&Event+Date=after+2020%2F07%2F20">
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/416?Provider=&Pricing+Plan=&Country=&Event+Date=after+2020%2F07%2F20">
 
        Subs Growth</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__retention?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Retention</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/414?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Retention</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__churn?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Churn</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/413?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Churn</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__revenue?Provider=&Pricing%20Plan=&Country=&Active%20Date=after%202020%2F07%2F20">Revenue</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/433?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">Revenue</a>
 
         <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://docs.google.com/document/d/1VtrTwm8Eqt9cPLZLaH1kjnM413gKtdaZArS29xcxXpA/edit?usp=sharing">Docs</a>
 
@@ -985,7 +998,7 @@
       options: []
     model: mozilla_vpn
     explore: active_subscriptions
-    listens_to_filters: [Active Date, Country, Pricing Plan]
+    listens_to_filters: [Plan Interval Type, Active Date, Country, Pricing Plan]
     field: active_subscriptions.provider
   - name: Pricing Plan
     title: Pricing Plan
@@ -999,7 +1012,7 @@
       options: []
     model: mozilla_vpn
     explore: active_subscriptions
-    listens_to_filters: [Active Date, Country, Provider]
+    listens_to_filters: [Plan Interval Type, Active Date, Country, Provider]
     field: active_subscriptions.pricing_plan
   - name: Country
     title: Country
@@ -1013,7 +1026,7 @@
       options: []
     model: mozilla_vpn
     explore: active_subscriptions
-    listens_to_filters: [Active Date, Pricing Plan, Provider]
+    listens_to_filters: [Plan Interval Type, Active Date, Pricing Plan, Provider]
     field: active_subscriptions.country_name
   - name: Active Date
     title: Active Date
@@ -1029,3 +1042,17 @@
     explore: active_subscriptions
     listens_to_filters: []
     field: active_subscriptions.active_date
+  - name: Plan Interval Type
+    title: Plan Interval Type
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+      options: []
+    model: mozilla_vpn
+    explore: active_subscriptions
+    listens_to_filters: [Active Date, Country, Pricing Plan, Provider]
+    field: active_subscriptions.plan_interval_type

--- a/mozilla_vpn/dashboards/vpn_saasboard_churn.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_churn.dashboard.lookml
@@ -3,6 +3,7 @@
   layout: newspaper
   preferred_viewer: dashboards-next
   crossfilter_enabled: true
+  description: ''
   refresh: 2147484 seconds
   elements:
   - name: ''
@@ -56,7 +57,7 @@
     filters:
       subscriptions__retention.months_since_subscription_start: ">0"
       subscriptions__retention.is_cohort_complete: 'Yes'
-    sorts: [subscriptions__retention.churned desc]
+    sorts: [subscriptions__retention.months_since_subscription_start]
     dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}",
         label: Churn Rate, value_format: !!null '', value_format_name: percent_1,
         _kind_hint: measure, table_calculation: churn_rate, _type_hint: number}, {
@@ -128,6 +129,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_date
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 10
     col: 0
     width: 13
@@ -210,6 +212,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_date
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 10
     col: 13
     width: 11
@@ -308,6 +311,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_date
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 45
     col: 0
     width: 13
@@ -410,6 +414,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_date
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 45
     col: 13
     width: 11
@@ -525,6 +530,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_date
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 58
     col: 13
     width: 11
@@ -576,6 +582,7 @@
     series_types: {}
     listen:
       Subscription Start Date: subscriptions.subscription_start_date
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 3
     col: 19
     width: 5
@@ -711,6 +718,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_date
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 21
     col: 13
     width: 11
@@ -835,6 +843,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_date
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 32
     col: 13
     width: 11
@@ -955,6 +964,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_date
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 21
     col: 0
     width: 13
@@ -962,6 +972,7 @@
   - name: " (6)"
     type: text
     title_text: ''
+    subtitle_text: ''
     body_text: |
       <div style="border-radius: 5px; padding: 5px 10px; background: #412399; height: 60px; color: red;">
 
@@ -969,19 +980,19 @@
 
         <img style="color: #efefef; padding: 5px 25px; float: left; height: 40px;" src="https://wwwstatic.lookercdn.com/logos/looker_all_white.svg"/>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__active_subscriptions?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/412?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">
 
        Active Subs</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__subscriptions_growth?Provider=&Pricing+Plan=&Country=&Event+Date=after+2020%2F07%2F20">
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/416?Provider=&Pricing+Plan=&Country=&Event+Date=after+2020%2F07%2F20">
 
        Subs Growth</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__retention?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Retention</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/414?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Retention</a>
 
-        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__churn?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Churn</a>
+        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards/413?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Churn</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px; " href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__revenue?Provider=&Pricing%20Plan=&Country=&Active%20Date=after%202020%2F07%2F20">Revenue</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px; " href="https://mozilla.cloud.looker.com/dashboards/433?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">Revenue</a>
 
         <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://docs.google.com/document/d/1VtrTwm8Eqt9cPLZLaH1kjnM413gKtdaZArS29xcxXpA/edit?usp=sharing">Docs</a>
 
@@ -1004,7 +1015,8 @@
       display: popover
     model: mozilla_vpn
     explore: subscriptions
-    listens_to_filters: [Subscription Start Date, Provider, Pricing Plan, Country]
+    listens_to_filters: [Provider, Plan Interval Type, Subscription Start Date, Country,
+      Pricing Plan]
     field: subscriptions.provider
   - name: Pricing Plan
     title: Pricing Plan
@@ -1017,7 +1029,8 @@
       display: popover
     model: mozilla_vpn
     explore: subscriptions
-    listens_to_filters: [Subscription Start Date, Pricing Plan, Provider, Country]
+    listens_to_filters: [Pricing Plan, Plan Interval Type, Subscription Start Date,
+      Country, Provider]
     field: subscriptions.pricing_plan
   - name: Country
     title: Country
@@ -1030,7 +1043,8 @@
       display: popover
     model: mozilla_vpn
     explore: subscriptions
-    listens_to_filters: [Subscription Start Date, Country, Provider, Pricing Plan]
+    listens_to_filters: [Country, Plan Interval Type, Subscription Start Date, Pricing
+        Plan, Provider]
     field: subscriptions.country_name
   - name: Subscription Start Date
     title: Subscription Start Date
@@ -1045,3 +1059,17 @@
     explore: subscriptions
     listens_to_filters: [Subscription Start Date]
     field: subscriptions.subscription_start_date
+  - name: Plan Interval Type
+    title: Plan Interval Type
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+      options: []
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: [Subscription Start Date, Country, Pricing Plan, Provider]
+    field: subscriptions.plan_interval_type

--- a/mozilla_vpn/dashboards/vpn_saasboard_retention.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_retention.dashboard.lookml
@@ -3,6 +3,7 @@
   layout: newspaper
   preferred_viewer: dashboards-next
   crossfilter_enabled: true
+  description: ''
   refresh: 2147484 seconds
   elements:
   - name: ''
@@ -172,6 +173,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 41
     col: 12
     width: 12
@@ -302,6 +304,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 41
     col: 0
     width: 12
@@ -425,6 +428,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 49
     col: 12
     width: 12
@@ -506,6 +510,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 10
     col: 12
     width: 12
@@ -595,6 +600,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 10
     col: 0
     width: 12
@@ -625,6 +631,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 2
     col: 19
     width: 5
@@ -731,6 +738,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 22
     col: 12
     width: 12
@@ -861,6 +869,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 31
     col: 12
     width: 12
@@ -967,6 +976,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 22
     col: 0
     width: 12
@@ -1063,6 +1073,7 @@
       Pricing Plan: subscriptions.pricing_plan
       Provider: subscriptions.provider
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan Interval Type: subscriptions.plan_interval_type
     row: 60
     col: 0
     width: 24
@@ -1070,6 +1081,7 @@
   - name: " (7)"
     type: text
     title_text: ''
+    subtitle_text: ''
     body_text: |
       <div style="border-radius: 5px; padding: 5px 10px; background: #412399; height: 60px; color: red;">
 
@@ -1077,19 +1089,19 @@
 
         <img style="color: #efefef; padding: 5px 25px; float: left; height: 40px;" src="https://wwwstatic.lookercdn.com/logos/looker_all_white.svg"/>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__active_subscriptions?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/412?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">
 
        Active Subs</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__subscriptions_growth?Provider=&Pricing+Plan=&Country=&Event+Date=after+2020%2F07%2F20">
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/416?Provider=&Pricing+Plan=&Country=&Event+Date=after+2020%2F07%2F20">
 
        Subs Growth</a>
 
-        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__retention?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Retention</a>
+        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards/414?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Retention</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__churn?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Churn</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/413?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Churn</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__revenue?Provider=&Pricing%20Plan=&Country=&Active%20Date=after%202020%2F07%2F20">Revenue</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/433?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">Revenue</a>
 
         <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://docs.google.com/document/d/1VtrTwm8Eqt9cPLZLaH1kjnM413gKtdaZArS29xcxXpA/edit?usp=sharing">Docs</a>
 
@@ -1112,7 +1124,8 @@
       display: popover
     model: mozilla_vpn
     explore: subscriptions
-    listens_to_filters: [Provider, Pricing Plan, Country, Subscription Start Date]
+    listens_to_filters: [Provider, Plan Interval Type, Subscription Start Date, Country,
+      Pricing Plan]
     field: subscriptions.provider
   - name: Pricing Plan
     title: Pricing Plan
@@ -1125,7 +1138,8 @@
       display: popover
     model: mozilla_vpn
     explore: subscriptions
-    listens_to_filters: [Provider, Pricing Plan, Country, Subscription Start Date]
+    listens_to_filters: [Pricing Plan, Plan Interval Type, Subscription Start Date,
+      Country, Provider]
     field: subscriptions.pricing_plan
   - name: Country
     title: Country
@@ -1138,7 +1152,8 @@
       display: popover
     model: mozilla_vpn
     explore: subscriptions
-    listens_to_filters: [Provider, Pricing Plan, Country, Subscription Start Date]
+    listens_to_filters: [Country, Plan Interval Type, Subscription Start Date, Pricing
+        Plan, Provider]
     field: subscriptions.country_name
   - name: Subscription Start Date
     title: Subscription Start Date
@@ -1154,3 +1169,17 @@
     explore: subscriptions
     listens_to_filters: []
     field: subscriptions.subscription_start_month
+  - name: Plan Interval Type
+    title: Plan Interval Type
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+      options: []
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: [Subscription Start Date, Country, Pricing Plan, Provider]
+    field: subscriptions.plan_interval_type

--- a/mozilla_vpn/dashboards/vpn_saasboard_revenue.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_revenue.dashboard.lookml
@@ -76,6 +76,7 @@
       Active Date: active_subscriptions.active_date
       Country: active_subscriptions.country_name
       Provider: active_subscriptions.provider
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 15
     col: 0
     width: 12
@@ -92,11 +93,13 @@
   - name: " (2)"
     type: text
     title_text: ''
+    subtitle_text: ''
     body_text: "<p style='background-color: #ffffdd; padding: 5px 10px; border: solid\
       \ 3px #ededed; border-radius: 5px; height:150px'>\n\nThis dashboard captures\
-      \ <strong>revenue</strong>.\n\n<br>\n<br>\nPlease submit any questions in  <b><a\
-      \ href=\"https://mozilla.slack.com/messages/mozilla-vpn-data/\">mozilla-vpn-data</a></b>\
-      \ channel on Slack for @wichan or @relud. \n\n</p>"
+      \ <strong>revenue</strong>.\n<br>\nRevenue from Apple Store is not included\
+      \ because price amount is not available.\n<br>\n<br>\n<br>\nPlease submit any\
+      \ questions in  <b><a href=\"https://mozilla.slack.com/messages/mozilla-vpn-data/\"\
+      >mozilla-vpn-data</a></b> channel on Slack for @wichan or @relud. \n\n</p>"
     row: 2
     col: 3
     width: 15
@@ -106,12 +109,14 @@
     model: mozilla_vpn
     explore: active_subscriptions
     type: looker_column
-    fields: [active_subscriptions.active_month, active_subscriptions.country_name, active_subscriptions.annual_recurring_revenue]
+    fields: [active_subscriptions.active_month, active_subscriptions.country_name,
+      active_subscriptions.annual_recurring_revenue]
     pivots: [active_subscriptions.country_name]
     fill_fields: [active_subscriptions.active_month]
     filters:
       active_subscriptions.is_end_of_month: 'Yes'
-    sorts: [active_subscriptions.active_month desc, active_subscriptions.country_name desc]
+    sorts: [active_subscriptions.active_month desc, active_subscriptions.country_name
+        desc]
     limit: 500
     x_axis_gridlines: false
     y_axis_gridlines: true
@@ -169,6 +174,7 @@
       Active Date: active_subscriptions.active_date
       Country: active_subscriptions.country_name
       Provider: active_subscriptions.provider
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 6
     col: 0
     width: 12
@@ -178,7 +184,8 @@
     model: mozilla_vpn
     explore: active_subscriptions
     type: looker_column
-    fields: [active_subscriptions.active_month, active_subscriptions.pricing_plan, active_subscriptions.annual_recurring_revenue]
+    fields: [active_subscriptions.active_month, active_subscriptions.pricing_plan,
+      active_subscriptions.annual_recurring_revenue]
     pivots: [active_subscriptions.pricing_plan]
     fill_fields: [active_subscriptions.active_month]
     filters:
@@ -238,6 +245,7 @@
       Active Date: active_subscriptions.active_date
       Country: active_subscriptions.country_name
       Provider: active_subscriptions.provider
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 6
     col: 12
     width: 12
@@ -277,6 +285,7 @@
       Active Date: active_subscriptions.active_date
       Country: active_subscriptions.country_name
       Provider: active_subscriptions.provider
+      Plan Interval Type: active_subscriptions.plan_interval_type
     row: 2
     col: 18
     width: 6
@@ -304,7 +313,7 @@
 
         <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/413?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Churn</a>
 
-        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards/415?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">Revenue</a>
+        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards/433?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">Revenue</a>
 
         <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://docs.google.com/document/d/1VtrTwm8Eqt9cPLZLaH1kjnM413gKtdaZArS29xcxXpA/edit?usp=sharing">Docs</a>
 
@@ -328,7 +337,7 @@
       options: []
     model: mozilla_vpn
     explore: active_subscriptions
-    listens_to_filters: [Pricing Plan, Country, Active Date]
+    listens_to_filters: [Plan Interval Type, Active Date, Country, Pricing Plan]
     field: active_subscriptions.provider
   - name: Pricing Plan
     title: Pricing Plan
@@ -342,7 +351,7 @@
       options: []
     model: mozilla_vpn
     explore: active_subscriptions
-    listens_to_filters: [Provider, Country, Active Date]
+    listens_to_filters: [Plan Interval Type, Active Date, Country, Provider]
     field: active_subscriptions.pricing_plan
   - name: Country
     title: Country
@@ -356,7 +365,7 @@
       options: []
     model: mozilla_vpn
     explore: active_subscriptions
-    listens_to_filters: [Provider, Pricing Plan, Active Date]
+    listens_to_filters: [Plan Interval Type, Active Date, Pricing Plan, Provider]
     field: active_subscriptions.country_name
   - name: Active Date
     title: Active Date
@@ -372,3 +381,17 @@
     explore: active_subscriptions
     listens_to_filters: []
     field: active_subscriptions.active_date
+  - name: Plan Interval Type
+    title: Plan Interval Type
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+      options: []
+    model: mozilla_vpn
+    explore: active_subscriptions
+    listens_to_filters: [Active Date, Country, Pricing Plan, Provider]
+    field: active_subscriptions.plan_interval_type

--- a/mozilla_vpn/dashboards/vpn_saasboard_subs_growth.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_subs_growth.dashboard.lookml
@@ -3,6 +3,7 @@
   layout: newspaper
   preferred_viewer: dashboards-next
   crossfilter_enabled: true
+  description: ''
   elements:
   - name: ''
     type: text
@@ -84,6 +85,7 @@
       Pricing Plan: subscription_events.pricing_plan
       Country: subscription_events.country_name
       Event Date: subscription_events.event_date
+      Plan Interval Type: subscription_events.plan_interval_type
     row: 2
     col: 19
     width: 5
@@ -98,7 +100,8 @@
     fill_fields: [subscription_events.event_month]
     filters:
       subscription_events.event_type: New
-    sorts: [subscription_events.event_month desc, subscription_events.country_name desc]
+    sorts: [subscription_events.event_month desc, subscription_events.country_name
+        desc]
     limit: 500
     x_axis_gridlines: false
     y_axis_gridlines: true
@@ -196,6 +199,7 @@
       Pricing Plan: subscription_events.pricing_plan
       Country: subscription_events.country_name
       Event Date: subscription_events.event_date
+      Plan Interval Type: subscription_events.plan_interval_type
     row: 8
     col: 0
     width: 8
@@ -308,6 +312,7 @@
       Pricing Plan: subscription_events.pricing_plan
       Country: subscription_events.country_name
       Event Date: subscription_events.event_date
+      Plan Interval Type: subscription_events.plan_interval_type
     row: 8
     col: 8
     width: 8
@@ -368,8 +373,6 @@
     series_colors:
       Resurrected - subscription_events.delta: "#47f5bf"
       New - subscription_events.delta: "#80ab62"
-      New - subscription_events.delta: "#80ab62"
-      Resurrected - subscription_events.delta: "#47f5bf"
     series_labels:
       Resurrected - subscription_events.delta: Returning
     show_null_points: true
@@ -384,79 +387,9 @@
       Pricing Plan: subscription_events.pricing_plan
       Country: subscription_events.country_name
       Event Date: subscription_events.event_date
+      Plan Interval Type: subscription_events.plan_interval_type
     row: 23
     col: 8
-    width: 8
-    height: 13
-  - title: Subscription Cancellations
-    name: Subscription Cancellations
-    model: mozilla_vpn
-    explore: subscription_events
-    type: looker_column
-    fields: [subscription_events.event_month, subscription_events.granular_event_type,
-      subscription_events.delta]
-    pivots: [subscription_events.granular_event_type]
-    fill_fields: [subscription_events.event_month]
-    filters:
-      subscription_events.event_type: Cancelled
-    sorts: [subscription_events.event_month desc, subscription_events.granular_event_type]
-    limit: 500
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: normal
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: true
-    show_silhouette: false
-    totals_color: "#808080"
-    color_application:
-      collection_id: 1297ec12-86a5-4ae0-9dfc-82de70b3806a
-      palette_id: 93f8aeb4-3f4a-4cd7-8fee-88c3417516a1
-      options:
-        steps: 5
-    x_axis_label: Month
-    limit_displayed_rows_values:
-      show_hide: hide
-      first_last: first
-      num_rows: 0
-    hide_legend: false
-    series_types: {}
-    series_colors:
-      Cancelled by IAP - subscription_events.delta: "#7CC8FA"
-      Cancelled by Customer - subscription_events.delta: "#FFDAC4"
-      Payment Failed - subscription_events.delta: "#F56776"
-    series_labels:
-      Resurrected - subscription_events.delta: Returning
-      Cancelled by IAP - subscription_events.delta: Not reported (Apple IAP)
-    show_null_points: true
-    interpolation: linear
-    defaults_version: 1
-    listen:
-      Provider: subscription_events.provider
-      Pricing Plan: subscription_events.pricing_plan
-      Country: subscription_events.country_name
-      Event Date: subscription_events.event_date
-    row: 23
-    col: 16
     width: 8
     height: 13
   - title: Net New Subscriptions
@@ -538,6 +471,7 @@
       Pricing Plan: subscription_events.pricing_plan
       Country: subscription_events.country_name
       Event Date: subscription_events.event_date
+      Plan Interval Type: subscription_events.plan_interval_type
     row: 23
     col: 0
     width: 8
@@ -648,6 +582,7 @@
       Pricing Plan: subscription_events.pricing_plan
       Country: subscription_events.country_name
       Event Date: subscription_events.event_date
+      Plan Interval Type: subscription_events.plan_interval_type
     row: 8
     col: 16
     width: 8
@@ -655,6 +590,7 @@
   - name: " (3)"
     type: text
     title_text: ''
+    subtitle_text: ''
     body_text: |
       <div style="border-radius: 5px; padding: 5px 10px; background: #412399; height: 60px; color: red;">
 
@@ -662,19 +598,19 @@
 
         <img style="color: #efefef; padding: 5px 25px; float: left; height: 40px;" src="https://wwwstatic.lookercdn.com/logos/looker_all_white.svg"/>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__active_subscriptions?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/412?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">
 
        Active Subs</a>
 
-        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__subscriptions_growth?Provider=&Pricing+Plan=&Country=&Event+Date=after+2020%2F07%2F20">
+        <a style="color: #efefef; border: 1px solid white; padding: 5px 25px; float: left; line-height: 40px; font-weight: bold; text-decoration: underline" href="https://mozilla.cloud.looker.com/dashboards/416?Provider=&Pricing+Plan=&Country=&Event+Date=after+2020%2F07%2F20">
 
        Subs Growth</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__retention?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Retention</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/414?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Retention</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__churn?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Churn</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/413?Provider=&Pricing+Plan=&Country=&Subscription+Start+Date=after+2020%2F07%2F20">Churn</a>
 
-        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards-next/mozilla_vpn::vpn_saasboard__revenue?Provider=&Pricing%20Plan=&Country=&Active%20Date=after%202020%2F07%2F20">Revenue</a>
+        <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://mozilla.cloud.looker.com/dashboards/433?Provider=&Pricing+Plan=&Country=&Active+Date=after+2020%2F07%2F20">Revenue</a>
 
         <a style="color: #efefef; padding: 5px 25px; float: left; line-height: 40px;" href="https://docs.google.com/document/d/1VtrTwm8Eqt9cPLZLaH1kjnM413gKtdaZArS29xcxXpA/edit?usp=sharing">Docs</a>
 
@@ -711,6 +647,15 @@
     col: 0
     width: 24
     height: 2
+  - name: Subscription Cancellations
+    type: text
+    title_text: Subscription Cancellations
+    subtitle_text: This view is currently unavailable.
+    body_text: ''
+    row: 23
+    col: 16
+    width: 8
+    height: 13
   filters:
   - name: Provider
     title: Provider
@@ -724,7 +669,7 @@
       options: []
     model: mozilla_vpn
     explore: subscription_events
-    listens_to_filters: [Pricing Plan, Country, Event Date]
+    listens_to_filters: [Plan Interval Type, Pricing Plan, Country, Event Date]
     field: subscription_events.provider
   - name: Pricing Plan
     title: Pricing Plan
@@ -738,7 +683,7 @@
       options: []
     model: mozilla_vpn
     explore: subscription_events
-    listens_to_filters: [Provider, Country, Event Date]
+    listens_to_filters: [Plan Interval Type, Provider, Country, Event Date]
     field: subscription_events.pricing_plan
   - name: Country
     title: Country
@@ -752,7 +697,7 @@
       options: []
     model: mozilla_vpn
     explore: subscription_events
-    listens_to_filters: [Provider, Pricing Plan, Event Date]
+    listens_to_filters: [Plan Interval Type, Provider, Pricing Plan, Event Date]
     field: subscription_events.country_name
   - name: Event Date
     title: Event Date
@@ -768,3 +713,17 @@
     explore: subscription_events
     listens_to_filters: []
     field: subscription_events.event_date
+  - name: Plan Interval Type
+    title: Plan Interval Type
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+      options: []
+    model: mozilla_vpn
+    explore: subscription_events
+    listens_to_filters: [Provider, Pricing Plan, Country, Event Date]
+    field: subscription_events.plan_interval_type


### PR DESCRIPTION
1. Added plan interval type filter to dashboards

2. Pie charts in active subs dashboard is now sorted by count sum instead of country name as requested by product team ([link to slack conversation](https://mozilla.slack.com/archives/C018SNLQP6C/p1643996085018059))

3. Subscription cancellation view is removed for now until categorization is fixed.  See ticket [[DVPN - 139](https://mozilla-hub.atlassian.net/browse/DVPN-139?atlOrigin=eyJpIjoiYjcwMjBjNmExYTZiNGM4MWIwMTYwZDk2NmZhNGJkMDgiLCJwIjoiaiJ9)]