### PR TITLE
Added wave launch dimension to vpn saasboard

### DIFF
--- a/mozilla_vpn/views/subscription_events_table.view.lkml
+++ b/mozilla_vpn/views/subscription_events_table.view.lkml
@@ -14,6 +14,18 @@ view: +subscription_events_table {
     sql: CONCAT(${plan_interval_count},"_",  ${plan_interval});;
   }
 
+  dimension: wave_launch {
+    description: "Indicates the wave of launch (Wave 1, Europe, Switzerland).  This is to primarily support finance reporting"
+    type: string
+    sql: CASE
+    WHEN ${pricing_plan} LIKE "%-eur-%" THEN "Europe"
+    WHEN ${pricing_plan} LIKE "%-chf-%" THEN "Switzerland"
+    WHEN ${pricing_plan} LIKE "1-month-usd-4.99" THEN "Wave_1 monthly legacy only"
+    ELSE "Wave_1 excluding monthly legacy"
+    END;;
+  }
+
+
   dimension: count {
     hidden: yes
   }

--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -66,6 +66,17 @@ view: +subscriptions {
     sql: CONCAT(${plan_interval_count},"_",  ${plan_interval});;
   }
 
+  dimension: wave_launch {
+    description: "Indicates the wave of launch (Wave 1, Europe, Switzerland).  This is to primarily support finance reporting"
+    type: string
+    sql: CASE
+          WHEN ${pricing_plan} LIKE "%-eur-%" THEN "Europe"
+          WHEN ${pricing_plan} LIKE "%-chf-%" THEN "Switzerland"
+          WHEN ${pricing_plan} LIKE "1-month-usd-4.99" THEN "Wave_1 monthly legacy only"
+          ELSE "Wave_1 excluding monthly legacy"
+          END;;
+  }
+
   dimension: normalized_source {
     group_label: "Attribution"
   }


### PR DESCRIPTION
There has been an increasing need from finance to report on vpn data by waves.  This dimension has been added to support this need.