### PR TITLE
Adjusted grace period in current_months_since_cohort_complete

### DIFF
--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -155,7 +155,7 @@ view: +subscriptions {
     sql: mozfun.norm.diff_months(
       start => LAST_DAY(DATE(${subscriptions.subscription_start_raw}), MONTH),
       `end` => DATE(${metadata.last_modified_date}),
-      grace_period => ${subscriptions.billing_grace_period},
+      grace_period => INTERVAL 7 DAY,
       inclusive => FALSE
     );;
   }


### PR DESCRIPTION
Some views in the VPN SaaSboard retention & churn dashboards rely on current_months_since_cohort_complete filter to hide data from most recent cohort.  Because mobile subscriptions have billing grace period = 0, this is causing those subscriptions to appear before stripe subscriptions that have a 7 days billing grace period. 