### PR TITLE
Attempting to fix is_default_browser counting by converting to string values

### DIFF
--- a/combined_browser_metrics/views/active_users_aggregates.view.lkml
+++ b/combined_browser_metrics/views/active_users_aggregates.view.lkml
@@ -284,6 +284,26 @@ view: +active_users_aggregates {
     sql:  ${TABLE}.active_hours ;;
   }
 
+  dimension: is_default_browser {
+    type:  string
+    case: {
+      when: {
+        sql: ${TABLE}.is_default_browser = true ;;
+        label: "yes"
+      }
+
+      when: {
+        sql: ${TABLE}.is_default_browser = false ;;
+        label: "no"
+      }
+
+      when: {
+        sql: ${TABLE}.is_default_browser is NULL ;;
+        label: "unknown"
+      }
+    }
+  }
+
 # Group dimensions in Explore
   dimension: os {
     sql: ${TABLE}.os ;;


### PR DESCRIPTION
Attempting to fix is_default_browser counting by converting to string values.

Otherwise `null` values from the table get counted as `false` resulting in values not representing the known state. The assumption here is that an absence of value, in this case, does not mean we know someone's browser preferences.