### PR TITLE
attempting to increase timeout when searching dashboards

### DIFF
--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -48,7 +48,8 @@ def get_all_linked_dashboards(sdk: methods.Looker31SDK) -> dict:
     """
     remote_config = {}
 
-    dashboards = sdk.search_dashboards(deleted=False)
+    transport_options = looker_sdk.rtl.transport.TransportOptions({"timeout": 60 * 5})
+    dashboards = sdk.search_dashboards(deleted=False, transport_options=transport_options)
 
     for dashboard in dashboards:
         if dashboard.model is None and dashboard.lookml_link_id:


### PR DESCRIPTION
It seems out builds for `main` branch are failing with the following error:

```
This as an attempt to increase the timeout to see if that resolves this failure.
```

Error observed:

```
2022-06-03 12:52:11 INFO     GET(********************************/api/3.1/dashboards/search)
Traceback (most recent call last):
  File "./src/sync_dashboards/main.py", line 138, in <module>
    cli(obj={})
  File "/home/circleci/.pyenv/versions/3.8.13/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/circleci/.pyenv/versions/3.8.13/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/circleci/.pyenv/versions/3.8.13/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/circleci/.pyenv/versions/3.8.13/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/circleci/.pyenv/versions/3.8.13/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/circleci/.pyenv/versions/3.8.13/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "./src/sync_dashboards/main.py", line 123, in sync
    remote_mappings = get_all_linked_dashboards(sdk)
  File "./src/sync_dashboards/main.py", line 51, in get_all_linked_dashboards
    dashboards = sdk.search_dashboards(deleted=False)
  File "/home/circleci/.pyenv/versions/3.8.13/lib/python3.8/site-packages/looker_sdk/sdk/api31/methods.py", line 2353, in search_dashboards
    self.get(
  File "/home/circleci/.pyenv/versions/3.8.13/lib/python3.8/site-packages/looker_sdk/rtl/api_methods.py", line 143, in get
    return self._return(response, structure)
  File "/home/circleci/.pyenv/versions/3.8.13/lib/python3.8/site-packages/looker_sdk/rtl/api_methods.py", line 87, in _return
    raise error.SDKError(response.value.decode(encoding=encoding))
looker_sdk.error.SDKError: HTTPSConnectionPool(host='[domain]', port=443): Read timed out. (read timeout=120)
```