### PR TITLE
Fix subscripiton events delta counts in vpn saasboard

### DIFF
--- a/mozilla_vpn/views/subscription_events_table.view.lkml
+++ b/mozilla_vpn/views/subscription_events_table.view.lkml
@@ -20,6 +20,6 @@ view: +subscription_events_table {
 
   measure: delta {
     type: sum
-    sql: IF(${event_type} = "New", ${count}, -${count});;
+    sql: IF(${event_type} LIKE "%New%", ${count}, -${count});;
   }
 }


### PR DESCRIPTION
As part of [#3031](https://github.com/mozilla/bigquery-etl/pull/3031), new events were added to the`mozilla_vpn_derived.subscription_events_v1` table for trials data.

The [vpn saasboard - subscriptions growth](https://mozilla.cloud.looker.com/dashboards/416) dashboard relies on subscription events to generate views.
This PR updates the delta counts to consider those events created for trials data.