### PR TITLE
Deng 163 improve query speed active_users_aggregates

### DIFF
--- a/combined_browser_metrics/combined_browser_metrics.model.lkml
+++ b/combined_browser_metrics/combined_browser_metrics.model.lkml
@@ -16,6 +16,17 @@ join: countries {
 }
 }
 
+explore: active_users_aggregates_mv {
+  always_filter: {
+    filters: [active_users_aggregates_mv.submission_date: "this year"]
+  }
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${active_users_aggregates_mv.country} = ${countries.code} ;;
+  }
+}
+
 explore: active_users_aggregates_device {
   always_filter: {
     filters: [active_users_aggregates_device.submission_date: "this year"]

--- a/combined_browser_metrics/combined_browser_metrics.model.lkml
+++ b/combined_browser_metrics/combined_browser_metrics.model.lkml
@@ -16,6 +16,49 @@ join: countries {
 }
 }
 
+# Aggregation for active users metrics for submission_date > 2021
+explore: +active_users_aggregates {
+  aggregate_table: rollup__active_users_metrics {
+    query: {
+      dimensions: [app_name, submission_date]
+      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click]
+      filters: [
+        active_users_aggregates.submission_date: "after 2021/01/01"
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
+      increment_key: active_users_aggregates.submission_date
+      increment_offset: 1
+    }
+  }
+}
+
+# Aggregation for active users metrics with Period over Period calculation
+explore: +active_users_aggregates {
+  aggregate_table: rollup__period_over_period_pivot__period_over_period_row {
+    query: {
+      dimensions: [app_name, submission_date, period_over_period_pivot, period_over_period_row]
+      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click]
+      filters: [
+        active_users_aggregates.choose_breakdown: "Month^_Day",
+        active_users_aggregates.choose_comparison: "Year",
+        active_users_aggregates.submission_date: "after 2021/01/01",
+        active_users_aggregates.ytd_only: "Yes"
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
+      increment_key: active_users_aggregates.submission_date
+      increment_offset: 1
+    }
+  }
+}
+
+
+
 explore: active_users_aggregates_mv {
   always_filter: {
     filters: [active_users_aggregates_mv.submission_date: "this year"]

--- a/combined_browser_metrics/combined_browser_metrics.model.lkml
+++ b/combined_browser_metrics/combined_browser_metrics.model.lkml
@@ -9,19 +9,31 @@ explore: active_users_aggregates {
     filters: [active_users_aggregates.submission_date: "this year"]
   }
 
-join: countries {
-  type: left_outer
-  relationship: one_to_one
-  sql_on: ${active_users_aggregates.country} = ${countries.code} ;;
-}
-}
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${active_users_aggregates.country} = ${countries.code} ;;
+  }
 
-# Aggregation for active users metrics for submission_date > 2021
-explore: +active_users_aggregates {
-  aggregate_table: rollup__active_users_metrics {
+  aggregate_table: rollup__active_users_aggregates_2022_usage {
     query: {
-      dimensions: [app_name, submission_date]
-      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click]
+      dimensions: [active_users_aggregates.app_name, active_users_aggregates.submission_date]
+      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click, organic_search_counts, search_counts, search_with_ad, uri_counts, active_hour]
+      filters: [
+        active_users_aggregates.submission_date: "after 2022/01/01"
+      ]
+    }
+    materialization: {
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
+      increment_key: active_users_aggregates.submission_date
+      increment_offset: 1
+    }
+  }
+
+  aggregate_table: rollup__active_users_aggregates_2021_common {
+    query: {
+      dimensions: [active_users_aggregates.submission_date, active_users_aggregates.country, active_users_aggregates.channel, active_users_aggregates.attribution_medium]
+      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click, organic_search_counts, search_counts, search_with_ad, uri_counts, active_hour]
       filters: [
         active_users_aggregates.submission_date: "after 2021/01/01"
       ]
@@ -35,51 +47,16 @@ explore: +active_users_aggregates {
   }
 }
 
-# Aggregation for active users metrics with Period over Period calculation
-explore: +active_users_aggregates {
-  aggregate_table: rollup__period_over_period_pivot__period_over_period_row {
-    query: {
-      dimensions: [app_name, submission_date, period_over_period_pivot, period_over_period_row]
-      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click]
-      filters: [
-        active_users_aggregates.choose_breakdown: "Month^_Day",
-        active_users_aggregates.choose_comparison: "Year",
-        active_users_aggregates.submission_date: "after 2021/01/01",
-        active_users_aggregates.ytd_only: "Yes"
-      ]
-    }
-
-    materialization: {
-      sql_trigger_value: SELECT CURRENT_DATE() ;;
-      increment_key: active_users_aggregates.submission_date
-      increment_offset: 1
-    }
-  }
-}
-
-
-
-explore: active_users_aggregates_mv {
-  always_filter: {
-    filters: [active_users_aggregates_mv.submission_date: "this year"]
-  }
-  join: countries {
-    type: left_outer
-    relationship: one_to_one
-    sql_on: ${active_users_aggregates_mv.country} = ${countries.code} ;;
-  }
-}
-
 explore: active_users_aggregates_device {
   always_filter: {
     filters: [active_users_aggregates_device.submission_date: "this year"]
   }
 
-join: countries {
-  type: left_outer
-  relationship: one_to_one
-  sql_on: ${active_users_aggregates_device.country} = ${countries.code} ;;
-}
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${active_users_aggregates_device.country} = ${countries.code} ;;
+  }
 }
 
 explore: active_users_aggregates_attribution {

--- a/combined_browser_metrics/views/active_users_aggregates_awareness.view.lkml
+++ b/combined_browser_metrics/views/active_users_aggregates_awareness.view.lkml
@@ -1,0 +1,69 @@
+view: active_users_aggregates_awareness {
+  # # You can specify the table name if it's different from the view name:
+  # sql_table_name: my_schema_name.tester ;;
+  #
+  # # Define your dimensions and measures here, like this:
+  # dimension: user_id {
+  #   description: "Unique ID for each user that has ordered"
+  #   type: number
+  #   sql: ${TABLE}.user_id ;;
+  # }
+  #
+  # dimension: lifetime_orders {
+  #   description: "The total number of orders for each user"
+  #   type: number
+  #   sql: ${TABLE}.lifetime_orders ;;
+  # }
+  #
+  # dimension_group: most_recent_purchase {
+  #   description: "The date when each user last ordered"
+  #   type: time
+  #   timeframes: [date, week, month, year]
+  #   sql: ${TABLE}.most_recent_purchase_at ;;
+  # }
+  #
+  # measure: total_lifetime_orders {
+  #   description: "Use this for counting lifetime orders across many users"
+  #   type: sum
+  #   sql: ${lifetime_orders} ;;
+  # }
+}
+
+# view: active_users_aggregates_awareness {
+#   # Or, you could make this view a derived table, like this:
+#   derived_table: {
+#     sql: SELECT
+#         user_id as user_id
+#         , COUNT(*) as lifetime_orders
+#         , MAX(orders.created_at) as most_recent_purchase_at
+#       FROM orders
+#       GROUP BY user_id
+#       ;;
+#   }
+#
+#   # Define your dimensions and measures here, like this:
+#   dimension: user_id {
+#     description: "Unique ID for each user that has ordered"
+#     type: number
+#     sql: ${TABLE}.user_id ;;
+#   }
+#
+#   dimension: lifetime_orders {
+#     description: "The total number of orders for each user"
+#     type: number
+#     sql: ${TABLE}.lifetime_orders ;;
+#   }
+#
+#   dimension_group: most_recent_purchase {
+#     description: "The date when each user last ordered"
+#     type: time
+#     timeframes: [date, week, month, year]
+#     sql: ${TABLE}.most_recent_purchase_at ;;
+#   }
+#
+#   measure: total_lifetime_orders {
+#     description: "Use this for counting lifetime orders across many users"
+#     type: sum
+#     sql: ${lifetime_orders} ;;
+#   }
+# }

--- a/combined_browser_metrics/views/active_users_aggregates_mv.view.lkml
+++ b/combined_browser_metrics/views/active_users_aggregates_mv.view.lkml
@@ -1,0 +1,406 @@
+include: "//looker-hub/combined_browser_metrics/views/active_users_aggregates.view.lkml"
+
+view: active_users_aggregates_mv {
+  derived_table: {
+    create_process: {
+      sql_step:
+        CREATE MATERIALIZED VIEW ${SQL_TABLE_NAME} AS
+        SELECT
+          segment,
+          app_version,
+          attribution_medium,
+          attribution_source,
+          city,
+          country,
+          distribution_id,
+          is_default_browser,
+          app_name,
+          channel,
+          os,
+          os_version,
+          os_version_major,
+          os_version_minor,
+          submission_date,
+          first_seen_year,
+          attributed,
+          language_name,
+          SUM(new_profiles) AS new_profiles,
+          SUM(mau) AS mau,
+          SUM(dau) AS dau,
+          SUM(wau) AS wau,
+          SUM(ad_clicks) AS ad_clicks,
+          SUM(active_hours) AS active_hours,
+          SUM(organic_search_count) AS organic_search_count,
+          SUM(search_count) AS search_count,
+          SUM(search_with_ads) AS search_with_ads,
+          SUM(uri_count) AS uri_count
+        FROM `moz-fx-data-shared-prod.telemetry_derived.active_users_aggregates_v1`
+        WHERE submission_date >= '2021-01-01'
+        GROUP BY 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18;;
+    }
+    sql_trigger_value: 1 ;;
+    publish_as_db_view: yes
+  }
+
+  parameter: choose_breakdown {
+    label: "Choose Grouping (Rows)"
+    view_label: "Date/Period Selection"
+    type: unquoted
+    default_value: "Month"
+    allowed_value: {label: "Month Number" value:"Month"}
+    allowed_value: {label: "Month and Day" value: "Month_Day"}
+    allowed_value: {label: "Week of Year" value: "WOY"}
+    allowed_value: {label: "Day of Year" value: "DOY"}
+    allowed_value: {label: "Day of Month" value: "DOM"}
+    allowed_value: {label: "Day of Week" value: "DOW"}
+    allowed_value: {value: "Date"}
+  }
+
+  parameter: choose_comparison {
+    label: "Choose Comparison (Pivot)"
+    view_label: "Date/Period Selection"
+    type: unquoted
+    default_value: "Year"
+    allowed_value: {value: "Year" }
+    allowed_value: {value: "Month"}
+    allowed_value: {value: "Week"}
+  }
+
+  dimension_group: submission {
+    type: time
+    view_label: "Date/Period Selection"
+    timeframes: [
+      raw,
+      date,
+      day_of_month,
+      day_of_year,
+      week,
+      week_of_year,
+      month,
+      month_name,
+      month_num,
+      quarter,
+      year
+    ]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.submission_date ;;
+  }
+
+  dimension: day_month_abbreviation {
+    type:  date
+    hidden: yes
+    view_label: "Date/Period Selection"
+    convert_tz: no
+    datatype:  date
+    sql: FORMAT_DATE("%b %d", ${TABLE}.submission_date);;
+  }
+
+  dimension: day_month_number {
+    type:  date
+    hidden: yes
+    view_label: "Date/Period Selection"
+    datatype:  date
+    sql: FORMAT_DATE("%m-%d", ${TABLE}.submission_date);;
+  }
+
+  dimension: period_over_period_row  {
+    view_label: "Date/Period Selection"
+    label_from_parameter: choose_breakdown
+    type: string
+    # order_by_field: sort_hack1 # Important # WON: no dimension called sort_hack1
+    order_by_field: sort_by1
+    sql:
+          {% if choose_breakdown._parameter_value == 'Month' %} ${submission_month_num}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${day_month_abbreviation}
+          {% elsif choose_breakdown._parameter_value == 'WOY' %} ${submission_week_of_year}
+          {% elsif choose_breakdown._parameter_value == 'DOY' %} ${submission_day_of_year}
+          {% elsif choose_breakdown._parameter_value == 'DOM' %} ${submission_day_of_month}
+          {% elsif choose_breakdown._parameter_value == 'Date' %} ${submission_date}
+          {% else %}NULL{% endif %} ;;
+  }
+
+  dimension: period_over_period_pivot {
+    view_label: "Date/Period Selection"
+    label_from_parameter: choose_comparison
+    type: string
+    # order_by_field: sort_hack2 # Important # WON: no dimension called sort_hack2
+    order_by_field: sort_by2
+    sql:
+          {% if choose_comparison._parameter_value == 'Year' %} ${submission_year}
+          {% elsif choose_comparison._parameter_value == 'Month' %} ${submission_month}
+          {% elsif choose_breakdown._parameter_value == 'WOY' %} ${submission_week_of_year}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${day_month_abbreviation}
+          {% else %}NULL{% endif %} ;;
+  }
+
+  dimension: app_name {
+    label: "Browser Name"
+    type: string
+    sql: ${TABLE}.app_name ;;
+  }
+
+  dimension: app_version{
+    label: "Browser Version"
+    type: string
+    sql: ${TABLE}.app_version ;;
+  }
+
+  dimension: attribution_medium {
+    label: "Attribution Medium"
+    type:  string
+    group_label: "Attribution"
+    sql: ${TABLE}.attribution_medium ;;
+  }
+
+  dimension: attribution_source {
+    label: "Attribution Source"
+    type:  string
+    group_label: "Attribution"
+    sql: ${TABLE}.attribution_source ;;
+  }
+
+  dimension: segment {
+    label: "Segment"
+    type: string
+    sql: ${TABLE}.segment ;;
+  }
+
+  dimension: city {
+    label: "City"
+    type: string
+    sql: ${TABLE}.city;;
+  }
+
+  dimension: country {
+    label: "Country"
+    type: string
+    sql: ${TABLE}.country;;
+  }
+
+  dimension: distribution_id {
+    label: "Distribution ID"
+    type: string
+    sql: ${TABLE}.distribution_id;;
+  }
+
+  dimension: channel {
+    label: "Channel"
+    type: string
+    sql: ${TABLE}.channel;;
+  }
+
+  dimension: first_seen_year {
+    label: "First Seen Year"
+    type: string
+    sql: ${TABLE}.first_seen_year;;
+  }
+
+  dimension: attributed {
+    label: "Is Attributed"
+    type: string
+    sql: ${TABLE}.attributed;;
+  }
+
+  dimension: language_name {
+    label: "Language"
+    type: string
+    sql: ${TABLE}.language_name;;
+  }
+
+# These dimensions are just to make sure the dimensions sort correctly
+  dimension: sort_by1 {
+    hidden: yes
+    type: number
+    sql:
+          {% if choose_breakdown._parameter_value == 'Month' %} ${submission_month_num}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${submission_day_of_year}
+          {% elsif choose_breakdown._parameter_value == 'WOY' %} ${submission_week_of_year}
+          {% elsif choose_breakdown._parameter_value == 'DOY' %} ${submission_day_of_year}
+          {% elsif choose_breakdown._parameter_value == 'DOM' %} ${submission_day_of_month}
+          {% elsif choose_breakdown._parameter_value == 'Date' %} ${submission_date}
+          {% else %}NULL{% endif %} ;;
+  }
+
+  dimension: sort_by2 {
+    hidden: yes
+    type: string
+    sql:
+          {% if choose_comparison._parameter_value == 'Year' %} ${submission_year}
+          {% elsif choose_comparison._parameter_value == 'Month' %} ${submission_month_num}
+          {% elsif choose_breakdown._parameter_value == 'WOY' %} ${submission_week_of_year}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${submission_day_of_year}
+          {% elsif choose_comparison._parameter_value == 'Week' %} ${submission_week}
+          {% else %}NULL{% endif %} ;;
+
+  }
+
+  dimension: mtd_only {
+    group_label: "To-Date Filters"
+    label: "MTD"
+    view_label: "Date/Period Selection"
+    type: yesno
+    sql:  (EXTRACT(DAY FROM ${submission_date}) < EXTRACT(DAY FROM CURRENT_DATE()));;
+  }
+
+  dimension: wtd_only {
+    group_label: "To-Date Filters"
+    label: "WTD"
+    view_label: "Date/Period Selection"
+    type: yesno
+    sql:  ${submission_week_of_year} < (EXTRACT(WEEK FROM CURRENT_DATE()));;
+  }
+
+  dimension: ytd_only {
+    group_label: "To-Date Filters"
+    label: "YTD"
+    view_label: "Date/Period Selection"
+    type: yesno
+    sql:  (EXTRACT(DAYOFYEAR FROM ${submission_date}) < EXTRACT(DAYOFYEAR FROM CURRENT_DATE()));;
+  }
+
+  # Hide metric columns showing as dimensions
+  dimension: mau {
+    hidden: yes
+    sql: ${TABLE}.mau ;;
+  }
+
+  dimension: dau {
+    hidden: yes
+    sql: ${TABLE}.dau ;;
+  }
+
+  dimension: wau {
+    hidden: yes
+    sql: ${TABLE}.wau ;;
+  }
+
+  dimension: new_profiles {
+    hidden: yes
+    sql: ${TABLE}.new_profiles ;;
+  }
+
+  dimension: ad_clicks {
+    hidden: yes
+    sql: ${TABLE}.ad_clicks ;;
+  }
+
+  dimension: organic_search_count {
+    hidden: yes
+    sql: ${TABLE}.organic_search_count ;;
+  }
+
+  dimension: search_count {
+    hidden: yes
+    sql: ${TABLE}.search_count ;;
+  }
+
+  dimension: uri_count {
+    hidden: yes
+    sql: ${TABLE}.uri_count ;;
+  }
+
+  dimension: active_hours {
+    hidden: yes
+    sql: ${TABLE}.active_hours ;;
+  }
+
+  # Define measures
+  measure: daily_active_users {
+    label: "DAU"
+    type:  sum
+    sql: (${TABLE}.dau) ;;
+  }
+
+  measure: weekly_active_users {
+    label: "WAU"
+    type: sum
+    sql:  ${TABLE}.wau ;;
+  }
+
+  measure: monthly_active_users {
+    label: "MAU"
+    type: sum
+    sql:  ${TABLE}.mau ;;
+  }
+
+  measure: new_profile {
+    label: "New Profiles"
+    type: sum
+    sql:  ${TABLE}.new_profiles ;;
+  }
+
+  measure: ad_click {
+    label: "Ad clicks"
+    type: sum
+    sql:  ${TABLE}.ad_clicks ;;
+  }
+
+  measure: organic_search_counts {
+    label: "Organic Search counts"
+    type: sum
+    sql:  ${TABLE}.organic_search_count ;;
+  }
+
+  measure: search_counts {
+    label: "Search counts"
+    type: sum
+    sql:  ${TABLE}.search_count ;;
+  }
+
+  measure: search_with_ads {
+    label: "Search with Ads"
+    type: sum
+    sql:  ${TABLE}.search_with_ads ;;
+  }
+
+  measure: uri_counts {
+    label: "URI counts"
+    type: sum
+    sql:  ${TABLE}.uri_count;;
+  }
+
+  measure: active_hour {
+    label: "Active Hours"
+    type: sum
+    sql:  ${TABLE}.active_hours ;;
+  }
+
+  dimension: is_default_browser {
+    type:  string
+    case: {
+      when: {
+        sql: ${TABLE}.is_default_browser = true ;;
+        label: "yes"
+      }
+
+      when: {
+        sql: ${TABLE}.is_default_browser = false ;;
+        label: "no"
+      }
+
+      when: {
+        sql: ${TABLE}.is_default_browser is NULL ;;
+        label: "unknown"
+      }
+    }
+  }
+
+# Group dimensions in Explore
+  dimension: os {
+    sql: ${TABLE}.os ;;
+    group_label: "OS"
+  }
+  dimension: os_version {
+    sql: ${TABLE}.os_version ;;
+    group_label: "OS"
+  }
+  dimension: os_version_major {
+    sql: ${TABLE}.os_version_major ;;
+    group_label: "OS"
+  }
+  dimension: os_version_minor {
+    sql: ${TABLE}.os_version_minor ;;
+    group_label: "OS"
+  }
+}


### PR DESCRIPTION
Adding aggregate awareness to the Explore for active_users_aggregates is part of the improvements to query performance when querying from Looker.

This PR adds two aggregates:
- Current year data for dimensions used in existing Looks under Browsers / <browser_name> / Usage
- Current and last year data for common dimensions identified during the creation of active_users_aggregates
