### PR TITLE
Improve query speed active_users_aggregates

### DIFF
--- a/combined_browser_metrics/combined_browser_metrics.model.lkml
+++ b/combined_browser_metrics/combined_browser_metrics.model.lkml
@@ -20,7 +20,7 @@ explore: active_users_aggregates {
       dimensions: [active_users_aggregates.app_name, active_users_aggregates.submission_date]
       measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click, organic_search_counts, search_counts, search_with_ad, uri_counts, active_hour]
       filters: [
-        active_users_aggregates.submission_date: "after 2022/01/01"
+        active_users_aggregates.submission_date: "this year"
       ]
     }
     materialization: {
@@ -32,10 +32,10 @@ explore: active_users_aggregates {
 
   aggregate_table: rollup__active_users_aggregates_2021_common {
     query: {
-      dimensions: [active_users_aggregates.submission_date, active_users_aggregates.country, active_users_aggregates.channel, active_users_aggregates.attribution_medium]
+      dimensions: [active_users_aggregates.app_name, active_users_aggregates.submission_date, active_users_aggregates.country, active_users_aggregates.channel, active_users_aggregates.attribution_medium]
       measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click, organic_search_counts, search_counts, search_with_ad, uri_counts, active_hour]
       filters: [
-        active_users_aggregates.submission_date: "after 2021/01/01"
+        active_users_aggregates.submission_date: "2 years"
       ]
     }
 

--- a/combined_browser_metrics/combined_browser_metrics.model.lkml
+++ b/combined_browser_metrics/combined_browser_metrics.model.lkml
@@ -9,11 +9,42 @@ explore: active_users_aggregates {
     filters: [active_users_aggregates.submission_date: "this year"]
   }
 
-join: countries {
-  type: left_outer
-  relationship: one_to_one
-  sql_on: ${active_users_aggregates.country} = ${countries.code} ;;
-}
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${active_users_aggregates.country} = ${countries.code} ;;
+  }
+
+  aggregate_table: rollup__active_users_aggregates_2022_usage {
+    query: {
+      dimensions: [active_users_aggregates.app_name, active_users_aggregates.submission_date]
+      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click, organic_search_counts, search_counts, search_with_ad, uri_counts, active_hour]
+      filters: [
+        active_users_aggregates.submission_date: "after 2022/01/01"
+      ]
+    }
+    materialization: {
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
+      increment_key: active_users_aggregates.submission_date
+      increment_offset: 1
+    }
+  }
+
+  aggregate_table: rollup__active_users_aggregates_2021_common {
+    query: {
+      dimensions: [active_users_aggregates.submission_date, active_users_aggregates.country, active_users_aggregates.channel, active_users_aggregates.attribution_medium]
+      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click, organic_search_counts, search_counts, search_with_ad, uri_counts, active_hour]
+      filters: [
+        active_users_aggregates.submission_date: "after 2021/01/01"
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: SELECT CURRENT_DATE() ;;
+      increment_key: active_users_aggregates.submission_date
+      increment_offset: 1
+    }
+  }
 }
 
 explore: active_users_aggregates_device {
@@ -21,11 +52,11 @@ explore: active_users_aggregates_device {
     filters: [active_users_aggregates_device.submission_date: "this year"]
   }
 
-join: countries {
-  type: left_outer
-  relationship: one_to_one
-  sql_on: ${active_users_aggregates_device.country} = ${countries.code} ;;
-}
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${active_users_aggregates_device.country} = ${countries.code} ;;
+  }
 }
 
 explore: active_users_aggregates_attribution {


### PR DESCRIPTION
Adding aggregate awareness to the Explore for active_users_aggregates is one of the improvements to query performance when querying from Looker.

This PR adds two aggregates:

    Current year data for dimensions used in existing Looks under Browsers / <browser_name> / Usage
    Current and last year data for common dimensions identified during the creation of active_users_aggregates

