### PR TITLE
RS-399 add mobile data and additional dimensions to bizdev_search_core_users view

### DIFF
--- a/search/views/bizdev_search_core_users.view.lkml
+++ b/search/views/bizdev_search_core_users.view.lkml
@@ -27,7 +27,7 @@ view: bizdev_search_core_users {
             DATE_TRUNC(submission_date, MONTH) as month,
             "desktop" as device,
             normalized_engine,
-            "desktop" as normalized_app_name,
+            '' as normalized_app_name,
             os,
             country,
             count(DISTINCT submission_date) AS days_of_use,

--- a/search/views/bizdev_search_core_users.view.lkml
+++ b/search/views/bizdev_search_core_users.view.lkml
@@ -55,6 +55,21 @@ view: bizdev_search_core_users {
     sql: ${TABLE}.country ;;
   }
 
+  dimension: device {
+    type: string
+    sql: ${TABLE}.device ;;
+  }
+
+  dimension: normalized_app_name {
+    type: string
+    sql: ${TABLE}.normalized_app_name ;;
+  }
+
+  dimension: os {
+    type: string
+    sql: ${TABLE}.os ;;
+  }
+
   dimension: normalized_engine {
     type: string
     sql: ${TABLE}.normalized_engine ;;

--- a/search/views/bizdev_search_core_users.view.lkml
+++ b/search/views/bizdev_search_core_users.view.lkml
@@ -4,20 +4,38 @@ view: bizdev_search_core_users {
     increment_offset: 1
     sql_trigger_value: SELECT DATE_TRUNC(CURRENT_DATE(), MONTH)  ;;
     sql: SELECT
-              client_id,
-              DATE_TRUNC(submission_date, MONTH) as month,
-              normalized_engine,
-              country,
-              count(DISTINCT submission_date) AS days_of_use,
-              COALESCE(SUM(sap), 0) AS searches,
-              COALESCE(SUM(search_with_ads), 0) AS search_with_ads,
-              COALESCE(SUM(ad_click), 0) AS ad_click
-         FROM
-              search.search_clients_engines_sources_daily
-        WHERE
-            {% incrementcondition %} submission_date {%  endincrementcondition %}
+            client_id,
+            DATE_TRUNC(submission_date, MONTH) as month,
+            "mobile" as device,
+            normalized_engine,
+            normalized_app_name,
+            os,
+            country,
+            COUNT(DISTINCT submission_date) AS days_of_use,
+            COALESCE(SUM(sap), 0) AS searches,
+            COALESCE(SUM(search_with_ads), 0) AS search_with_ads,
+            COALESCE(SUM(ad_click), 0) AS ad_click
+            FROM search.mobile_search_clients_engines_sources_daily
+            WHERE {% incrementcondition %} submission_date {% endincrementcondition %}
+            AND submission_date >= DATE("2020-01-01")
+            GROUP BY 1, 2, 3, 4, 5, 6, 7
+
+        UNION ALL
+
+        SELECT
+            client_id,
+            DATE_TRUNC(submission_date, MONTH) as month,
+            "desktop" as device,
+            normalized_engine,
+            "desktop" as normalized_app_name,
+            os,
+            country,
+            count(DISTINCT submission_date) AS days_of_use,
+            COALESCE(SUM(sap), 0) AS searches,
+            FROM search.search_clients_engines_sources_daily
+            WHERE {% incrementcondition %} submission_date {% endincrementcondition %}
             AND submission_date >= DATE("2019-01-01")
-         GROUP BY 1, 2, 3, 4
+            GROUP BY 1, 2, 3, 4, 5, 6, 7
        ;;
   }
 

--- a/search/views/bizdev_search_core_users.view.lkml
+++ b/search/views/bizdev_search_core_users.view.lkml
@@ -1,8 +1,5 @@
 view: bizdev_search_core_users {
   derived_table: {
-    increment_key: "submission_month"
-    increment_offset: 1
-    sql_trigger_value: SELECT DATE_TRUNC(CURRENT_DATE(), MONTH)  ;;
     sql: SELECT
             client_id,
             DATE_TRUNC(submission_date, MONTH) as month,
@@ -27,15 +24,18 @@ view: bizdev_search_core_users {
             DATE_TRUNC(submission_date, MONTH) as month,
             "desktop" as device,
             normalized_engine,
-            '' as normalized_app_name,
+            'Firefox Desktop' as normalized_app_name,
             os,
             country,
             count(DISTINCT submission_date) AS days_of_use,
             COALESCE(SUM(sap), 0) AS searches,
+            COALESCE(SUM(search_with_ads), 0) AS search_with_ads,
+            COALESCE(SUM(ad_click), 0) AS ad_click
             FROM search.search_clients_engines_sources_daily
             WHERE {% incrementcondition %} submission_date {% endincrementcondition %}
             AND submission_date >= DATE("2019-01-01")
             GROUP BY 1, 2, 3, 4, 5, 6, 7
+
        ;;
   }
 


### PR DESCRIPTION
Implements https://mozilla-hub.atlassian.net/browse/RS-399

Request from BD team to add device, os, normalized_app_name to the dimensions in the `bizdev_search_core_users.view`
Also, adds mobile data (`search.mobile_search_clients_engines_sources_daily`) to the view 