### PR TITLE
Firefox for Families: add campaign forecast data 

### DIFF
--- a/marketing/explores/firefox_for_families_forecasted_expectations.explore.lkml
+++ b/marketing/explores/firefox_for_families_forecasted_expectations.explore.lkml
@@ -1,0 +1,10 @@
+include: "//looker-hub/marketing/views/firefox_for_families_forecasted_expectations.view.lkml"
+
+explore: firefox_for_families_forecasted_expectations {
+  view_name: firefox_for_families_forecasted_expectations
+
+  always_filter: {
+    filters: [Country_Group: "-EMPTY",
+              Metric: "-EMPTY"]
+  }
+}

--- a/marketing/marketing.model.lkml
+++ b/marketing/marketing.model.lkml
@@ -2,3 +2,4 @@ connection: "telemetry"
 label: "Marketing"
 
 include: "explores/*"
+include: "views/*"

--- a/marketing/views/firefox_for_families_forecasted_expectations.view.lkml
+++ b/marketing/views/firefox_for_families_forecasted_expectations.view.lkml
@@ -1,0 +1,35 @@
+include: "//looker-hub/marketing/views/firefox_for_families_forecasted_expectations.view.lkml"
+
+
+view: +firefox_for_families_forecasted_expectations {
+
+  dimension: Country_Group {
+    label: "Campaign Countries"
+  }
+
+  dimension: Value {
+    hidden: yes
+  }
+
+  dimension_group: Date {
+    hidden: yes
+  }
+
+  dimension_group: submission {
+    sql: CAST(${TABLE}.Date AS DATE);;
+    type: time
+    timeframes: [
+      month,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+
+  measure: forecasted_value {
+    type: sum
+    sql: CAST(${Value} AS NUMERIC) ;;
+  }
+
+}


### PR DESCRIPTION
For campaign monitoring purposes, as relates to [RS-409](https://mozilla-hub.atlassian.net/browse/RS-409) 
