### PR TITLE
Add submission_date to the list of fields for aggregate

### DIFF
--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -14,7 +14,7 @@ explore: active_users_aggregates {
 
   aggregate_table: rollup__period_over_period {
     query: {
-      dimensions: [period_over_period_pivot, period_over_period_row, active_users_aggregates.app_name]
+      dimensions: [period_over_period_pivot, period_over_period_row, active_users_aggregates.app_name, active_users_aggregates.submission_date]
       measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click, organic_search_counts, search_counts, search_with_ad, uri_counts, active_hour]
       filters: [
         active_users_aggregates.choose_breakdown: "Month^_Day",


### PR DESCRIPTION
The definition of the aggregate awareness for period over period based on active_users_aggregates could not update the aggregate because the submission_date was not part of the list of fields.

It was initially not retrieved by the LookML generated by Looker, so it is added manually in this PR.

The original error was:  `Unrecognized name: active_users_aggregates_submission_date at [1:52]`