### PR TITLE
Add desktop_mobile_search_monthly view

### DIFF
--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -30,14 +30,14 @@ explore: +mobile_search_counts {
 explore: desktop_search_alert_latest_daily {}
 
 explore: business_development_core_search_users_monthly {
-  view_name: bizdev_search_core_users
+  view_name: desktop_mobile_search_clients_monthly
 
-  aggregate_table: rollup__bizdev_search_core_users_last_month {
+  aggregate_table: rollup__desktop_mobile_search_clients_monthly_last_month {
     query: {
-      dimensions: [bizdev_search_core_users.days_of_use_bucket, bizdev_search_core_users.ad_click_bucket, bizdev_search_core_users.country, bizdev_search_core_users.normalized_engine, bizdev_search_core_users.submission_month]
-      measures: [bizdev_search_core_users.ad_clicks, bizdev_search_core_users.clients, bizdev_search_core_users.searches]
+      dimensions: [desktop_mobile_search_clients_monthly.days_of_use_bucket, desktop_mobile_search_clients_monthly.ad_click_bucket, desktop_mobile_search_clients_monthly.country, desktop_mobile_search_clients_monthly.normalized_engine, desktop_mobile_search_clients_monthly.submission_month]
+      measures: [desktop_mobile_search_clients_monthly.total_ad_clicks, desktop_mobile_search_clients_monthly.clients, desktop_mobile_search_clients_monthly.total_searches]
       filters: [
-        bizdev_search_core_users.submission_month: "1 months ago for 1 months"
+        desktop_mobile_search_clients_monthly.submission_month: "1 months ago for 1 months"
       ]
     }
 
@@ -47,13 +47,13 @@ explore: business_development_core_search_users_monthly {
 
   }
 
-  aggregate_table: rollup__bizdev_search_core_users_clients {
+  aggregate_table: rollup__desktop_mobile_search_clients_monthly_clients {
     query: {
-      dimensions: [bizdev_search_core_users.submission_month, bizdev_search_core_users.days_of_use_bucket]
-      measures: [bizdev_search_core_users.clients]
+      dimensions: [desktop_mobile_search_clients_monthly.submission_month, desktop_mobile_search_clients_monthly.days_of_use_bucket]
+      measures: [desktop_mobile_search_clients_monthly.approx_clients]
       filters: [
-        bizdev_search_core_users.country: "US",
-        bizdev_search_core_users.normalized_engine: "Google"
+        desktop_mobile_search_clients_monthly.country: "US",
+        desktop_mobile_search_clients_monthly.normalized_engine: "Google"
       ]
     }
 
@@ -62,13 +62,13 @@ explore: business_development_core_search_users_monthly {
     }
   }
 
-  aggregate_table: rollup__bizdev_search_core_users_ad_click_bucket {
+  aggregate_table: rollup__desktop_mobile_search_clients_monthly_ad_click_bucket {
     query: {
-      dimensions: [bizdev_search_core_users.submission_month, bizdev_search_core_users.ad_click_bucket]
-      measures: [bizdev_search_core_users.clients]
+      dimensions: [desktop_mobile_search_clients_monthly.submission_month, desktop_mobile_search_clients_monthly.ad_click_bucket]
+      measures: [desktop_mobile_search_clients_monthly.clients]
       filters: [
-        bizdev_search_core_users.country: "US",
-        bizdev_search_core_users.normalized_engine: "Google"
+        desktop_mobile_search_clients_monthly.country: "US",
+        desktop_mobile_search_clients_monthly.normalized_engine: "Google"
       ]
     }
 

--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -21,7 +21,7 @@ explore: business_development_core_search_users_monthly {
   aggregate_table: rollup__desktop_mobile_search_clients_monthly_last_month {
     query: {
       dimensions: [desktop_mobile_search_clients_monthly.days_of_use_bucket, desktop_mobile_search_clients_monthly.ad_click_bucket, desktop_mobile_search_clients_monthly.country, desktop_mobile_search_clients_monthly.normalized_engine, desktop_mobile_search_clients_monthly.submission_month]
-      measures: [desktop_mobile_search_clients_monthly.total_ad_clicks, desktop_mobile_search_clients_monthly.clients, desktop_mobile_search_clients_monthly.total_searches]
+      measures: [desktop_mobile_search_clients_monthly.total_ad_clicks, desktop_mobile_search_clients_monthly.approx_clients, desktop_mobile_search_clients_monthly.total_searches]
       filters: [
         desktop_mobile_search_clients_monthly.submission_month: "1 months ago for 1 months"
       ]
@@ -51,7 +51,7 @@ explore: business_development_core_search_users_monthly {
   aggregate_table: rollup__desktop_mobile_search_clients_monthly_ad_click_bucket {
     query: {
       dimensions: [desktop_mobile_search_clients_monthly.submission_month, desktop_mobile_search_clients_monthly.ad_click_bucket]
-      measures: [desktop_mobile_search_clients_monthly.clients]
+      measures: [desktop_mobile_search_clients_monthly.approx_clients]
       filters: [
         desktop_mobile_search_clients_monthly.country: "US",
         desktop_mobile_search_clients_monthly.normalized_engine: "Google"

--- a/search/views/bizdev_search_core_users.view.lkml
+++ b/search/views/bizdev_search_core_users.view.lkml
@@ -1,46 +1,13 @@
 view: bizdev_search_core_users {
   derived_table: {
     sql: SELECT
-            client_id,
-            DATE_TRUNC(submission_date, MONTH) as month,
-            "mobile" as device,
-            normalized_engine,
-            normalized_app_name,
-            os,
-            country,
-            COUNT(DISTINCT submission_date) AS days_of_use,
-            COALESCE(SUM(sap), 0) AS searches,
-            COALESCE(SUM(search_with_ads), 0) AS search_with_ads,
-            COALESCE(SUM(ad_click), 0) AS ad_click
-            FROM search.mobile_search_clients_engines_sources_daily
-            WHERE {% incrementcondition %} submission_date {% endincrementcondition %}
-            AND submission_date >= DATE("2020-01-01")
-            GROUP BY 1, 2, 3, 4, 5, 6, 7
-
-        UNION ALL
-
-        SELECT
-            client_id,
-            DATE_TRUNC(submission_date, MONTH) as month,
-            "desktop" as device,
-            normalized_engine,
-            'Firefox Desktop' as normalized_app_name,
-            os,
-            country,
-            count(DISTINCT submission_date) AS days_of_use,
-            COALESCE(SUM(sap), 0) AS searches,
-            COALESCE(SUM(search_with_ads), 0) AS search_with_ads,
-            COALESCE(SUM(ad_click), 0) AS ad_click
-            FROM search.search_clients_engines_sources_daily
-            WHERE {% incrementcondition %} submission_date {% endincrementcondition %}
-            AND submission_date >= DATE("2019-01-01")
-            GROUP BY 1, 2, 3, 4, 5, 6, 7
-
+           *
+         FROM `mozdata.search.desktop_mobile_search_clients_monthly_v1`
        ;;
   }
 
   dimension_group: submission {
-    sql: ${TABLE}.month ;;
+    sql: ${TABLE}.submission_month ;;
     type: time
     timeframes: [
       month,

--- a/search/views/bizdev_search_core_users.view.lkml
+++ b/search/views/bizdev_search_core_users.view.lkml
@@ -2,7 +2,7 @@ view: bizdev_search_core_users {
   derived_table: {
     sql: SELECT
            *
-         FROM `mozdata.search.desktop_mobile_search_clients_monthly_v1`
+         FROM `mozdata.search.desktop_mobile_search_clients_monthly`
        ;;
   }
 

--- a/search/views/desktop_mobile_search_clients_monthly.view.lkml
+++ b/search/views/desktop_mobile_search_clients_monthly.view.lkml
@@ -1,11 +1,6 @@
-view: bizdev_search_core_users {
-  derived_table: {
-    sql: SELECT
-           *
-         FROM `mozdata.search.desktop_mobile_search_clients_monthly`
-       ;;
-  }
+include: "//looker-hub/search/views/desktop_mobile_search_clients_monthly.view.lkml"
 
+view: +desktop_mobile_search_clients_monthly {
   dimension_group: submission {
     sql: ${TABLE}.submission_month ;;
     type: time
@@ -15,31 +10,6 @@ view: bizdev_search_core_users {
     ]
     convert_tz: no
     datatype: date
-  }
-
-  dimension: country {
-    type: string
-    sql: ${TABLE}.country ;;
-  }
-
-  dimension: device {
-    type: string
-    sql: ${TABLE}.device ;;
-  }
-
-  dimension: normalized_app_name {
-    type: string
-    sql: ${TABLE}.normalized_app_name ;;
-  }
-
-  dimension: os {
-    type: string
-    sql: ${TABLE}.os ;;
-  }
-
-  dimension: normalized_engine {
-    type: string
-    sql: ${TABLE}.normalized_engine ;;
   }
 
   dimension: ad_click_bucket {
@@ -59,28 +29,42 @@ view: bizdev_search_core_users {
           END ;;
   }
 
-  measure: searches {
+  dimension: tagged_follow_on {
+    hidden: yes
+  }
+
+  dimension: tagged_sap {
+    hidden: yes
+  }
+
+  measure: total_searches {
     type: sum
     sql: ${TABLE}.searches ;;
   }
 
-  measure: search_with_ads {
+  measure: total_search_with_ads {
     type: sum
     sql: ${TABLE}.search_with_ads ;;
   }
 
-  measure: ad_clicks {
+  measure: total_ad_clicks {
     type: sum
     sql: ${TABLE}.ad_click ;;
   }
 
-  measure: days_of_use {
+  measure: total_days_of_use {
     type: sum
     sql: ${TABLE}.days_of_use ;;
   }
 
   measure: clients {
     type: count_distinct
+    sql: ${TABLE}.client_id ;;
+  }
+
+  measure: approx_clients {
+    type: count_distinct
+    approximate: yes
     sql: ${TABLE}.client_id ;;
   }
 


### PR DESCRIPTION
In an effort to speed up [bizdev Looker dashboards](https://mozilla.cloud.looker.com/dashboards/430), a derived table has been created that contains client-level data in BQ aggregated over a month with all relevant dimensions and measures. 

Please be noted, that the table has been backfilled until 2022-01-01. Once this PR is approved , I will go ahead with backfilling the data until 2019-01-01
