### PR TITLE
Add automated KPI forecast data to Looker

### DIFF
--- a/kpi/explores/automated_KPI_confidence_intervals.explore.lkml
+++ b/kpi/explores/automated_KPI_confidence_intervals.explore.lkml
@@ -1,0 +1,12 @@
+include: "//looker-hub/kpi/views/*"
+include: "/kpi/views/*"
+
+explore: automated_KPI_confidence_intervals {
+  view_name: automated_kpi_confidence_intervals
+
+  always_filter: {
+    filters: [automated_kpi_confidence_intervals.target: "-EMPTY",
+      automated_kpi_confidence_intervals.forecast_date: "-EMPTY",
+      automated_kpi_confidence_intervals.unit: "-EMPTY"]
+  }
+}

--- a/kpi/explores/automated_KPI_forecasts.explore.lkml
+++ b/kpi/explores/automated_KPI_forecasts.explore.lkml
@@ -1,0 +1,12 @@
+include: "//looker-hub/kpi/views/*"
+include: "/kpi/views/*"
+
+explore: automated_KPI_forecasts {
+  view_name: automated_kpi_forecasts
+
+  always_filter: {
+    filters: [automated_kpi_forecasts.target: "-EMPTY",
+      automated_kpi_forecasts.forecast_date: "-EMPTY",
+      automated_kpi_forecasts.metric: "-EMPTY"]
+  }
+}

--- a/kpi/kpi.model.lkml
+++ b/kpi/kpi.model.lkml
@@ -148,6 +148,22 @@ explore: loines_browser_2022_forecasts {
   label: "Official Browser KPI Forecasts and Targets"
 }
 
-explore: automated_kpi_forecasts {}
+explore: automated_KPI_forecasts {
+  view_name: automated_kpi_forecasts
 
-explore: automated_kpi_confidence_intervals {}
+  always_filter: {
+    filters: [automated_kpi_forecasts.target: "-EMPTY",
+              automated_kpi_forecasts.forecast_date: "-EMPTY",
+              automated_kpi_forecasts.metric: "-EMPTY"]
+  }
+}
+
+explore: automated_KPI_confidence_intervals {
+  view_name: automated_kpi_confidence_intervals
+
+  always_filter: {
+    filters: [automated_kpi_confidence_intervals.target: "-EMPTY",
+      automated_kpi_confidence_intervals.forecast_date: "-EMPTY",
+      automated_kpi_confidence_intervals.unit: "-EMPTY"]
+  }
+}

--- a/kpi/kpi.model.lkml
+++ b/kpi/kpi.model.lkml
@@ -5,6 +5,7 @@ include: "//looker-hub/kpi/views/*"
 include: "./dashboards/*.dashboard"
 include: "./views/*.view.lkml"                # include all views in the views/ folder in this project
 include: "/shared/views/*"
+include: "explores/*"
 
 explore: firefox_desktop_usage_2021 {
   label: "Firefox Desktop Usage"
@@ -146,24 +147,4 @@ explore: browser_dau {
 explore: loines_browser_2022_forecasts {
   group_label: "Official Browser KPIs"
   label: "Official Browser KPI Forecasts and Targets"
-}
-
-explore: automated_KPI_forecasts {
-  view_name: automated_kpi_forecasts
-
-  always_filter: {
-    filters: [automated_kpi_forecasts.target: "-EMPTY",
-              automated_kpi_forecasts.forecast_date: "-EMPTY",
-              automated_kpi_forecasts.metric: "-EMPTY"]
-  }
-}
-
-explore: automated_KPI_confidence_intervals {
-  view_name: automated_kpi_confidence_intervals
-
-  always_filter: {
-    filters: [automated_kpi_confidence_intervals.target: "-EMPTY",
-      automated_kpi_confidence_intervals.forecast_date: "-EMPTY",
-      automated_kpi_confidence_intervals.unit: "-EMPTY"]
-  }
 }

--- a/kpi/views/Automated_KPI_Forecast_Confidence_Intervals.view.lkml
+++ b/kpi/views/Automated_KPI_Forecast_Confidence_Intervals.view.lkml
@@ -1,4 +1,4 @@
-include: "//looker-hub/kpi/views/automated_kpi_confidence_intervals.view.lkml"
+include: "//looker-hub/kpi/views/*"
 
 view: +automated_kpi_confidence_intervals {
 
@@ -12,7 +12,7 @@ view: +automated_kpi_confidence_intervals {
     }
 
   dimension_group: submission {
-    sql: ${TABLE}.date ;;
+    sql: CAST(${TABLE}.date as DATE) ;;
     type: time
     timeframes: [
       date,

--- a/kpi/views/Automated_KPI_Forecast_Confidence_Intervals.view.lkml
+++ b/kpi/views/Automated_KPI_Forecast_Confidence_Intervals.view.lkml
@@ -6,28 +6,16 @@ view: +automated_kpi_confidence_intervals {
     label: "Last Forecasted Date"
   }
 
-  dimension: date {
-    hidden: yes
-    sql: ${TABLE}.date ;;
-    }
-
   dimension_group: submission {
-    sql: CAST(${TABLE}.date as DATE) ;;
+    timeframes: [month]
     type: time
-    timeframes: [
-      date,
-      month,
-      month_name,
-      quarter,
-      year,
-    ]
     convert_tz: no
-    datatype: date
+    sql: CAST(${TABLE}.date AS DATE) ;;
   }
 
   dimension: forecast_date {
     label: "Forecast Run Date"
-    }
+  }
 
   dimension: value {
     hidden:  yes
@@ -36,7 +24,7 @@ view: +automated_kpi_confidence_intervals {
 
   measure: Estimated_Value {
     type: number
-    description: "Forecasted if after forecast date, observed if before."
+    description: "Forecasted if after forecast run date, observed if before. If forecasted, this is the average of the uncertainty samples."
     sql: SUM(CAST(${TABLE}.value as NUMERIC)) ;;
   }
 

--- a/kpi/views/Automated_KPI_Forecast_Confidence_Intervals.view.lkml
+++ b/kpi/views/Automated_KPI_Forecast_Confidence_Intervals.view.lkml
@@ -1,0 +1,154 @@
+include: "//looker-hub/kpi/views/automated_kpi_confidence_intervals.view.lkml"
+
+view: +automated_kpi_confidence_intervals {
+
+  dimension: asofdate {
+    label: "Last Forecasted Date"
+  }
+
+  dimension: date {
+    hidden: yes
+    sql: ${TABLE}.date ;;
+    }
+
+  dimension_group: submission {
+    sql: ${TABLE}.date ;;
+    type: time
+    timeframes: [
+      date,
+      month,
+      month_name,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+
+  dimension: forecast_date {
+    label: "Forecast Run Date"
+    }
+
+  dimension: value {
+    hidden:  yes
+    sql: ${TABLE}.value ;;
+  }
+
+  measure: Estimated_Value {
+    type: number
+    description: "Forecasted if after forecast date, observed if before."
+    sql: SUM(CAST(${TABLE}.value as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p5 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p5 ;;
+  }
+
+  measure: Estimated_05th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p5 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p10 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p10 ;;
+  }
+
+  measure: Estimated_10th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p10 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p20 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p20 ;;
+  }
+
+  measure: Estimated_20th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p20 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p30 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p30 ;;
+  }
+
+  measure: Estimated_30th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p30 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p40 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p40 ;;
+  }
+
+  measure: Estimated_40th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p40 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p50 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p50 ;;
+  }
+
+  measure: Estimated_50th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p50 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p60 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p60 ;;
+  }
+
+  measure: Estimated_60th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p60 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p70 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p70 ;;
+  }
+
+  measure: Estimated_70th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p70 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p80 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p80 ;;
+  }
+
+  measure: Estimated_80th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p80 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p90 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p90 ;;
+  }
+
+  measure: Estimated_90th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p90 as NUMERIC)) ;;
+  }
+
+  dimension: yhat_p95 {
+    hidden:  yes
+    sql: ${TABLE}.yhat_p95 ;;
+  }
+
+  measure: Estimated_95th_Percentile{
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_p95 as NUMERIC)) ;;
+  }
+
+
+}

--- a/kpi/views/Automated_KPI_Forecasts.view.lkml
+++ b/kpi/views/Automated_KPI_Forecasts.view.lkml
@@ -1,0 +1,54 @@
+include: "//looker-hub/kpi/views/automated_kpi_forecasts.view.lkml"
+
+view: +automated_kpi_forecasts {
+
+  dimension_group: ds {
+    label: "Submission"
+    sql: ${TABLE}.ds ;;
+    type: time
+    timeframes: [
+      date,
+      month,
+      month_name,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+
+  dimension: forecast_date {
+    label: "Date of Forecast"
+  }
+
+  dimension: yhat {
+    hidden:  yes
+    sql: ${TABLE}.yhat ;;
+  }
+
+  dimension: yhat_lower {
+    hidden:  yes
+    sql: ${TABLE}.yhat_lower ;;
+  }
+
+  dimension: yhat_upper {
+    hidden:  yes
+    sql: ${TABLE}.yhat_upper ;;
+  }
+
+  measure: Forecasted_Value {
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat as NUMERIC)) ;;
+  }
+
+  measure: Forecasted_Lower_Bound {
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_lower as NUMERIC)) ;;
+  }
+
+  measure: Forecasted_Upper_Bound {
+    type: number
+    sql: SUM(CAST(${TABLE}.yhat_upper as NUMERIC)) ;;
+  }
+
+}

--- a/kpi/views/Automated_KPI_Forecasts.view.lkml
+++ b/kpi/views/Automated_KPI_Forecasts.view.lkml
@@ -1,10 +1,10 @@
-include: "//looker-hub/kpi/views/automated_kpi_forecasts.view.lkml"
+include: "//looker-hub/kpi/views/*"
 
 view: +automated_kpi_forecasts {
 
   dimension_group: ds {
     label: "Submission"
-    sql: ${TABLE}.ds ;;
+    sql: CAST(${TABLE}.ds as DATE) ;;
     type: time
     timeframes: [
       date,

--- a/kpi/views/Automated_KPI_Forecasts.view.lkml
+++ b/kpi/views/Automated_KPI_Forecasts.view.lkml
@@ -3,22 +3,18 @@ include: "//looker-hub/kpi/views/*"
 view: +automated_kpi_forecasts {
 
   dimension_group: ds {
-    label: "Submission"
-    sql: CAST(${TABLE}.ds as DATE) ;;
-    type: time
-    timeframes: [
-      date,
-      month,
-      month_name,
-      quarter,
-      year,
-    ]
+    hidden: yes
+  }
+
+  dimension: date {
+    label: "Submission Date"
+    type: date
     convert_tz: no
-    datatype: date
+    sql: CAST(${TABLE}.ds AS DATE) ;;
   }
 
   dimension: forecast_date {
-    label: "Date of Forecast"
+    label: "Forecast Run Date"
   }
 
   dimension: yhat {


### PR DESCRIPTION
Adding table with detailed view of forecast output and table with confidence interval output. Also moving this out of the model file so we have the appropriate view and explore files.