### PR TITLE
Fix the broken bizdev search dashboards

### DIFF
--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -21,7 +21,7 @@ explore: business_development_core_search_users_monthly {
   aggregate_table: rollup__bizdev_search_core_users_last_month {
     query: {
       dimensions: [bizdev_search_core_users.days_of_use_bucket, bizdev_search_core_users.ad_click_bucket, bizdev_search_core_users.country, bizdev_search_core_users.normalized_engine, bizdev_search_core_users.submission_month]
-      measures: [bizdev_search_core_users.ad_clicks, bizdev_search_core_users.clients, bizdev_search_core_users.searches]
+      measures: [bizdev_search_core_users.ad_clicks, bizdev_search_core_users.approx_clients, bizdev_search_core_users.searches]
       filters: [
         bizdev_search_core_users.submission_month: "1 months ago for 1 months"
       ]
@@ -36,7 +36,7 @@ explore: business_development_core_search_users_monthly {
   aggregate_table: rollup__bizdev_search_core_users_clients {
     query: {
       dimensions: [bizdev_search_core_users.submission_month, bizdev_search_core_users.days_of_use_bucket]
-      measures: [bizdev_search_core_users.clients]
+      measures: [bizdev_search_core_users.approx_clients]
       filters: [
         bizdev_search_core_users.country: "US",
         bizdev_search_core_users.normalized_engine: "Google"
@@ -51,7 +51,7 @@ explore: business_development_core_search_users_monthly {
   aggregate_table: rollup__bizdev_search_core_users_ad_click_bucket {
     query: {
       dimensions: [bizdev_search_core_users.submission_month, bizdev_search_core_users.ad_click_bucket]
-      measures: [bizdev_search_core_users.clients]
+      measures: [bizdev_search_core_users.approx_clients]
       filters: [
         bizdev_search_core_users.country: "US",
         bizdev_search_core_users.normalized_engine: "Google"

--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -16,14 +16,14 @@ explore: +desktop_search_counts {
 explore: desktop_search_alert_latest_daily {}
 
 explore: business_development_core_search_users_monthly {
-  view_name: desktop_mobile_search_clients_monthly
+  view_name: bizdev_search_core_users
 
-  aggregate_table: rollup__desktop_mobile_search_clients_monthly_last_month {
+  aggregate_table: rollup__bizdev_search_core_users_last_month {
     query: {
-      dimensions: [desktop_mobile_search_clients_monthly.days_of_use_bucket, desktop_mobile_search_clients_monthly.ad_click_bucket, desktop_mobile_search_clients_monthly.country, desktop_mobile_search_clients_monthly.normalized_engine, desktop_mobile_search_clients_monthly.submission_month]
-      measures: [desktop_mobile_search_clients_monthly.total_ad_clicks, desktop_mobile_search_clients_monthly.approx_clients, desktop_mobile_search_clients_monthly.total_searches]
+      dimensions: [bizdev_search_core_users.days_of_use_bucket, bizdev_search_core_users.ad_click_bucket, bizdev_search_core_users.country, bizdev_search_core_users.normalized_engine, bizdev_search_core_users.submission_month]
+      measures: [bizdev_search_core_users.ad_clicks, bizdev_search_core_users.clients, bizdev_search_core_users.searches]
       filters: [
-        desktop_mobile_search_clients_monthly.submission_month: "1 months ago for 1 months"
+        bizdev_search_core_users.submission_month: "1 months ago for 1 months"
       ]
     }
 
@@ -33,13 +33,13 @@ explore: business_development_core_search_users_monthly {
 
   }
 
-  aggregate_table: rollup__desktop_mobile_search_clients_monthly_clients {
+  aggregate_table: rollup__bizdev_search_core_users_clients {
     query: {
-      dimensions: [desktop_mobile_search_clients_monthly.submission_month, desktop_mobile_search_clients_monthly.days_of_use_bucket]
-      measures: [desktop_mobile_search_clients_monthly.approx_clients]
+      dimensions: [bizdev_search_core_users.submission_month, bizdev_search_core_users.days_of_use_bucket]
+      measures: [bizdev_search_core_users.clients]
       filters: [
-        desktop_mobile_search_clients_monthly.country: "US",
-        desktop_mobile_search_clients_monthly.normalized_engine: "Google"
+        bizdev_search_core_users.country: "US",
+        bizdev_search_core_users.normalized_engine: "Google"
       ]
     }
 
@@ -48,13 +48,13 @@ explore: business_development_core_search_users_monthly {
     }
   }
 
-  aggregate_table: rollup__desktop_mobile_search_clients_monthly_ad_click_bucket {
+  aggregate_table: rollup__bizdev_search_core_users_ad_click_bucket {
     query: {
-      dimensions: [desktop_mobile_search_clients_monthly.submission_month, desktop_mobile_search_clients_monthly.ad_click_bucket]
-      measures: [desktop_mobile_search_clients_monthly.approx_clients]
+      dimensions: [bizdev_search_core_users.submission_month, bizdev_search_core_users.ad_click_bucket]
+      measures: [bizdev_search_core_users.clients]
       filters: [
-        desktop_mobile_search_clients_monthly.country: "US",
-        desktop_mobile_search_clients_monthly.normalized_engine: "Google"
+        bizdev_search_core_users.country: "US",
+        bizdev_search_core_users.normalized_engine: "Google"
       ]
     }
 

--- a/search/views/bizdev_search_core_users.view.lkml
+++ b/search/views/bizdev_search_core_users.view.lkml
@@ -84,4 +84,10 @@ view: bizdev_search_core_users {
     sql: ${TABLE}.client_id ;;
   }
 
+  measure: approx_clients {
+    type: count_distinct
+    approximate: yes
+    sql: ${TABLE}.client_id ;;
+  }
+
 }

--- a/search/views/bizdev_search_core_users.view.lkml
+++ b/search/views/bizdev_search_core_users.view.lkml
@@ -1,6 +1,11 @@
-include: "//looker-hub/search/views/desktop_mobile_search_clients_monthly.view.lkml"
+view: bizdev_search_core_users {
+  derived_table: {
+    sql: SELECT
+           *
+         FROM `mozdata.search.desktop_mobile_search_clients_monthly`
+      ;;
+  }
 
-view: +desktop_mobile_search_clients_monthly {
   dimension_group: submission {
     sql: ${TABLE}.submission_month ;;
     type: time
@@ -10,6 +15,31 @@ view: +desktop_mobile_search_clients_monthly {
     ]
     convert_tz: no
     datatype: date
+  }
+
+  dimension: country {
+    type: string
+    sql: ${TABLE}.country ;;
+  }
+
+  dimension: device {
+    type: string
+    sql: ${TABLE}.device ;;
+  }
+
+  dimension: normalized_app_name {
+    type: string
+    sql: ${TABLE}.normalized_app_name ;;
+  }
+
+  dimension: os {
+    type: string
+    sql: ${TABLE}.os ;;
+  }
+
+  dimension: normalized_engine {
+    type: string
+    sql: ${TABLE}.normalized_engine ;;
   }
 
   dimension: ad_click_bucket {
@@ -29,42 +59,28 @@ view: +desktop_mobile_search_clients_monthly {
           END ;;
   }
 
-  dimension: tagged_follow_on {
-    hidden: yes
-  }
-
-  dimension: tagged_sap {
-    hidden: yes
-  }
-
-  measure: total_searches {
+  measure: searches {
     type: sum
     sql: ${TABLE}.searches ;;
   }
 
-  measure: total_search_with_ads {
+  measure: search_with_ads {
     type: sum
     sql: ${TABLE}.search_with_ads ;;
   }
 
-  measure: total_ad_clicks {
+  measure: ad_clicks {
     type: sum
     sql: ${TABLE}.ad_click ;;
   }
 
-  measure: total_days_of_use {
+  measure: days_of_use {
     type: sum
     sql: ${TABLE}.days_of_use ;;
   }
 
   measure: clients {
     type: count_distinct
-    sql: ${TABLE}.client_id ;;
-  }
-
-  measure: approx_clients {
-    type: count_distinct
-    approximate: yes
     sql: ${TABLE}.client_id ;;
   }
 


### PR DESCRIPTION
The [Looker dashboards](https://mozilla.cloud.looker.com/dashboards/430) are currently broken as the table calculations point to a view `bizdev search core users` that was replaced with a new search monthly view. 
Correcting this means rebuilding all the dashboards which seems time-consuming and not worth the effort. 
Hence reverting to keep the view name as `bizdev search core users`
