### PR TITLE
fixed websites/* Looker errors related to reusing field names

### DIFF
--- a/websites/views/blogs_daily_summary.view.lkml
+++ b/websites/views/blogs_daily_summary.view.lkml
@@ -1,27 +1,27 @@
 include: "//looker-hub/websites/views/blogs_daily_summary.view.lkml"
 
 view: +blogs_daily_summary {
-  measure: sessions {
-    label: "Sessions Count"
+  measure: sessions_sum {
+    label: "Sessions Sum"
     type: sum
-    sql: ${TABLE}.sessions;;
+    sql: ${sessions} ;;
   }
 
-  measure: downloads {
-    label: "Downloads Count"
+  measure: downloads_sum {
+    label: "Downloads Sum"
     type: sum
-    sql: ${TABLE}.downloads;;
+    sql: ${downloads} ;;
   }
 
-  measure: social_share {
-    label: "Social Share Count"
+  measure: social_shares_sum {
+    label: "Social Share Sum"
     type: sum
-    sql: ${TABLE}.social_share;;
+    sql: ${social_share} ;;
   }
 
-  measure: newsletter_subscription {
-    label: "Newsletter Subscription Count"
+  measure: newsletter_subscriptions_sum {
+    label: "Newsletter Subscription Sum"
     type: sum
-    sql: ${TABLE}.newsletter_subscription;;
+    sql: ${newsletter_subscription} ;;
   }
 }

--- a/websites/views/blogs_landing_page_summary.view.lkml
+++ b/websites/views/blogs_landing_page_summary.view.lkml
@@ -1,27 +1,27 @@
 include: "//looker-hub/websites/views/blogs_landing_page_summary.view.lkml"
 
 view: +blogs_landing_page_summary {
-  measure: sessions {
-    label: "Sessions Count"
+  measure: sessions_sum {
+    label: "Sessions Sum"
     type: sum
-    sql: ${TABLE}.sessions;;
+    sql: ${sessions} ;;
   }
 
-  measure: downloads {
-    label: "Downloads Count"
+  measure: downloads_sum {
+    label: "Downloads Sum"
     type: sum
-    sql: ${TABLE}.downloads;;
+    sql: ${downloads} ;;
   }
 
-  measure: social_share {
-    label: "Social Share Count"
+  measure: social_shares_sum {
+    label: "Social Share Sum"
     type: sum
-    sql: ${TABLE}.social_share;;
+    sql: ${social_share} ;;
   }
 
-  measure: newsletter_subscription {
-    label: "Newsletter Subscription Count"
+  measure: newsletter_subscriptions_sum {
+    label: "Newsletter Subscription Sum"
     type: sum
-    sql: ${TABLE}.newsletter_subscription;;
+    sql: ${newsletter_subscription} ;;
   }
 }

--- a/websites/views/moz_org_landing_page_metrics.view.lkml
+++ b/websites/views/moz_org_landing_page_metrics.view.lkml
@@ -1,51 +1,51 @@
 include: "//looker-hub/websites/views/moz_org_landing_page_metrics.view.lkml"
 
 view: +moz_org_landing_page_metrics {
-  measure: sessions {
-    label: "Session Count"
+  measure: sessions_sum {
+    label: "Session Sum"
     type: sum
-    sql: ${TABLE}.sessions;;
+    sql: ${sessions} ;;
   }
 
-  measure: non_fx_sessions {
-    label: "Non Fx session Count"
+  measure: non_fx_sessions_sum {
+    label: "Non Fx session Sum"
     type: sum
-    sql: ${TABLE}.non_fx_sessions;;
+    sql: ${non_fx_sessions} ;;
   }
 
-  measure: downloads {
-    label: "Download Count"
+  measure: downloads_sum {
+    label: "Download Sum"
     type: sum
-    sql: ${TABLE}.downloads;;
+    sql: ${downloads} ;;
   }
 
-  measure:  non_fx_downloads {
-    label: "Non-Fx Download Count"
+  measure:  non_fx_downloads_sum {
+    label: "Non-Fx Download Sum"
     type: sum
-    sql: ${TABLE}.non_fx_downloads;;
+    sql: ${non_fx_downloads} ;;
   }
 
-  measure: pageviews {
-    label: "Page View Count"
+  measure: pageviews_sum {
+    label: "Page View Sum"
     type: sum
-    sql: ${TABLE}.pageviews;;
+    sql: ${pageviews} ;;
   }
 
-  measure: unique_pageviews {
-    label: "Unique Page View Count"
+  measure: unique_pageviews_sum {
+    label: "Unique Page View Sum"
     type: sum
-    sql: ${TABLE}.unique_pageviews;;
+    sql: ${unique_pageviews} ;;
   }
 
-  measure: bounces {
-    label: "Bounce Count"
+  measure: bounces_sum {
+    label: "Bounce Sum"
     type: sum
-    sql: ${TABLE}.bounces;;
+    sql: ${bounces} ;;
   }
 
-  measure: exits {
-    label: "Exit Count"
+  measure: exits_sum {
+    label: "Exit Sum"
     type: sum
-    sql: ${TABLE}.exits;;
+    sql: ${exits} ;;
   }
 }

--- a/websites/views/moz_org_metrics_summary.view.lkml
+++ b/websites/views/moz_org_metrics_summary.view.lkml
@@ -1,27 +1,27 @@
-include: "//looker-hub/websites/views/moz_org_landing_page_metrics.view.lkml"
+include: "//looker-hub/websites/views/moz_org_metrics_summary.view.lkml"
 
-view: +moz_org_landing_page_metrics {
-  measure: sessions {
-    label: "Session Count"
+view: +moz_org_metrics_summary {
+  measure: sessions_sum {
+    label: "Session Sum"
     type: sum
-    sql: ${TABLE}.sessions;;
+    sql: ${sessions} ;;
   }
 
-  measure: non_fx_sessions {
-    label: "Non Fx session Count"
+  measure: non_fx_sessions_sum {
+    label: "Non Fx session Sum"
     type: sum
-    sql: ${TABLE}.non_fx_sessions;;
+    sql: ${non_fx_sessions} ;;
   }
 
-  measure: downloads {
-    label: "Download Count"
+  measure: downloads_sum {
+    label: "Download Sum"
     type: sum
-    sql: ${TABLE}.downloads;;
+    sql: ${downloads} ;;
   }
 
-  measure:  non_fx_downloads {
-    label: "Non-Fx Download Count"
+  measure:  non_fx_downloads_sum {
+    label: "Non-Fx Download Sum"
     type: sum
-    sql: ${TABLE}.non_fx_downloads;;
+    sql: ${non_fx_downloads} ;;
   }
 }

--- a/websites/views/moz_org_page_metrics.view.lkml
+++ b/websites/views/moz_org_page_metrics.view.lkml
@@ -1,63 +1,63 @@
 include: "//looker-hub/websites/views/moz_org_page_metrics.view.lkml"
 
 view: +moz_org_page_metrics {
-  measure: pageviews {
-    label: "Page View Count"
+  measure: pageviews_sum {
+    label: "Page View Sum"
     type: sum
-    sql: ${TABLE}.pageviews;;
+    sql: ${pageviews} ;;
   }
 
-  measure: unique_pageviews {
-    label: "Unique Page View Count"
+  measure: unique_pageviews_sum {
+    label: "Unique Page View Sum"
     type: sum
-    sql: ${TABLE}.unique_pageviews;;
+    sql: ${unique_pageviews} ;;
   }
 
-  measure: entrances {
-    label: "Entrance Count"
+  measure: entrances_sum {
+    label: "Entrance Sum"
     type: sum
-    sql: ${TABLE}.entrances;;
+    sql: ${entrances} ;;
   }
 
-  measure: exits {
-    label: "Exit Count"
+  measure: exits_sum {
+    label: "Exit Sum"
     type: sum
-    sql: ${TABLE}.exits;;
+    sql: ${exits} ;;
   }
 
-  measure: non_exit_pageviews {
-    label: "Non-Exit Page View Count"
+  measure: non_exit_pageviews_sum {
+    label: "Non-Exit Page View Sum"
     type: sum
-    sql: ${TABLE}.non_exit_pageviews;;
+    sql: ${non_exit_pageviews} ;;
   }
 
-  measure: total_events {
-    label: "Total Event Count"
+  measure: total_events_sum {
+    label: "Total Event Sum"
     type: sum
-    sql: ${TABLE}.total_events;;
+    sql: ${total_events} ;;
   }
 
-  measure: unique_events {
-    label: "Unique Event Count"
+  measure: unique_events_sum {
+    label: "Unique Event Sum"
     type: sum
-    sql: ${TABLE}.unique_events;;
+    sql: ${unique_events} ;;
   }
 
-  measure: total_time_on_page {
+  measure: total_time_on_page_average {
     label: "Average Total Time on Page"
     type: average
-    sql: ${TABLE}.total_time_on_page;;
+    sql: ${total_time_on_page} ;;
   }
 
-  measure: single_page_sessions {
-    label: "Single Page Session Count"
+  measure: single_page_sessions_sum {
+    label: "Single Page Session Sum"
     type: sum
-    sql: ${TABLE}.single_page_sessions;;
+    sql: ${single_page_sessions} ;;
   }
 
-  measure: bounces {
-    label: "Bounce Count"
+  measure: bounces_sum {
+    label: "Bounce Sum"
     type: sum
-    sql: ${TABLE}.bounces;;
+    sql: ${bounces} ;;
   }
 }


### PR DESCRIPTION
Follow up to: https://github.com/mozilla/looker-spoke-default/pull/391

Addresses errors related to reusing field name.