### PR TITLE
change the increment key to use a timestamp in fxa_flow_aggregates

### DIFF
--- a/firefox_accounts/views/fxa_flow_aggregates.view.lkml
+++ b/firefox_accounts/views/fxa_flow_aggregates.view.lkml
@@ -4,7 +4,7 @@
 view: fxa_flow_aggregates {
   derived_table: {
     interval_trigger: "24 hours"
-    increment_key: "flow_start_date"
+    increment_key: "flow_start_ts"
     # go back 2 days to allow recent flows to complete
     increment_offset: 2
     sql: WITH
@@ -95,6 +95,13 @@ view: fxa_flow_aggregates {
     convert_tz: no
     datatype: date
     sql: DATE(${TABLE}.flow_start_date);;
+  }
+
+  dimension: flow_start_ts {
+    type: date_time
+    datatype: timestamp
+    sql: TIMESTAMP(${TABLE}.flow_start_date);;
+    hidden: yes
   }
 
   dimension: entrypoint {


### PR DESCRIPTION
the issue here is that I was using a date dimension for the increment_key, but when looker uses it to decide whether to update the table, it compares it to a timestamp, which throws an error. this caused the PDT to stop building. so i workaround this by making a hidden timestamp field that looker can use to do the comparison. 