### PR TITLE
Update crashes explore

### DIFF
--- a/firefox_desktop/explores/crashes.explore.lkml
+++ b/firefox_desktop/explores/crashes.explore.lkml
@@ -18,7 +18,7 @@ explore: crash_usage {
     sql_on: ${crash_usage.country_code} = ${countries.code} ;;
   }
 
-  sql_always_where: ${crash_usage.submission_date} >= "2022-09-01" ;;
+  sql_always_where: ${crash_usage.submission_date} >= "2021-01-01" ;;
 
   always_filter: {
     filters: [

--- a/firefox_desktop/explores/crashes.explore.lkml
+++ b/firefox_desktop/explores/crashes.explore.lkml
@@ -1,10 +1,20 @@
 include: "../views/crash_usage.view.lkml"
 include: "/shared/views/countries.view.lkml"
 
+datagroup: clients_daily_joined_partitions {
+  max_cache_age: "24 hours"
+  sql_trigger:
+    SELECT MAX(last_modified_time)
+    FROM `moz-fx-data-shared-prod`.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
+    WHERE table_name = "clients_daily_joined_v1" ;;
+  label: "Clients Daily Joined Partitions"
+  description: "Updates when new partitions are added to clients_daily_joined"
+}
 
 explore: crash_usage {
   label: "Crashes"
   description: "Crash counts for Desktop Firefox, derived from the crash ping."
+  persist_with: clients_daily_joined_partitions
 
   join: buildhub {
     sql_on: ${crash_usage.version} = ${buildhub.version} AND ${crash_usage.channel} = ${buildhub.channel} ;;
@@ -67,7 +77,7 @@ explore: crash_usage {
       ]
     }
     materialization: {
-      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+      datagroup_trigger: clients_daily_joined_partitions
       increment_key: "submission_date"
     }
   }
@@ -98,7 +108,10 @@ explore: crash_usage {
     }
 
     materialization: {
-      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+      sql_trigger_value:
+        SELECT MAX(last_modified_time)
+        FROM `moz-fx-data-shared-prod`.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
+        WHERE table_name = "clients_daily_joined_v1" ;;
     }
   }
 
@@ -142,7 +155,7 @@ explore: crash_usage {
       ]
     }
     materialization: {
-      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+      datagroup_trigger: clients_daily_joined_partitions
       increment_key: "submission_date"
     }
   }
@@ -174,7 +187,7 @@ explore: crash_usage {
     }
 
     materialization: {
-      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+      datagroup_trigger: clients_daily_joined_partitions
     }
   }
 
@@ -219,7 +232,7 @@ explore: crash_usage {
       ]
     }
     materialization: {
-      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+      datagroup_trigger: clients_daily_joined_partitions
       increment_key: "submission_date"
     }
   }
@@ -251,7 +264,7 @@ explore: crash_usage {
     }
 
     materialization: {
-      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+      datagroup_trigger: clients_daily_joined_partitions
     }
   }
 }

--- a/firefox_desktop/explores/crashes.explore.lkml
+++ b/firefox_desktop/explores/crashes.explore.lkml
@@ -1,4 +1,3 @@
-include: "//looker-hub/firefox_desktop/views/crashes_daily.view.lkml"
 include: "../views/crash_usage.view.lkml"
 include: "/shared/views/countries.view.lkml"
 
@@ -6,13 +5,6 @@ include: "/shared/views/countries.view.lkml"
 explore: crash_usage {
   label: "Crashes"
   description: "Crash counts for Desktop Firefox, derived from the crash ping."
-
-  join: crashes_daily {
-    sql_on: ${crashes_daily.client_id} = ${crash_usage.client_id}
-            AND ${crashes_daily.submission_date} = ${crash_usage.submission_date} ;;
-    relationship: one_to_one
-    fields: [main_crash_count, content_crash_count, gpu_crash_count, rdd_crash_count, utility_crash_count, socket_crash_count, vr_crash_count]
-  }
 
   join: buildhub {
     sql_on: ${crash_usage.version} = ${buildhub.version} AND ${crash_usage.channel} = ${buildhub.channel} ;;
@@ -26,14 +18,240 @@ explore: crash_usage {
     sql_on: ${crash_usage.country_code} = ${countries.code} ;;
   }
 
-  sql_always_where: {% condition crash_usage.date %} TIMESTAMP(${crash_usage.submission_date}) {% endcondition %}
-    AND {% condition crash_usage.date %} TIMESTAMP(${crashes_daily.submission_date}) {% endcondition %}
-    AND {% condition crash_usage.sample_id %} ${crash_usage.sample_id_dim} {% endcondition %}
-    AND {% condition crash_usage.sample_id %} ${crashes_daily.sample_id} {% endcondition %};;
+  sql_always_where: ${crash_usage.submission_date} >= "2022-09-01" ;;
 
   always_filter: {
     filters: [
-      crash_usage.date: "28 days",
+      crash_usage.submission_date: "3 month",
+      crash_usage.ten_percent_sample: "Yes"
     ]
+  }
+
+  aggregate_table: ten_percent_daily_rollups {
+    query: {
+      dimensions: [
+        submission_date,
+        version,
+        major_version,
+        minor_version,
+        os_name,
+        channel,
+      ]
+      measures: [
+        active_hours,
+        dau_count,
+        content_crash_rate,
+        content_crashes,
+        content_crash_incidence,
+        gpu_crash_rate,
+        gpu_crashes,
+        gpu_crash_incidence,
+        main_crash_rate,
+        main_crashes,
+        main_crash_incidence,
+        rdd_crash_rate,
+        rdd_crashes,
+        rdd_crash_incidence,
+        socket_crash_rate,
+        socket_crashes,
+        utility_crash_incidence,
+        utility_crash_rate,
+        utility_crashes,
+        vr_crash_rate,
+        vr_crashes,
+        vr_crash_incidence,
+      ]
+      filters: [
+        crash_usage.days_since_build_published: "<=56",
+        crash_usage.ten_percent_sample: "Yes",
+      ]
+    }
+    materialization: {
+      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+      increment_key: "submission_date"
+    }
+  }
+
+  aggregate_table: ten_percent_build_id_rollups {
+    query: {
+      dimensions: [
+        build_id,
+        build_id_as_int,
+        channel,
+        os_name,
+      ]
+      measures: [
+        active_hours,
+        content_crash_rate,
+        gpu_crash_rate,
+        main_crash_rate,
+        rdd_crash_rate,
+        socket_crash_rate,
+        utility_crash_rate,
+        vr_crash_rate,
+      ]
+      filters: [
+        crash_usage.submission_date: "3 month",
+        crash_usage.days_since_build_published: "<=56",
+        crash_usage.ten_percent_sample: "Yes",
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+    }
+  }
+
+  aggregate_table: full_nightly_daily_rollups {
+    query: {
+      dimensions: [
+        submission_date,
+        version,
+        major_version,
+        minor_version,
+        os_name,
+      ]
+      measures: [
+        active_hours,
+        dau_count,
+        content_crash_rate,
+        content_crashes,
+        content_crash_incidence,
+        gpu_crash_rate,
+        gpu_crashes,
+        gpu_crash_incidence,
+        main_crash_rate,
+        main_crashes,
+        main_crash_incidence,
+        rdd_crash_rate,
+        rdd_crashes,
+        rdd_crash_incidence,
+        socket_crash_rate,
+        socket_crashes,
+        utility_crash_incidence,
+        utility_crash_rate,
+        utility_crashes,
+        vr_crash_rate,
+        vr_crashes,
+        vr_crash_incidence,
+      ]
+      filters: [
+        crash_usage.days_since_build_published: "<=56",
+        crash_usage.ten_percent_sample: "No",
+        crash_usage.channel: "nightly"
+      ]
+    }
+    materialization: {
+      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+      increment_key: "submission_date"
+    }
+  }
+
+  aggregate_table: full_nightly_buildid_rollups {
+    query: {
+      dimensions: [
+        build_id,
+        build_id_as_int,
+        channel,
+        os_name,
+      ]
+      measures: [
+        active_hours,
+        content_crash_rate,
+        gpu_crash_rate,
+        main_crash_rate,
+        rdd_crash_rate,
+        socket_crash_rate,
+        utility_crash_rate,
+        vr_crash_rate,
+      ]
+      filters: [
+        crash_usage.submission_date: "3 month",
+        crash_usage.days_since_build_published: "<=56",
+        crash_usage.ten_percent_sample: "No",
+        crash_usage.channel: "nightly"
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+    }
+  }
+
+
+  aggregate_table: full_beta_daily_rollups {
+    query: {
+      dimensions: [
+        submission_date,
+        version,
+        major_version,
+        minor_version,
+        os_name,
+      ]
+      measures: [
+        active_hours,
+        dau_count,
+        content_crash_rate,
+        content_crashes,
+        content_crash_incidence,
+        gpu_crash_rate,
+        gpu_crashes,
+        gpu_crash_incidence,
+        main_crash_rate,
+        main_crashes,
+        main_crash_incidence,
+        rdd_crash_rate,
+        rdd_crashes,
+        rdd_crash_incidence,
+        socket_crash_rate,
+        socket_crashes,
+        utility_crash_incidence,
+        utility_crash_rate,
+        utility_crashes,
+        vr_crash_rate,
+        vr_crashes,
+        vr_crash_incidence,
+      ]
+      filters: [
+        crash_usage.days_since_build_published: "<=56",
+        crash_usage.ten_percent_sample: "No",
+        crash_usage.channel: "beta"
+      ]
+    }
+    materialization: {
+      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+      increment_key: "submission_date"
+    }
+  }
+
+  aggregate_table: full_beta_buildid_rollups {
+    query: {
+      dimensions: [
+        build_id,
+        build_id_as_int,
+        channel,
+        os_name,
+      ]
+      measures: [
+        active_hours,
+        content_crash_rate,
+        gpu_crash_rate,
+        main_crash_rate,
+        rdd_crash_rate,
+        socket_crash_rate,
+        utility_crash_rate,
+        vr_crash_rate,
+      ]
+      filters: [
+        crash_usage.submission_date: "3 month",
+        crash_usage.days_since_build_published: "<=56",
+        crash_usage.ten_percent_sample: "No",
+        crash_usage.channel: "beta"
+      ]
+    }
+
+    materialization: {
+      sql_trigger_value: SELECT MAX(submission_date) FROM `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+    }
   }
 }


### PR DESCRIPTION
- Use clients_daily_joined_v1
- Create aggregate tables for Stability & Release dashboard

This improves usability in a few key ways.
1. Use clients_daily_joined means we don't have to join in Looker queries
2. Removing the join lets us build aggregate tables where previously we couldn't
3. Aggregate tables improve usability of the dashboard considerably