### PR TITLE
Fix health dashboard notes join

### DIFF
--- a/monitoring/monitoring.model.lkml
+++ b/monitoring/monitoring.model.lkml
@@ -56,8 +56,6 @@ explore: +structured_missing_columns {
       AND (${missing_columns_notes.document_type} IS NULL OR ${structured_missing_columns.document_type} = ${missing_columns_notes.document_type})
       AND (${missing_columns_notes.document_version} IS NULL OR ${structured_missing_columns.document_version} = ${missing_columns_notes.document_version})
       AND (${missing_columns_notes.path} IS NULL OR ${structured_missing_columns.path} = ${missing_columns_notes.path})
-      AND (${missing_columns_notes.start_date} IS NULL OR ${missing_columns_notes.start_date} <= ${structured_missing_columns.submission_date})
-      AND (${missing_columns_notes.end_date} IS NULL OR ${missing_columns_notes.end_date} >= ${structured_missing_columns.submission_date})
       AND (${missing_columns_notes.bug} IS NOT NULL OR ${missing_columns_notes.notes} IS NOT NULL);;
   }
 }
@@ -70,8 +68,7 @@ explore: +schema_error_counts {
     sql_on: (${schema_errors_notes.document_namespace} IS NULL OR ${schema_error_counts.document_namespace} = ${schema_errors_notes.document_namespace})
       AND (${schema_errors_notes.document_type} IS NULL OR ${schema_error_counts.document_type} = ${schema_errors_notes.document_type})
       AND (${schema_errors_notes.path} IS NULL OR ${schema_error_counts.path} = ${schema_errors_notes.path})
-      AND (${schema_errors_notes.start_date} IS NULL OR ${schema_errors_notes.start_date} <= ${schema_error_counts.submission_date})
-      AND (${schema_errors_notes.end_date} IS NULL OR ${schema_errors_notes.end_date} >= ${schema_error_counts.submission_date});;
+      AND (${schema_errors_notes.bug} IS NOT NULL OR ${schema_errors_notes.notes} IS NOT NULL);;
   }
 }
 
@@ -84,8 +81,6 @@ explore: +telemetry_missing_columns {
       AND (${missing_columns_notes.document_type} IS NULL OR ${telemetry_missing_columns.document_type} = ${missing_columns_notes.document_type})
       AND (${missing_columns_notes.document_version} IS NULL OR ${telemetry_missing_columns.document_version} = ${missing_columns_notes.document_version})
       AND (${missing_columns_notes.path} IS NULL OR ${telemetry_missing_columns.path} = ${missing_columns_notes.path})
-      AND (${missing_columns_notes.start_date} IS NULL OR ${missing_columns_notes.start_date} <= ${telemetry_missing_columns.submission_date})
-      AND (${missing_columns_notes.end_date} IS NULL OR ${missing_columns_notes.end_date} >= ${telemetry_missing_columns.submission_date})
       AND (${missing_columns_notes.bug} IS NOT NULL OR ${missing_columns_notes.notes} IS NOT NULL);;
   }
 }
@@ -95,8 +90,6 @@ explore: +distinct_docids {
     relationship: many_to_one
     sql_on: (${distinct_docids_notes.document_namespace} IS NULL OR ${distinct_docids.namespace} = ${distinct_docids_notes.document_namespace})
       AND (${distinct_docids_notes.document_type} IS NULL OR ${distinct_docids.doc_type} = ${distinct_docids_notes.document_type})
-      AND (${distinct_docids_notes.start_date} IS NULL OR ${distinct_docids_notes.start_date} <= ${distinct_docids.submission_date})
-      AND (${distinct_docids_notes.end_date} IS NULL OR ${distinct_docids_notes.end_date} >= ${distinct_docids.submission_date})
       AND (${distinct_docids_notes.notes} IS NOT NULL OR ${distinct_docids_notes.bug} IS NOT NULL);;
   }
 }


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
