### PR TITLE
Allow wildcards in health queries

### DIFF
--- a/monitoring/monitoring.model.lkml
+++ b/monitoring/monitoring.model.lkml
@@ -52,10 +52,10 @@ explore: +structured_missing_columns {
 
   join: missing_columns_notes {
     relationship: many_to_one
-    sql_on: (${missing_columns_notes.document_namespace} IS NULL OR ${structured_missing_columns.document_namespace} = ${missing_columns_notes.document_namespace})
-      AND (${missing_columns_notes.document_type} IS NULL OR ${structured_missing_columns.document_type} = ${missing_columns_notes.document_type})
-      AND (${missing_columns_notes.document_version} IS NULL OR ${structured_missing_columns.document_version} = ${missing_columns_notes.document_version})
-      AND (${missing_columns_notes.path} IS NULL OR ${structured_missing_columns.path} = ${missing_columns_notes.path})
+    sql_on: (${missing_columns_notes.document_namespace} IS NULL OR ${structured_missing_columns.document_namespace} LIKE ${missing_columns_notes.document_namespace})
+      AND (${missing_columns_notes.document_type} IS NULL OR ${structured_missing_columns.document_type} LIKE ${missing_columns_notes.document_type})
+      AND (${missing_columns_notes.document_version} IS NULL OR ${structured_missing_columns.document_version} LIKE ${missing_columns_notes.document_version})
+      AND (${missing_columns_notes.path} IS NULL OR ${structured_missing_columns.path} LIKE ${missing_columns_notes.path})
       AND (${missing_columns_notes.bug} IS NOT NULL OR ${missing_columns_notes.notes} IS NOT NULL);;
   }
 }
@@ -65,9 +65,9 @@ explore: +schema_error_counts {
 
   join: schema_errors_notes {
     relationship: many_to_one
-    sql_on: (${schema_errors_notes.document_namespace} IS NULL OR ${schema_error_counts.document_namespace} = ${schema_errors_notes.document_namespace})
-      AND (${schema_errors_notes.document_type} IS NULL OR ${schema_error_counts.document_type} = ${schema_errors_notes.document_type})
-      AND (${schema_errors_notes.path} IS NULL OR ${schema_error_counts.path} = ${schema_errors_notes.path})
+    sql_on: (${schema_errors_notes.document_namespace} IS NULL OR ${schema_error_counts.document_namespace} LIKE ${schema_errors_notes.document_namespace})
+      AND (${schema_errors_notes.document_type} IS NULL OR ${schema_error_counts.document_type} LIKE ${schema_errors_notes.document_type})
+      AND (${schema_errors_notes.path} IS NULL OR ${schema_error_counts.path} LIKE ${schema_errors_notes.path})
       AND (${schema_errors_notes.bug} IS NOT NULL OR ${schema_errors_notes.notes} IS NOT NULL);;
   }
 }
@@ -77,10 +77,10 @@ explore: +telemetry_missing_columns {
 
   join: missing_columns_notes {
     relationship: many_to_one
-    sql_on: (${missing_columns_notes.document_namespace} IS NULL OR ${telemetry_missing_columns.document_namespace} = ${missing_columns_notes.document_namespace})
-      AND (${missing_columns_notes.document_type} IS NULL OR ${telemetry_missing_columns.document_type} = ${missing_columns_notes.document_type})
-      AND (${missing_columns_notes.document_version} IS NULL OR ${telemetry_missing_columns.document_version} = ${missing_columns_notes.document_version})
-      AND (${missing_columns_notes.path} IS NULL OR ${telemetry_missing_columns.path} = ${missing_columns_notes.path})
+    sql_on: (${missing_columns_notes.document_namespace} IS NULL OR ${telemetry_missing_columns.document_namespace} LIKE ${missing_columns_notes.document_namespace})
+      AND (${missing_columns_notes.document_type} IS NULL OR ${telemetry_missing_columns.document_type} LIKE ${missing_columns_notes.document_type})
+      AND (${missing_columns_notes.document_version} IS NULL OR ${telemetry_missing_columns.document_version} LIKE ${missing_columns_notes.document_version})
+      AND (${missing_columns_notes.path} IS NULL OR ${telemetry_missing_columns.path} LIKE ${missing_columns_notes.path})
       AND (${missing_columns_notes.bug} IS NOT NULL OR ${missing_columns_notes.notes} IS NOT NULL);;
   }
 }
@@ -88,8 +88,8 @@ explore: +telemetry_missing_columns {
 explore: +distinct_docids {
   join: distinct_docids_notes {
     relationship: many_to_one
-    sql_on: (${distinct_docids_notes.document_namespace} IS NULL OR ${distinct_docids.namespace} = ${distinct_docids_notes.document_namespace})
-      AND (${distinct_docids_notes.document_type} IS NULL OR ${distinct_docids.doc_type} = ${distinct_docids_notes.document_type})
+    sql_on: (${distinct_docids_notes.document_namespace} IS NULL OR ${distinct_docids.namespace} LIKE ${distinct_docids_notes.document_namespace})
+      AND (${distinct_docids_notes.document_type} IS NULL OR ${distinct_docids.doc_type} LIKE ${distinct_docids_notes.document_type})
       AND (${distinct_docids_notes.notes} IS NOT NULL OR ${distinct_docids_notes.bug} IS NOT NULL);;
   }
 }
@@ -98,9 +98,9 @@ explore: +missing_namespaces_and_document_types {
   hidden: yes
   join: missing_document_namespaces_notes {
     relationship: many_to_one
-    sql_on: (${missing_document_namespaces_notes.document_namespace} IS NULL OR ${missing_namespaces_and_document_types.document_namespace} = ${missing_document_namespaces_notes.document_namespace})
-      AND (${missing_document_namespaces_notes.document_type} IS NULL OR ${missing_namespaces_and_document_types.document_type} = ${missing_document_namespaces_notes.document_type})
-      AND (${missing_document_namespaces_notes.document_version} IS NULL OR ${missing_namespaces_and_document_types.document_version} = ${missing_document_namespaces_notes.document_version})
+    sql_on: (${missing_document_namespaces_notes.document_namespace} IS NULL OR ${missing_namespaces_and_document_types.document_namespace} LIKE ${missing_document_namespaces_notes.document_namespace})
+      AND (${missing_document_namespaces_notes.document_type} IS NULL OR ${missing_namespaces_and_document_types.document_type} LIKE ${missing_document_namespaces_notes.document_type})
+      AND (${missing_document_namespaces_notes.document_version} IS NULL OR ${missing_namespaces_and_document_types.document_version} LIKE ${missing_document_namespaces_notes.document_version})
       AND (${missing_document_namespaces_notes.notes} IS NOT NULL OR ${missing_document_namespaces_notes.bug} IS NOT NULL);;
   }
 }


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
