### PR TITLE
do not make fxa_flow_aggregates incremental

### DIFF
--- a/firefox_accounts/views/fxa_flow_aggregates.view.lkml
+++ b/firefox_accounts/views/fxa_flow_aggregates.view.lkml
@@ -3,10 +3,7 @@
 
 view: fxa_flow_aggregates {
   derived_table: {
-    interval_trigger: "24 hours"
-    increment_key: "flow_start_ts"
-    # go back 2 days to allow recent flows to complete
-    increment_offset: 2
+    sql_trigger_value: SELECT CURRENT_DATE() ;;
     sql: WITH
           flow_ids AS (
               SELECT
@@ -95,13 +92,6 @@ view: fxa_flow_aggregates {
     convert_tz: no
     datatype: date
     sql: DATE(${TABLE}.flow_start_date);;
-  }
-
-  dimension: flow_start_ts {
-    type: date_time
-    datatype: timestamp
-    sql: TIMESTAMP(${TABLE}.flow_start_date);;
-    hidden: yes
   }
 
   dimension: entrypoint {

--- a/firefox_accounts/views/fxa_flow_aggregates.view.lkml
+++ b/firefox_accounts/views/fxa_flow_aggregates.view.lkml
@@ -3,7 +3,9 @@
 
 view: fxa_flow_aggregates {
   derived_table: {
-    sql_trigger_value: SELECT CURRENT_DATE() ;;
+    interval_trigger: "24 hours"
+    increment_key: "flow_start_date"
+    increment_offset: 2
     sql: WITH
           flow_ids AS (
               SELECT
@@ -36,7 +38,7 @@ view: fxa_flow_aggregates {
           f.browser_name,
           f.browser_version,
           f.os_name,
-          f.flow_start_date,
+          TIMESTAMP(f.flow_start_date) AS flow_start_date,
           e.event_type,
           COUNT(*) as n_events
         FROM flow_ids f
@@ -77,6 +79,7 @@ view: fxa_flow_aggregates {
         COUNTIF(event_type = 'fxa_reg - complete') AS registrations_complete,
         COUNTIF(event_type = 'fxa_login - complete') AS logins_complete,
       FROM flow_agg
+      WHERE {% incrementcondition %} flow_start_date {% endincrementcondition %}
       GROUP BY 1,2,3,4,5,6,7,8,9,10;;
   }
   dimension_group: flow_start {


### PR DESCRIPTION
I noticed that my incrementing scheme on this table isn't working, leading to duplication and appending of already existing rows - this leads to inflated numbers when the table is aggregated by the user. so this just rebuilds the whole table every new day now.

I'm not 100% sure what is going on. my understanding, clearly wrong, of what was going was that every 24 hours based on the `flow_start_ts` column, the table would be rebuilt for the previous 2 x 24 hours or 2 days. 

before that, I tried using the flow_start_date column as the `increment_key` with an `increment_offset` of 2. however, that threw an error when the table attempted to update because of an invalid comparison between a TIMESTAMP and DATE. 

my guess is that either the increment offset of `2` is actually being read as "2 HOURS", or there is something else going on.

@ANich can you help me understand the error of my ways here?

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
