### PR TITLE
change flow_start to timestamp

### DIFF
--- a/firefox_accounts/views/fxa_flow_aggregates.view.lkml
+++ b/firefox_accounts/views/fxa_flow_aggregates.view.lkml
@@ -93,8 +93,8 @@ view: fxa_flow_aggregates {
       year
     ]
     convert_tz: no
-    datatype: date
-    sql: DATE(${TABLE}.flow_start_date);;
+    datatype: timestamp
+    sql: ${TABLE}.flow_start_date;;
   }
 
   dimension: entrypoint {


### PR DESCRIPTION
This is a follow onto https://github.com/mozilla/looker-spoke-default/pull/441 I think once this is fixed, it will finally work. 

was getting:

```SQL Error in incremental PDT: Query execution failed:  - No matching signature for operator >= for argument types: TIMESTAMP, DATE. Supported signature: ANY >= ANY at [75:15]```

I was able to rebuild the table in dev mode after making this change. 
