### PR TITLE
DENG-444 Remove PoP aggregate awareness

### DIFF
--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -12,24 +12,6 @@ explore: active_users_aggregates {
     sql_on: ${active_users_aggregates.country} = ${countries.code} ;;
   }
 
-  aggregate_table: rollup__period_over_period {
-    query: {
-      dimensions: [period_over_period_pivot, period_over_period_row, active_users_aggregates.app_name, active_users_aggregates.submission_date]
-      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click, organic_search_counts, search_counts, search_with_ad, uri_counts, active_hour]
-      filters: [
-        active_users_aggregates.choose_breakdown: "Month^_Day",
-        active_users_aggregates.choose_comparison: "Year",
-        active_users_aggregates.submission_date: "after 2021/01/01",
-        active_users_aggregates.ytd_only: "Yes"
-      ]
-    }
-
-    materialization: {
-      sql_trigger_value: SELECT CURRENT_DATE() ;;
-      increment_key: active_users_aggregates.submission_date
-      increment_offset: 1
-    }
-  }
   aggregate_table: rollup__active_users_aggregates_2022_usage {
     query: {
       dimensions: [active_users_aggregates.app_name, active_users_aggregates.submission_date]


### PR DESCRIPTION
This PR removes the aggregate awareness definition for period over period from the active_users_aggregates explore,  because it is not working correctly when the user changes the date filter.

More details in the [Jira story](https://mozilla-hub.atlassian.net/jira/software/c/projects/DENG/boards/465?modal=detail&selectedIssue=DENG-444&quickFilter=2143).


Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
