### PR TITLE
Add measures to adm_clients_daily explores

### DIFF
--- a/firefox_desktop/explores/sponsored_tiles_clients_daily.explore.lkml
+++ b/firefox_desktop/explores/sponsored_tiles_clients_daily.explore.lkml
@@ -1,0 +1,11 @@
+include: "//looker-hub/firefox_desktop/views/*"
+include: "/firefox_desktop/views/*"
+
+explore: sponsored_tiles_clients_daily {
+  view_name: sponsored_tiles_clients_daily
+
+  always_filter: {
+    filters: [sponsored_tiles_clients_daily.submission_date: "28 days"
+      ]
+  }
+}

--- a/firefox_desktop/explores/suggest_clients_daily.explore.lkml
+++ b/firefox_desktop/explores/suggest_clients_daily.explore.lkml
@@ -1,0 +1,11 @@
+include: "//looker-hub/firefox_desktop/views/*"
+include: "/firefox_desktop/views/*"
+
+explore: suggest_clients_daily {
+  view_name: suggest_clients_daily
+
+  always_filter: {
+    filters: [suggest_clients_daily.submission_date: "28 days"
+      ]
+  }
+}

--- a/firefox_desktop/views/sponsored_tiles_clients_daily.view.lkml
+++ b/firefox_desktop/views/sponsored_tiles_clients_daily.view.lkml
@@ -1,0 +1,52 @@
+include: "//looker-hub/firefox_desktop/views/*"
+
+view: +sponsored_tiles_clients_daily {
+
+  measure: distinct_client_count {
+    type: number
+    sql: COUNT(DISTINCT ${TABLE}.client_id) ;;
+  }
+
+  dimension: sponsored_tiles_enabled_at_startup {
+    description: "Only available for Android. Must filter to Android to avoid overinflated disable counts."
+    sql:${TABLE}.sponsored_tiles_enabled_at_startup ;;
+  }
+
+  measure: sponsored_tiles_impression {
+    type: number
+    sql: SUM(${TABLE}.sponsored_tiles_impression_count) ;;
+  }
+
+  measure: sponsored_tiles_click {
+    type: number
+    sql: SUM(${TABLE}.sponsored_tiles_click_count) ;;
+  }
+
+  measure: sponsored_tiles_disable {
+    type: number
+    sql: SUM(${TABLE}.sponsored_tiles_disable_count) ;;
+  }
+
+  measure: sponsored_tiles_dismissal {
+    type: number
+    description: "Only available for desktop."
+    sql: SUM(${TABLE}.sponsored_tiles_dismissal_count) ;;
+  }
+
+  dimension: sponsored_tiles_impression_count {
+    hidden: yes
+  }
+
+  dimension: sponsored_tiles_click_count {
+    hidden: yes
+  }
+
+  dimension: sponsored_tiles_disable_count {
+    hidden: yes
+  }
+
+  dimension: sponsored_tiles_dismissal_count {
+    hidden: yes
+  }
+
+}

--- a/firefox_desktop/views/suggest_clients_daily.view.lkml
+++ b/firefox_desktop/views/suggest_clients_daily.view.lkml
@@ -1,0 +1,178 @@
+include: "//looker-hub/firefox_desktop/views/*"
+
+view: +suggest_clients_daily {
+
+  measure: distinct_client_count {
+    type: number
+    sql: COUNT(DISTINCT ${TABLE}.client_id) ;;
+  }
+
+  measure: total_block_count {
+    type: number
+    sql: SUM(${TABLE}.block_nonsponsored_bestmatch_count + ${TABLE}.block_nonsponsored_count +
+    ${TABLE}.block_sponsored_bestmatch_count + ${TABLE}.block_sponsored_count) ;;
+  }
+
+  dimension: block_nonsponsored_bestmatch_count {
+    hidden: yes
+  }
+
+  dimension: block_nonsponsored_count {
+    hidden: yes
+  }
+
+  dimension: block_sponsored_bestmatch_count {
+    hidden: yes
+  }
+
+  dimension: block_sponsored_count {
+    hidden: yes
+  }
+
+  measure: block_nonsponsored_bestmatch {
+    type: number
+    sql: SUM(${TABLE}.block_nonsponsored_bestmatch_count) ;;
+  }
+
+  measure: block_nonsponsored {
+    type: number
+    sql: SUM(${TABLE}.block_nonsponsored_count) ;;
+  }
+
+  measure: block_sponsored_bestmatch {
+    type: number
+    sql: SUM(${TABLE}.block_sponsored_bestmatch_count) ;;
+  }
+
+  measure: block_sponsored {
+    type: number
+    sql: SUM(${TABLE}.block_sponsored_count) ;;
+  }
+
+  measure: total_click_count {
+    type: number
+    sql: SUM(${TABLE}.click_nonsponsored_bestmatch_count + ${TABLE}.click_nonsponsored_count +
+      ${TABLE}.click_sponsored_bestmatch_count + ${TABLE}.click_sponsored_count) ;;
+  }
+
+  dimension: click_nonsponsored_bestmatch_count {
+    hidden: yes
+  }
+
+  dimension: click_nonsponsored_count {
+    hidden: yes
+  }
+
+  dimension: click_sponsored_bestmatch_count {
+    hidden: yes
+  }
+
+  dimension: click_sponsored_count {
+    hidden: yes
+  }
+
+  measure: click_nonsponsored_bestmatch {
+    type: number
+    sql: SUM(${TABLE}.click_nonsponsored_bestmatch_count) ;;
+  }
+
+  measure: click_nonsponsored {
+    type: number
+    sql: SUM(${TABLE}.click_nonsponsored_count) ;;
+  }
+
+  measure: click_sponsored_bestmatch {
+    type: number
+    sql: SUM(${TABLE}.click_sponsored_bestmatch_count) ;;
+  }
+
+  measure: click_sponsored {
+    type: number
+    sql: SUM(${TABLE}.click_sponsored_count) ;;
+  }
+
+  measure: total_help_count {
+    type: number
+    sql: SUM(${TABLE}.help_nonsponsored_bestmatch_count + ${TABLE}.help_nonsponsored_count +
+      ${TABLE}.help_sponsored_bestmatch_count + ${TABLE}.help_sponsored_count) ;;
+  }
+
+  dimension: help_nonsponsored_bestmatch_count {
+    hidden: yes
+  }
+
+  dimension: help_nonsponsored_count {
+    hidden: yes
+  }
+
+  dimension: help_sponsored_bestmatch_count {
+    hidden: yes
+  }
+
+  dimension: help_sponsored_count {
+    hidden: yes
+  }
+
+  measure: help_nonsponsored_bestmatch {
+    type: number
+    sql: SUM(${TABLE}.help_nonsponsored_bestmatch_count) ;;
+  }
+
+  measure: help_nonsponsored {
+    type: number
+    sql: SUM(${TABLE}.help_nonsponsored_count) ;;
+  }
+
+  measure: help_sponsored_bestmatch {
+    type: number
+    sql: SUM(${TABLE}.help_sponsored_bestmatch_count) ;;
+  }
+
+  measure: help_sponsored {
+    type: number
+    sql: SUM(${TABLE}.help_sponsored_count) ;;
+  }
+
+  measure: total_impression_count {
+    type: number
+    sql: SUM(${TABLE}.impression_nonsponsored_bestmatch_count + ${TABLE}.impression_nonsponsored_count +
+      ${TABLE}.impression_sponsored_bestmatch_count + ${TABLE}.impression_sponsored_count) ;;
+  }
+
+  dimension: impression_nonsponsored_bestmatch_count {
+    hidden: yes
+  }
+
+  dimension: impression_nonsponsored_count {
+    hidden: yes
+  }
+
+  dimension: impression_sponsored_bestmatch_count {
+    hidden: yes
+  }
+
+  dimension: impression_sponsored_count {
+    hidden: yes
+  }
+
+  measure: impression_nonsponsored_bestmatch {
+    type: number
+    sql: SUM(${TABLE}.impression_nonsponsored_bestmatch_count) ;;
+  }
+
+  measure: impression_nonsponsored {
+    type: number
+    sql: SUM(${TABLE}.impression_nonsponsored_count) ;;
+  }
+
+  measure: impression_sponsored_bestmatch {
+    type: number
+    sql: SUM(${TABLE}.impression_sponsored_bestmatch_count) ;;
+  }
+
+  measure: impression_sponsored {
+    type: number
+    sql: SUM(${TABLE}.impression_sponsored_count) ;;
+  }
+
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
