### PR TITLE
add total ad click and total search with ads measures

### DIFF
--- a/data_integrity_monitoring/data_integrity_monitoring.model.lkml
+++ b/data_integrity_monitoring/data_integrity_monitoring.model.lkml
@@ -1,5 +1,5 @@
 connection: "telemetry"
 label: "Data Integrity Monitoring (dim)"
-include: "views/*"
-include: "explores/*"
-include: "dashboards/*"
+# include: "views/*"
+# include: "explores/*"
+# include: "dashboards/*"

--- a/firefox_desktop/views/newtab_interactions.view.lkml
+++ b/firefox_desktop/views/newtab_interactions.view.lkml
@@ -195,6 +195,20 @@ view: newtab_interactions {
     sql: ${tagged_follow_on_search_ad_clicks} ;;
   }
 
+  measure: sum_all_search_ad_clicks {
+    group_label: "Search"
+    label: "Total Ad Clicks"
+    type: sum
+    sql: ${tagged_search_ad_clicks} + ${follow_on_search_ad_clicks} ;;
+  }
+
+  measure: sum_all_search_ad_impressions {
+    group_label: "Search"
+    label: "Total Ad Impressions"
+    type: sum
+    sql: ${tagged_search_ad_impressions} + ${follow_on_search_ad_impressions} ;;
+  }
+
   measure: visits_with_search {
     group_label: "Search"
     type: count_distinct
@@ -241,6 +255,20 @@ view: newtab_interactions {
     group_label: "Search"
     type: count_distinct
     sql: IF(${tagged_follow_on_search_ad_clicks} > 0, ${newtab_visit_id}, NULL) ;;
+    approximate: yes
+  }
+
+  measure:  visits_with_any_ad_click {
+    group_label: "Search"
+    type: count_distinct
+    sql: IF(${tagged_follow_on_search_ad_clicks} + ${tagged_search_ad_clicks} > 0, ${newtab_visit_id}, NULL) ;;
+    approximate: yes
+  }
+
+  measure:  visits_with_any_ad_impression {
+    group_label: "Search"
+    type: count_distinct
+    sql: IF(${tagged_follow_on_search_ad_impressions} + ${tagged_search_ad_impressions} > 0, ${newtab_visit_id}, NULL) ;;
     approximate: yes
   }
 
@@ -293,6 +321,19 @@ view: newtab_interactions {
     approximate: yes
   }
 
+  measure:  clients_with_any_ad_click {
+    group_label: "Search"
+    type: count_distinct
+    sql: IF(${tagged_follow_on_search_ad_clicks} + ${tagged_search_ad_clicks} > 0, ${client_id}, NULL) ;;
+    approximate: yes
+  }
+
+  measure:  clients_with_any_ad_impression {
+    group_label: "Search"
+    type: count_distinct
+    sql: IF(${tagged_follow_on_search_ad_impressions} + ${tagged_search_ad_impressions} > 0, ${client_id}, NULL) ;;
+    approximate: yes
+  }
 
   ### Topsites
 

--- a/firefox_desktop/views/newtab_interactions.view.lkml
+++ b/firefox_desktop/views/newtab_interactions.view.lkml
@@ -157,28 +157,14 @@ view: newtab_interactions {
     group_label: "Search"
     label: "Tagged Search Ad Impressions"
     type: sum
-    sql: ${tagged_search_ad_impressions} ;;
+    sql: ${tagged_search_ad_impressions} - ${tagged_follow_on_search_ad_impressions};;
   }
 
   measure: sum_tagged_search_ad_clicks {
     group_label: "Search"
     label: "Tagged Search Ad Clicks"
     type: sum
-    sql: ${tagged_search_ad_clicks} ;;
-  }
-
-  measure: sum_follow_on_search_ad_impressions {
-    group_label: "Search"
-    label: "Follow-on Search Ad Impressions"
-    type: sum
-    sql: ${follow_on_search_ad_impressions} ;;
-  }
-
-  measure: sum_follow_on_search_ad_clicks {
-    group_label: "Search"
-    label: "Follow-on Search Ad Clicks"
-    type: sum
-    sql: ${follow_on_search_ad_clicks} ;;
+    sql: ${tagged_search_ad_clicks} - ${tagged_follow_on_search_ad_clicks};;
   }
 
   measure: sum_tagged_follow_on_search_ad_impressions {
@@ -197,16 +183,16 @@ view: newtab_interactions {
 
   measure: sum_all_search_ad_clicks {
     group_label: "Search"
-    label: "Total Ad Clicks"
+    label: "Total Tagged Ad Clicks"
     type: sum
-    sql: ${tagged_search_ad_clicks} + ${follow_on_search_ad_clicks} ;;
+    sql: ${tagged_search_ad_clicks} ;;
   }
 
   measure: sum_all_search_ad_impressions {
     group_label: "Search"
-    label: "Total Ad Impressions"
+    label: "Total Tagged Ad Impressions"
     type: sum
-    sql: ${tagged_search_ad_impressions} + ${follow_on_search_ad_impressions} ;;
+    sql: ${tagged_search_ad_impressions} ;;
   }
 
   measure: visits_with_search {
@@ -219,28 +205,14 @@ view: newtab_interactions {
   measure: visits_with_tagged_search_ad_impression {
     group_label: "Search"
     type: count_distinct
-    sql: IF(${tagged_search_ad_impressions} > 0, ${newtab_visit_id}, NULL) ;;
+    sql: IF(${tagged_search_ad_impressions} - ${tagged_follow_on_search_ad_impressions} > 0, ${newtab_visit_id}, NULL) ;;
     approximate: yes
   }
 
   measure:  visits_with_tagged_search_ad_click {
     group_label: "Search"
     type: count_distinct
-    sql: IF(${tagged_search_ad_clicks} > 0, ${newtab_visit_id}, NULL) ;;
-    approximate: yes
-  }
-
-  measure: visits_with_follow_on_search_ad_impression {
-    group_label: "Search"
-    type: count_distinct
-    sql: IF(${follow_on_search_ad_impressions} > 0, ${newtab_visit_id}, NULL) ;;
-    approximate: yes
-  }
-
-  measure:  visits_with_follow_on_search_ad_click {
-    group_label: "Search"
-    type: count_distinct
-    sql: IF(${follow_on_search_ad_clicks} > 0, ${newtab_visit_id}, NULL) ;;
+    sql: IF(${tagged_search_ad_clicks} - ${tagged_follow_on_search_ad_impressions} > 0, ${newtab_visit_id}, NULL) ;;
     approximate: yes
   }
 
@@ -261,14 +233,14 @@ view: newtab_interactions {
   measure:  visits_with_any_ad_click {
     group_label: "Search"
     type: count_distinct
-    sql: IF(${tagged_follow_on_search_ad_clicks} + ${tagged_search_ad_clicks} > 0, ${newtab_visit_id}, NULL) ;;
+    sql: IF(${tagged_search_ad_clicks} > 0, ${newtab_visit_id}, NULL) ;;
     approximate: yes
   }
 
   measure:  visits_with_any_ad_impression {
     group_label: "Search"
     type: count_distinct
-    sql: IF(${tagged_follow_on_search_ad_impressions} + ${tagged_search_ad_impressions} > 0, ${newtab_visit_id}, NULL) ;;
+    sql: IF(${tagged_search_ad_impressions} > 0, ${newtab_visit_id}, NULL) ;;
     approximate: yes
   }
 
@@ -282,28 +254,14 @@ view: newtab_interactions {
   measure: clients_with_tagged_search_ad_impression {
     group_label: "Search"
     type: count_distinct
-    sql: IF(${tagged_search_ad_impressions} > 0, ${client_id}, NULL) ;;
+    sql: IF(${tagged_search_ad_impressions} - ${tagged_follow_on_search_ad_impressions}> 0, ${client_id}, NULL) ;;
     approximate: yes
   }
 
   measure:  clients_with_tagged_search_ad_click {
     group_label: "Search"
     type: count_distinct
-    sql: IF(${tagged_search_ad_clicks} > 0, ${client_id}, NULL) ;;
-    approximate: yes
-  }
-
-  measure: clients_with_follow_on_search_ad_impression {
-    group_label: "Search"
-    type: count_distinct
-    sql: IF(${follow_on_search_ad_impressions} > 0, ${client_id}, NULL) ;;
-    approximate: yes
-  }
-
-  measure:  clients_with_follow_on_search_ad_click {
-    group_label: "Search"
-    type: count_distinct
-    sql: IF(${follow_on_search_ad_clicks} > 0, ${client_id}, NULL) ;;
+    sql: IF(${tagged_search_ad_clicks} - ${tagged_follow_on_search_ad_clicks}> 0, ${client_id}, NULL) ;;
     approximate: yes
   }
 
@@ -324,14 +282,14 @@ view: newtab_interactions {
   measure:  clients_with_any_ad_click {
     group_label: "Search"
     type: count_distinct
-    sql: IF(${tagged_follow_on_search_ad_clicks} + ${tagged_search_ad_clicks} > 0, ${client_id}, NULL) ;;
+    sql: IF(${tagged_search_ad_clicks} > 0, ${client_id}, NULL) ;;
     approximate: yes
   }
 
   measure:  clients_with_any_ad_impression {
     group_label: "Search"
     type: count_distinct
-    sql: IF(${tagged_follow_on_search_ad_impressions} + ${tagged_search_ad_impressions} > 0, ${client_id}, NULL) ;;
+    sql: IF(${tagged_search_ad_impressions} > 0, ${client_id}, NULL) ;;
     approximate: yes
   }
 


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
