### PR TITLE
add colorways explore and view

### DIFF
--- a/data_integrity_monitoring/data_integrity_monitoring.model.lkml
+++ b/data_integrity_monitoring/data_integrity_monitoring.model.lkml
@@ -1,5 +1,5 @@
 connection: "telemetry"
 label: "Data Integrity Monitoring (dim)"
-include: "views/*"
-include: "explores/*"
-include: "dashboards/*"
+# include: "views/*"
+# include: "explores/*"
+# include: "dashboards/*"

--- a/firefox_desktop/explores/colorways.explore.lkml
+++ b/firefox_desktop/explores/colorways.explore.lkml
@@ -1,0 +1,13 @@
+
+include: "../views/colorways.view.lkml"
+
+explore: colorways {
+  view_name: colorways
+  description: "Basic stats about colorways usage."
+
+  always_filter: {
+    filters: [
+      submission_date: "after 2022-10-17",
+    ]
+  }
+}

--- a/firefox_desktop/explores/colorways.explore.lkml
+++ b/firefox_desktop/explores/colorways.explore.lkml
@@ -3,11 +3,11 @@ include: "../views/colorways.view.lkml"
 
 explore: colorways {
   view_name: colorways
-  description: "Basic stats about colorways usage."
+  description: "Basic stats about colorways usage. Only supports daily-level data."
 
   always_filter: {
     filters: [
-      submission_date: "after 2022-10-17",
+      submission_date: "after 2022-10-18",
     ]
   }
 }

--- a/firefox_desktop/firefox_desktop.model.lkml
+++ b/firefox_desktop/firefox_desktop.model.lkml
@@ -102,10 +102,6 @@ view: +metrics {
   }
 }
 
-# explore: colorways {
-#   label: "Colorways"
-# }
-
 view: +clients_daily_table__contextual_services_quicksuggest_block_nonsponsored_bestmatch_sum {
   dimension: value {
     hidden: yes

--- a/firefox_desktop/firefox_desktop.model.lkml
+++ b/firefox_desktop/firefox_desktop.model.lkml
@@ -102,6 +102,10 @@ view: +metrics {
   }
 }
 
+# explore: colorways {
+#   label: "Colorways"
+# }
+
 view: +clients_daily_table__contextual_services_quicksuggest_block_nonsponsored_bestmatch_sum {
   dimension: value {
     hidden: yes

--- a/firefox_desktop/views/colorways.view.lkml
+++ b/firefox_desktop/views/colorways.view.lkml
@@ -1,0 +1,115 @@
+view: colorways {
+  derived_table: {
+    sql: -- basic example of how to set a variable in the BQ scripting language
+-- https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#declare
+DECLARE start_date DATE DEFAULT DATE(2022, 10, 18);
+
+WITH indp_voices_colorways AS
+  (SELECT *
+   FROM UNNEST (["visionary-balanced-colorway@mozilla.org",
+   "visionary-bold-colorway@mozilla.org",
+         "visionary-soft-colorway@mozilla.org",
+         "playmaker-balanced-colorway@mozilla.org",
+         "playmaker-bold-colorway@mozilla.org",
+         "playmaker-soft-colorway@mozilla.org",
+         "innovator-balanced-colorway@mozilla.org",
+         "innovator-bold-colorway@mozilla.org",
+         "innovator-soft-colorway@mozilla.org",
+         "expressionist-balanced-colorway@mozilla.org",
+         "expressionist-bold-colorway@mozilla.org",
+         "expressionist-soft-colorway@mozilla.org",
+         "dreamer-balanced-colorway@mozilla.org",
+         "dreamer-bold-colorway@mozilla.org",
+         "dreamer-soft-colorway@mozilla.org",
+         "activist-balanced-colorway@mozilla.org",
+         "activist-bold-colorway@mozilla.org",
+         "activist-soft-colorway@mozilla.org"])),
+ currently_set AS
+  (SELECT DATE(submission_timestamp) AS submission_date,
+          SPLIT(environment.addons.theme.id, '-colorway')[OFFSET(0)] AS id,
+          100 * COUNT(DISTINCT client_id) AS clients_currently_set
+   FROM telemetry.main_1pct -- these tables that end in _1pct are random 1 percent samples (based on client_id) of their parent tables. they speed things up when that's all you need.
+
+   WHERE DATE(submission_timestamp) >= start_date
+     AND environment.addons.theme.id IN
+       (SELECT *
+        FROM indp_voices_colorways)
+     AND environment.addons.theme.user_disabled IS NOT TRUE -- this is just to be safe, it doesn't seem to happen much at all in practice
+
+   GROUP BY 1,
+            2 -- ORDER BY 2 DESC
+ ), -- themes set today according to telemetry events
+ -- https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/collection/events.html#eventtelemetry
+ -- see https://searchfox.org/mozilla-central/source/toolkit/components/telemetry/Events.yaml#185
+ -- this means that it was set at anytime, including clients just trying it in the modal. they don't have to actuall set it "permanently" for this event to fire
+ play_today AS
+  (SELECT submission_date,
+          SPLIT(event_string_value, '-colorway')[OFFSET(0)] AS id,
+          100 * COUNT(DISTINCT client_id) AS clients_play_today
+   FROM telemetry.events_1pct
+   WHERE submission_date >= start_date
+     AND event_string_value IN
+       (SELECT *
+        FROM indp_voices_colorways)
+     AND event_category = 'addonsManager'
+     AND event_method = 'enable'
+     AND event_object = 'theme'
+   GROUP BY 1,
+            2 -- ORDER BY 2 DESC
+ ), -- themes actually selected AND set in the modal, so the theme was actually set durably.
+ -- see https://searchfox.org/mozilla-central/source/toolkit/components/telemetry/Events.yaml#3447
+ set_today AS
+  (SELECT submission_date,
+          SPLIT(e.value, '-colorway')[OFFSET(0)] AS id,
+          100 * COUNT(DISTINCT client_id) AS clients_set_today
+   FROM telemetry.events_1pct
+   CROSS JOIN UNNEST(event_map_values) e
+   WHERE submission_date >= start_date
+     AND e.value IN
+       (SELECT *
+        FROM indp_voices_colorways)
+     AND e.key = 'colorway_id'
+     AND event_category = 'colorways_modal'
+     AND event_method = 'set_colorway'
+   GROUP BY 1,
+            2)
+SELECT *
+FROM currently_set
+LEFT JOIN play_today USING(submission_date,
+                          id)
+LEFT JOIN set_today USING(submission_date,
+                               id)
+ORDER BY submission_date, id
+       ;;
+  }
+
+  dimension: submission_date {
+    type: date
+    datatype: date
+    sql: ${TABLE}.submission_date ;;
+  }
+
+  dimension: id {
+    type: string
+    sql: ${TABLE}.id ;;
+  }
+
+  measure: clients_currently_set {
+    type: sum
+    sql: ${TABLE}.clients_currently_set ;;
+  }
+
+  measure: clients_play_today {
+    type: sum
+    sql: ${TABLE}.clients_play_today ;;
+  }
+
+  measure: clients_set_today {
+    type: sum
+    sql: ${TABLE}.clients_set_today ;;
+  }
+
+  set: detail {
+    fields: [submission_date, id, clients_currently_set, clients_play_today, clients_set_today]
+  }
+}

--- a/firefox_desktop/views/colorways.view.lkml
+++ b/firefox_desktop/views/colorways.view.lkml
@@ -2,8 +2,6 @@ view: colorways {
   derived_table: {
     sql: -- basic example of how to set a variable in the BQ scripting language
 -- https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#declare
-DECLARE start_date DATE DEFAULT DATE(2022, 10, 18);
-
 WITH indp_voices_colorways AS
   (SELECT *
    FROM UNNEST (["visionary-balanced-colorway@mozilla.org",
@@ -30,7 +28,7 @@ WITH indp_voices_colorways AS
           100 * COUNT(DISTINCT client_id) AS clients_currently_set
    FROM telemetry.main_1pct -- these tables that end in _1pct are random 1 percent samples (based on client_id) of their parent tables. they speed things up when that's all you need.
 
-   WHERE DATE(submission_timestamp) >= start_date
+   WHERE DATE(submission_timestamp) >= DATE(2022, 10, 18)
      AND environment.addons.theme.id IN
        (SELECT *
         FROM indp_voices_colorways)
@@ -47,7 +45,7 @@ WITH indp_voices_colorways AS
           SPLIT(event_string_value, '-colorway')[OFFSET(0)] AS id,
           100 * COUNT(DISTINCT client_id) AS clients_play_today
    FROM telemetry.events_1pct
-   WHERE submission_date >= start_date
+   WHERE submission_date >= DATE(2022, 10, 18)
      AND event_string_value IN
        (SELECT *
         FROM indp_voices_colorways)
@@ -64,7 +62,7 @@ WITH indp_voices_colorways AS
           100 * COUNT(DISTINCT client_id) AS clients_set_today
    FROM telemetry.events_1pct
    CROSS JOIN UNNEST(event_map_values) e
-   WHERE submission_date >= start_date
+   WHERE submission_date >= DATE(2022, 10, 18)
      AND e.value IN
        (SELECT *
         FROM indp_voices_colorways)
@@ -91,22 +89,26 @@ ORDER BY submission_date, id
 
   dimension: id {
     type: string
+    label: "Colorways identifier"
     sql: ${TABLE}.id ;;
   }
 
   measure: clients_currently_set {
     type: sum
     sql: ${TABLE}.clients_currently_set ;;
+    label: "Number of daily clients having already set a Colorway"
   }
 
   measure: clients_play_today {
     type: sum
     sql: ${TABLE}.clients_play_today ;;
+    label: "Number of daily clients exploring Colorways choices"
   }
 
   measure: clients_set_today {
     type: sum
     sql: ${TABLE}.clients_set_today ;;
+    label: "Number of daily clients choosing a Colorways"
   }
 
   set: detail {


### PR DESCRIPTION
Note: fields for colorways are not in any other current looker explores

Checklist for reviewer:

When adding a new derived dataset:
- [x] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [x] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [x] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [x] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
