### PR TITLE
feat: more usable measures for Suggest Clients Daily

### DIFF
--- a/firefox_desktop/views/suggest_clients_daily.view.lkml
+++ b/firefox_desktop/views/suggest_clients_daily.view.lkml
@@ -7,12 +7,6 @@ view: +suggest_clients_daily {
     sql: COUNT(DISTINCT ${TABLE}.client_id) ;;
   }
 
-  measure: total_block_count {
-    type: number
-    sql: SUM(${TABLE}.block_nonsponsored_bestmatch_count + ${TABLE}.block_nonsponsored_count +
-    ${TABLE}.block_sponsored_bestmatch_count + ${TABLE}.block_sponsored_count) ;;
-  }
-
   dimension: block_nonsponsored_bestmatch_count {
     hidden: yes
   }
@@ -29,30 +23,21 @@ view: +suggest_clients_daily {
     hidden: yes
   }
 
-  measure: block_nonsponsored_bestmatch {
+  measure: block_total {
     type: number
-    sql: SUM(${TABLE}.block_nonsponsored_bestmatch_count) ;;
+    sql: SUM(${TABLE}.block_nonsponsored_bestmatch_count + ${TABLE}.block_nonsponsored_count +
+      ${TABLE}.block_sponsored_bestmatch_count + ${TABLE}.block_sponsored_count) ;;
+    description: "All blocks, sponsored and nonsponsored"
   }
 
   measure: block_nonsponsored {
     type: number
-    sql: SUM(${TABLE}.block_nonsponsored_count) ;;
-  }
-
-  measure: block_sponsored_bestmatch {
-    type: number
-    sql: SUM(${TABLE}.block_sponsored_bestmatch_count) ;;
+    sql: SUM(${TABLE}.block_nonsponsored_bestmatch_count + ${TABLE}.block_nonsponsored_count) ;;
   }
 
   measure: block_sponsored {
     type: number
-    sql: SUM(${TABLE}.block_sponsored_count) ;;
-  }
-
-  measure: total_click_count {
-    type: number
-    sql: SUM(${TABLE}.click_nonsponsored_bestmatch_count + ${TABLE}.click_nonsponsored_count +
-      ${TABLE}.click_sponsored_bestmatch_count + ${TABLE}.click_sponsored_count) ;;
+    sql: SUM(${TABLE}.block_sponsored_count + ${TABLE}.block_sponsored_bestmatch_count) ;;
   }
 
   dimension: click_nonsponsored_bestmatch_count {
@@ -71,30 +56,21 @@ view: +suggest_clients_daily {
     hidden: yes
   }
 
-  measure: click_nonsponsored_bestmatch {
+  measure: click_total {
     type: number
-    sql: SUM(${TABLE}.click_nonsponsored_bestmatch_count) ;;
+    sql: SUM(${TABLE}.click_nonsponsored_bestmatch_count + ${TABLE}.click_nonsponsored_count +
+      ${TABLE}.click_sponsored_bestmatch_count + ${TABLE}.click_sponsored_count) ;;
+    description: "All clicks, sponsored and nonsponsored"
   }
 
   measure: click_nonsponsored {
     type: number
-    sql: SUM(${TABLE}.click_nonsponsored_count) ;;
-  }
-
-  measure: click_sponsored_bestmatch {
-    type: number
-    sql: SUM(${TABLE}.click_sponsored_bestmatch_count) ;;
+    sql: SUM(${TABLE}.click_nonsponsored_count + ${TABLE}.click_nonsponsored_bestmatch_count) ;;
   }
 
   measure: click_sponsored {
     type: number
-    sql: SUM(${TABLE}.click_sponsored_count) ;;
-  }
-
-  measure: total_help_count {
-    type: number
-    sql: SUM(${TABLE}.help_nonsponsored_bestmatch_count + ${TABLE}.help_nonsponsored_count +
-      ${TABLE}.help_sponsored_bestmatch_count + ${TABLE}.help_sponsored_count) ;;
+    sql: SUM(${TABLE}.click_sponsored_count + ${TABLE}.click_sponsored_bestmatch_count) ;;
   }
 
   dimension: help_nonsponsored_bestmatch_count {
@@ -113,30 +89,21 @@ view: +suggest_clients_daily {
     hidden: yes
   }
 
-  measure: help_nonsponsored_bestmatch {
+  measure: help_total {
     type: number
-    sql: SUM(${TABLE}.help_nonsponsored_bestmatch_count) ;;
+    sql: SUM(${TABLE}.help_nonsponsored_bestmatch_count + ${TABLE}.help_nonsponsored_count +
+      ${TABLE}.help_sponsored_bestmatch_count + ${TABLE}.help_sponsored_count) ;;
+    description: "All helps, sponsored and nonsponsored"
   }
 
   measure: help_nonsponsored {
     type: number
-    sql: SUM(${TABLE}.help_nonsponsored_count) ;;
-  }
-
-  measure: help_sponsored_bestmatch {
-    type: number
-    sql: SUM(${TABLE}.help_sponsored_bestmatch_count) ;;
+    sql: SUM(${TABLE}.help_nonsponsored_count + ${TABLE}.help_nonsponsored_bestmatch_count) ;;
   }
 
   measure: help_sponsored {
     type: number
-    sql: SUM(${TABLE}.help_sponsored_count) ;;
-  }
-
-  measure: total_impression_count {
-    type: number
-    sql: SUM(${TABLE}.impression_nonsponsored_bestmatch_count + ${TABLE}.impression_nonsponsored_count +
-      ${TABLE}.impression_sponsored_bestmatch_count + ${TABLE}.impression_sponsored_count) ;;
+    sql: SUM(${TABLE}.help_sponsored_count + ${TABLE}.help_sponsored_bestmatch_count) ;;
   }
 
   dimension: impression_nonsponsored_bestmatch_count {
@@ -155,24 +122,41 @@ view: +suggest_clients_daily {
     hidden: yes
   }
 
-  measure: impression_nonsponsored_bestmatch {
+  measure: impression_total {
     type: number
-    sql: SUM(${TABLE}.impression_nonsponsored_bestmatch_count) ;;
+    sql: SUM(${TABLE}.impression_nonsponsored_bestmatch_count + ${TABLE}.impression_nonsponsored_count +
+      ${TABLE}.impression_sponsored_bestmatch_count + ${TABLE}.impression_sponsored_count) ;;
+    description: "All impressions, sponsored and nonsponsored"
   }
 
   measure: impression_nonsponsored {
     type: number
-    sql: SUM(${TABLE}.impression_nonsponsored_count) ;;
-  }
-
-  measure: impression_sponsored_bestmatch {
-    type: number
-    sql: SUM(${TABLE}.impression_sponsored_bestmatch_count) ;;
+    sql: SUM(${TABLE}.impression_nonsponsored_count + ${TABLE}.impression_nonsponsored_bestmatch_count) ;;
   }
 
   measure: impression_sponsored {
     type: number
-    sql: SUM(${TABLE}.impression_sponsored_count) ;;
+    sql: SUM(${TABLE}.impression_sponsored_count + ${TABLE}.impression_sponsored_bestmatch_count) ;;
   }
 
+  measure: clickthrough_rate {
+    type: number
+    sql: SAFE_DIVIDE(${click_total}, ${impression_total}) * 100;;
+    description: "Total clicks divided by total impressions. Displayed as a percent."
+    value_format: "0.00\%"
+  }
+
+  measure: clickthrough_rate_sponsored {
+    type: number
+    sql: SAFE_DIVIDE(${click_sponsored}, ${impression_sponsored}) * 100;;
+    description: "Sponsored clicks divided by sponsored impressions. Displayed as a percent."
+    value_format: "0.00\%"
+  }
+
+  measure: clickthrough_rate_nonsponsored {
+    type: number
+    sql: SAFE_DIVIDE(${click_nonsponsored}, ${impression_nonsponsored}) * 100;;
+    description: "Nonsponsored clicks divided by nonsponsored impressions. Displayed as a percent."
+    value_format: "0.00\%"
+  }
 }


### PR DESCRIPTION
- Break out measures by sponsored vs nonsponsored, but not by best match vs non-best match
- Add measures for click through rates


Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
