### PR TITLE
Updated dimensions and explores for Data Usage Monitoring Dashboard

### DIFF
--- a/monitoring/explores/bigquery_usage.explore.lkml
+++ b/monitoring/explores/bigquery_usage.explore.lkml
@@ -1,5 +1,16 @@
-include: "../views//bigquery_usage.view.lkml"
+include: "../views/bigquery_usage.view.lkml"
+include: "../views/bigquery_tables_inventory.view.lkml"
 
 explore: bigquery_usage {
   from: bigquery_usage
+
+  join: bigquery_tables_inventory {
+    view_label: "Table Inventory (reference tables)"
+    fields: [bigquery_tables_inventory.table_type]
+    sql_on: ${bigquery_usage.reference_project_id} = ${bigquery_tables_inventory.project_id}
+          AND ${bigquery_usage.reference_dataset_id} = ${bigquery_tables_inventory.dataset_id}
+          AND ${bigquery_usage.reference_table_id} = ${bigquery_tables_inventory.table_id}
+          ;;
+    relationship: one_to_one
+  }
 }

--- a/monitoring/views/bigquery_table_storage.view.lkml
+++ b/monitoring/views/bigquery_table_storage.view.lkml
@@ -4,57 +4,59 @@ view: +bigquery_table_storage {
 
   measure: sum_total_rows{
     type: sum
-    sql: {total_rows} ;;
+    sql: ${total_rows} ;;
   }
 
   measure: sum_total_partitions{
     type: sum
-    sql: {total_partitions} ;;
+    sql: ${total_partitions} ;;
   }
 
-  measure: sum_total_logical_bytes{
+  measure: sum_total_logical_TB{
     type: sum
-    sql: {total_logical_bytes} ;;
+    sql: ${total_logical_bytes}/ 1024 / 1024 / 1024 / 1024 ;;
+    value_format: "#,##0.00"
   }
 
   measure: sum_active_logical_bytes{
     type: sum
-    sql: {active_logical_bytes} ;;
+    sql: ${active_logical_bytes} ;;
   }
 
   measure: sum_long_term_logical_bytes{
     type: sum
-    sql: {long_term_logical_bytes} ;;
+    sql: ${long_term_logical_bytes} ;;
   }
 
-  measure: sum_total_physical_bytes{
+  measure: sum_total_physical_TB{
     type: sum
-    sql: {total_physical_bytes} ;;
+    sql: ${total_physical_bytes}/ 1024 / 1024 / 1024 / 1024 ;;
+    value_format: "#,##0.00"
   }
 
   measure: sum_active_physical_bytes{
     type: sum
-    sql: {active_physical_bytes} ;;
+    sql: ${active_physical_bytes} ;;
   }
 
   measure: sum_long_term_physical_bytes{
     type: sum
-    sql: {long_term_physical_bytes} ;;
+    sql: ${long_term_physical_bytes} ;;
   }
 
   measure: sum_time_travel_physical_bytes{
     type: sum
-    sql: {time_travel_physical_bytes} ;;
+    sql: ${time_travel_physical_bytes} ;;
   }
 
   measure: sum_logical_billing_cost_usd{
     type: sum
-    sql: {logical_billing_cost_usd} ;;
+    sql: ${logical_billing_cost_usd} ;;
   }
 
   measure: sum_physical_billing_cost_usd{
     type: sum
-    sql: {physical_billing_cost_usd} ;;
+    sql: ${physical_billing_cost_usd} ;;
   }
 
   measure: count{

--- a/monitoring/views/bigquery_usage.view.lkml
+++ b/monitoring/views/bigquery_usage.view.lkml
@@ -9,14 +9,21 @@ view: +bigquery_usage {
   }
 
   dimension: full_reference_table_name {
-    sql: concat(reference_project_id, reference_dataset_id, reference_table_id) ;;
+    sql: concat(reference_project_id, '.', reference_dataset_id, '.', reference_table_id) ;;
     type: string
   }
 
   dimension: full_destination_table_name {
-    sql: concat(destination_project_id, destination_dataset_id, destination_table_id) ;;
+    sql: concat(destination_project_id, '.', destination_dataset_id, '.', destination_table_id) ;;
     type: string
   }
+
+  measure: avg_total_job_cost_usd{
+    type: average_distinct
+    sql_distinct_key: ${job_id} ;;
+    sql: ${cost_usd} ;;
+    value_format:"$#,##0.00"
+    }
 
   measure: sum_total_job_cost_usd{
     type: sum_distinct
@@ -25,10 +32,18 @@ view: +bigquery_usage {
     value_format:"$#,##0.00"
   }
 
+  measure: avg_total_terabytes_processed{
+    type: average_distinct
+    sql_distinct_key: ${job_id} ;;
+    sql: ${total_terabytes_processed} ;;
+    value_format: "#,##0.00"
+  }
+
   measure: sum_total_terabytes_processed{
     type: sum_distinct
     sql_distinct_key: ${job_id} ;;
     sql: ${total_terabytes_processed} ;;
+    value_format: "#,##0.00"
   }
 
   measure: number_of_unique_job_ids{


### PR DESCRIPTION
Updated some dimensions and explores for [Data Usage Monitoring Dashboard](https://mozilla.cloud.looker.com/dashboards/976) that is still in development.  The logic at this phase is still constantly being tested and adjusted.  This PR for merging into main is primarily for ease of sharing progress.  I am the only user of this dashboard and the lookml logic at the moment.



Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
