### PR TITLE
DENG 580 - updated dimensions to use GB format

### DIFF
--- a/monitoring/explores/bigquery_table_storage.explore.lkml
+++ b/monitoring/explores/bigquery_table_storage.explore.lkml
@@ -1,4 +1,15 @@
 include: "../views/bigquery_table_storage.view.lkml"
+include: "../views/bigquery_tables_inventory.view.lkml"
 
 explore: bigquery_table_storage {
+
+  join: bigquery_tables_inventory {
+    view_label: "Table Inventory"
+    fields: [bigquery_tables_inventory.table_type]
+    sql_on: ${bigquery_table_storage.project_id} = ${bigquery_tables_inventory.project_id}
+          AND ${bigquery_table_storage.dataset_id} = ${bigquery_tables_inventory.dataset_id}
+          AND ${bigquery_table_storage.table_id} = ${bigquery_tables_inventory.table_id}
+          ;;
+    relationship: one_to_one
+  }
 }

--- a/monitoring/explores/bigquery_table_storage_timeline_daily.explore.lkml
+++ b/monitoring/explores/bigquery_table_storage_timeline_daily.explore.lkml
@@ -1,5 +1,15 @@
-include: "../views//bigquery_table_storage_timeline_daily.view.lkml"
+include: "../views/bigquery_table_storage_timeline_daily.view.lkml"
+include: "../views/bigquery_tables_inventory.view.lkml"
 
 explore: bigquery_table_storage_timeline_daily {
-  from: bigquery_table_storage_timeline_daily
+
+  join: bigquery_tables_inventory {
+    view_label: "Table Inventory"
+    fields: [bigquery_tables_inventory.table_type]
+    sql_on: ${bigquery_table_storage_timeline_daily.project_id} = ${bigquery_tables_inventory.project_id}
+          AND ${bigquery_table_storage_timeline_daily.dataset_id} = ${bigquery_tables_inventory.dataset_id}
+          AND ${bigquery_table_storage_timeline_daily.table_id} = ${bigquery_tables_inventory.table_id}
+          ;;
+    relationship: one_to_one
+  }
 }

--- a/monitoring/explores/bigquery_tables_inventory.explore.lkml
+++ b/monitoring/explores/bigquery_tables_inventory.explore.lkml
@@ -1,5 +1,4 @@
-include: "../views//bigquery_tables_inventory.view.lkml"
+include: "../views/bigquery_tables_inventory.view.lkml"
 
 explore: bigquery_tables_inventory {
-  from: bigquery_tables_inventory
 }

--- a/monitoring/views/bigquery_table_storage.view.lkml
+++ b/monitoring/views/bigquery_table_storage.view.lkml
@@ -5,6 +5,7 @@ view: +bigquery_table_storage {
   measure: sum_total_rows{
     type: sum
     sql: ${total_rows} ;;
+    value_format: "#,##0,,\" M\""
   }
 
   measure: sum_total_partitions{
@@ -12,51 +13,58 @@ view: +bigquery_table_storage {
     sql: ${total_partitions} ;;
   }
 
-  measure: sum_total_logical_TB{
+  measure: sum_total_logical_GB{
     type: sum
-    sql: ${total_logical_bytes}/ 1024 / 1024 / 1024 / 1024 ;;
+    sql: ${total_logical_bytes}/POW(1024, 3) ;;
     value_format: "#,##0.00"
   }
 
-  measure: sum_active_logical_bytes{
+  measure: sum_active_logical_GB{
     type: sum
-    sql: ${active_logical_bytes} ;;
-  }
-
-  measure: sum_long_term_logical_bytes{
-    type: sum
-    sql: ${long_term_logical_bytes} ;;
-  }
-
-  measure: sum_total_physical_TB{
-    type: sum
-    sql: ${total_physical_bytes}/ 1024 / 1024 / 1024 / 1024 ;;
+    sql: ${active_logical_bytes}/POW(1024, 3) ;;
     value_format: "#,##0.00"
   }
 
-  measure: sum_active_physical_bytes{
+  measure: sum_long_term_logical_GB{
     type: sum
-    sql: ${active_physical_bytes} ;;
+    sql: ${long_term_logical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
   }
 
-  measure: sum_long_term_physical_bytes{
+  measure: sum_total_physical_GB{
     type: sum
-    sql: ${long_term_physical_bytes} ;;
+    sql: ${total_physical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
   }
 
-  measure: sum_time_travel_physical_bytes{
+  measure: sum_active_physical_GB{
     type: sum
-    sql: ${time_travel_physical_bytes} ;;
+    sql: ${active_physical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
+  }
+
+  measure: sum_long_term_physical_GB{
+    type: sum
+    sql: ${long_term_physical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
+  }
+
+  measure: sum_time_travel_physical_GB{
+    type: sum
+    sql: ${time_travel_physical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
   }
 
   measure: sum_logical_billing_cost_usd{
     type: sum
-    sql: ${logical_billing_cost_usd} ;;
+    sql: ${logical_billing_cost_usd};;
+    value_format:"$#,##0.00"
   }
 
   measure: sum_physical_billing_cost_usd{
     type: sum
-    sql: ${physical_billing_cost_usd} ;;
+    sql: ${physical_billing_cost_usd};;
+    value_format:"$#,##0.00"
   }
 
   measure: count{

--- a/monitoring/views/bigquery_table_storage_timeline_daily.view.lkml
+++ b/monitoring/views/bigquery_table_storage_timeline_daily.view.lkml
@@ -19,43 +19,43 @@ view: +bigquery_table_storage_timeline_daily {
     value_format: "#,##0,,\" M\""
   }
 
-  measure: sum_total_logical_terabytes{
+  measure: sum_total_logical_GB{
     type: sum
     sql: ${avg_total_logical_bytes}/POW(1024, 3) ;;
     value_format: "#,##0.00"
   }
 
-  measure: sum_active_logical_bytes{
+  measure: sum_active_logical_GB{
     type: sum
     sql: ${avg_active_logical_bytes}/POW(1024, 3) ;;
     value_format: "#,##0.00"
   }
 
-  measure: sum_long_term_logical_bytes{
+  measure: sum_long_term_logical_GB{
     type: sum
     sql: ${avg_long_term_logical_bytes}/POW(1024, 3) ;;
     value_format: "#,##0.00"
   }
 
-  measure: sum_total_physical_terabytes{
+  measure: sum_total_physical_GB{
     type: sum
     sql: ${avg_total_physical_bytes}/POW(1024, 3);;
     value_format: "#,##0.00"
   }
 
-  measure: sum_active_physical_bytes{
+  measure: sum_active_physical_GB{
     type: sum
     sql: ${avg_active_physical_bytes}/POW(1024, 3) ;;
     value_format: "#,##0.00"
   }
 
-  measure: sum_long_term_physical_bytes{
+  measure: sum_long_term_physical_GB{
     type: sum
     sql: ${avg_long_term_physical_bytes}/POW(1024, 3) ;;
     value_format: "#,##0.00"
   }
 
-  measure: sum_time_travel_physical_bytes{
+  measure: sum_time_travel_physical_GB{
     type: sum
     sql: ${avg_time_travel_physical_bytes}/POW(1024, 3) ;;
     value_format: "#,##0.00"

--- a/monitoring/views/bigquery_table_storage_timeline_daily.view.lkml
+++ b/monitoring/views/bigquery_table_storage_timeline_daily.view.lkml
@@ -10,56 +10,67 @@ view: +bigquery_table_storage_timeline_daily {
   measure: sum_total_rows{
     type: sum
     sql: ${avg_total_rows} ;;
+    value_format: "#,##0,,\" M\""
   }
 
   measure: sum_total_partitions{
     type: sum
     sql: ${avg_total_partitions} ;;
+    value_format: "#,##0,,\" M\""
   }
 
-  measure: sum_total_logical_bytes{
+  measure: sum_total_logical_terabytes{
     type: sum
-    sql: ${avg_total_logical_bytes} ;;
+    sql: ${avg_total_logical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
   }
 
   measure: sum_active_logical_bytes{
     type: sum
-    sql: ${avg_active_logical_bytes} ;;
+    sql: ${avg_active_logical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
   }
 
   measure: sum_long_term_logical_bytes{
     type: sum
-    sql: ${avg_long_term_logical_bytes} ;;
+    sql: ${avg_long_term_logical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
   }
 
-  measure: sum_total_physical_bytes{
+  measure: sum_total_physical_terabytes{
     type: sum
-    sql: ${avg_total_physical_bytes} ;;
+    sql: ${avg_total_physical_bytes}/POW(1024, 3);;
+    value_format: "#,##0.00"
   }
 
   measure: sum_active_physical_bytes{
     type: sum
-    sql: ${avg_active_physical_bytes} ;;
+    sql: ${avg_active_physical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
   }
 
   measure: sum_long_term_physical_bytes{
     type: sum
-    sql: ${avg_long_term_physical_bytes} ;;
+    sql: ${avg_long_term_physical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
   }
 
   measure: sum_time_travel_physical_bytes{
     type: sum
-    sql: ${avg_time_travel_physical_bytes} ;;
+    sql: ${avg_time_travel_physical_bytes}/POW(1024, 3) ;;
+    value_format: "#,##0.00"
   }
 
   measure: sum_logical_billing_cost_usd{
     type: sum
-    sql: ${avg_logical_billing_cost_usd} ;;
+    sql: ${avg_logical_billing_cost_usd};;
+    value_format:"$#,##0.00"
   }
 
   measure: sum_physical_billing_cost_usd{
     type: sum
-    sql: ${avg_physical_billing_cost_usd} ;;
+    sql: ${avg_physical_billing_cost_usd};;
+    value_format:"$#,##0.00"
   }
 
   measure: count{

--- a/monitoring/views/bigquery_usage.view.lkml
+++ b/monitoring/views/bigquery_usage.view.lkml
@@ -18,6 +18,16 @@ view: +bigquery_usage {
     type: string
   }
 
+  dimension: destination_table_id {
+    sql: split(destination_table_id, '$')[SAFE_OFFSET(0)];;
+    type: string
+  }
+
+  dimension: partition {
+    sql: split(destination_table_id, '$')[SAFE_OFFSET(1)];;
+    type: string
+  }
+
   measure: avg_total_job_cost_usd{
     type: average_distinct
     sql_distinct_key: ${job_id} ;;


### PR DESCRIPTION
This lookml is used for the Data Platform Usage Monitoring dashboards.  It is currently being actively developed and tested.  The current phase is poc and will likely require more iterations of changes.  The impact and risk is low for reviewing this PR.

[DENG 580](https://mozilla-hub.atlassian.net/browse/DENG-580):  Updated fields related to storage size in unit of GB.  This is because storage costs are in the unit of GB.

* connected table storage explores with table inventory to allow filtering by table type

* destination tables with partitions were showing up in job usage table as separate rows.  Destination table name and partition were extracted to separate dimensions to allow grouping by destination tables names without partition.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
