### PR TITLE
DENG-592:  Added table storage cost calcluations

### DIFF
--- a/monitoring/views/bigquery_table_storage.view.lkml
+++ b/monitoring/views/bigquery_table_storage.view.lkml
@@ -57,13 +57,13 @@ view: +bigquery_table_storage {
 
   measure: sum_logical_billing_cost_usd{
     type: sum
-    sql: ${logical_billing_cost_usd};;
+    sql: (${active_logical_bytes}/POW(1024, 3) * 0.02) + ((${long_term_logical_bytes}/POW(1024, 3)) * 0.01);;
     value_format:"$#,##0.00"
   }
 
   measure: sum_physical_billing_cost_usd{
     type: sum
-    sql: ${physical_billing_cost_usd};;
+    sql: (${active_physical_bytes}/POW(1024, 3) * 0.04) + ((${long_term_physical_bytes}/POW(1024, 3)) * 0.02);;
     value_format:"$#,##0.00"
   }
 

--- a/monitoring/views/bigquery_table_storage_timeline_daily.view.lkml
+++ b/monitoring/views/bigquery_table_storage_timeline_daily.view.lkml
@@ -63,13 +63,13 @@ view: +bigquery_table_storage_timeline_daily {
 
   measure: sum_logical_billing_cost_usd{
     type: sum
-    sql: ${avg_logical_billing_cost_usd};;
+    sql: (${avg_active_logical_bytes}/POW(1024, 3) * 0.02) + ((${avg_long_term_logical_bytes}/ POW(1024, 3)) * 0.01);;
     value_format:"$#,##0.00"
   }
 
   measure: sum_physical_billing_cost_usd{
     type: sum
-    sql: ${avg_physical_billing_cost_usd};;
+    sql: (${avg_active_physical_bytes}/POW(1024, 3) * 0.04) + ((${avg_long_term_physical_bytes}/ POW(1024, 3)) * 0.02);;
     value_format:"$#,##0.00"
   }
 


### PR DESCRIPTION
[DENG-592](https://mozilla-hub.atlassian.net/browse/DENG-592):  

Added storage calculations in lookml.  The calcluations were removed from bqetl ([PR #3451](https://github.com/mozilla/bigquery-etl/pull/3451)).  In the event that GCP storage costs per GB change in the future then we can manage that change a little bit easier. 

These lookmls are being actively developed and will likely change after some iterations. The impact and risk is low.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
