### PR TITLE
Mobile activation

### DIFF
--- a/duet/explores/fenix_new_profile_activation.explore.lkml
+++ b/duet/explores/fenix_new_profile_activation.explore.lkml
@@ -1,0 +1,17 @@
+include: "../../fenix/views/new_profile_activation_table.view.lkml"
+include: "/shared/views/*"
+
+explore: fenix_new_profile_activation {
+  label: "Activation Metric for Firefox for Android (Fenix)"
+  view_name: new_profile_activation_table
+
+  always_filter: {
+    filters: [new_profile_activation_table.submission_date: "7 days",]
+  }
+
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${new_profile_activation_table.country} = ${countries.code} ;;
+  }
+}

--- a/fenix/explores/new_profile_activation.explore.lkml
+++ b/fenix/explores/new_profile_activation.explore.lkml
@@ -1,4 +1,4 @@
-include: "../../fenix/views/new_profile_activation_table.view.lkml"
+include: "../views/new_profile_activation_table.view.lkml"
 include: "/shared/views/*"
 
 explore: fenix_new_profile_activation {

--- a/fenix/fenix.model.lkml
+++ b/fenix/fenix.model.lkml
@@ -1,6 +1,7 @@
 connection: "telemetry"
 label: "Firefox for Android"
 include: "//looker-hub/fenix/explores/*"
+include: "explores/*.explore.lkml"
 
 
 explore: +topsites_impression {

--- a/fenix/views/new_profile_activation_table.view.lkml
+++ b/fenix/views/new_profile_activation_table.view.lkml
@@ -1,0 +1,58 @@
+include: "//looker-hub/fenix/views/new_profile_activation_table.view.lkml"
+
+view: +new_profile_activation_table {
+
+  dimension: activated {
+    hidden: yes
+    sql: ${TABLE}.activated ;;
+  }
+
+  measure: activated_sum {
+    label: "Activated"
+    type: sum
+    sql: ${TABLE}.activated ;;
+  }
+
+  dimension: new_profile {
+    hidden: yes
+    sql: ${TABLE}.new_profile ;;
+  }
+
+  measure: new_profile_sum {
+    label: "New Profiles"
+    type: sum
+    sql: ${TABLE}.new_profile ;;
+  }
+
+  measure: activation_rate {
+    label: "Activation Rate"
+    type: number
+    value_format_name: percent_2
+    sql: ${activated_sum}/ NULLIF(${new_profile_sum},0) ;;
+  }
+
+  dimension: adjust_adgroup {
+    group_label: "Adjust parameters"
+    type: string
+    sql: ${TABLE}.adjust_adgroup ;;
+  }
+
+  dimension: adjust_campaign {
+    group_label: "Adjust parameters"
+    type: string
+    sql: ${TABLE}.adjust_campaign ;;
+  }
+
+  dimension: adjust_creative {
+    group_label: "Adjust parameters"
+    type: string
+    sql: ${TABLE}.adjust_creative ;;
+  }
+
+  dimension: adjust_network {
+    group_label: "Adjust parameters"
+    type: string
+    sql: ${TABLE}.adjust_network ;;
+  }
+
+}

--- a/firefox_ios/explores/new_profile_activation.explore.lkml
+++ b/firefox_ios/explores/new_profile_activation.explore.lkml
@@ -1,0 +1,17 @@
+include: "../views/new_profile_activation_table.view.lkml"
+include: "/shared/views/*"
+
+explore: firefox_ios_new_profile_activation {
+  label: "Activation Metric for Firefox for iOS"
+  view_name: new_profile_activation_table
+
+  always_filter: {
+    filters: [new_profile_activation_table.submission_date: "7 days",]
+  }
+
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${new_profile_activation_table.country} = ${countries.code} ;;
+  }
+}

--- a/firefox_ios/firefox_ios.model.lkml
+++ b/firefox_ios/firefox_ios.model.lkml
@@ -5,6 +5,7 @@ include: "//looker-hub/firefox_ios/views/*.view.lkml"
 include: "//looker-hub/firefox_ios/explores/*.explore.lkml"
 include: "views/*.view.lkml"
 include: "dashboards/*.dashboard"
+include: "explores/*.explore.lkml"
 
 explore: usage {
   always_filter: {

--- a/firefox_ios/views/new_profile_activation_table.view.lkml
+++ b/firefox_ios/views/new_profile_activation_table.view.lkml
@@ -1,0 +1,34 @@
+include: "//looker-hub/firefox_ios/views/new_profile_activation_table.view.lkml"
+
+view: +new_profile_activation_table {
+
+  dimension: activated {
+    hidden: yes
+    sql: ${TABLE}.activated ;;
+  }
+
+  measure: activated_sum {
+    label: "Activated"
+    type: sum
+    sql: ${TABLE}.activated ;;
+  }
+
+  dimension: new_profile {
+    hidden: yes
+    sql: ${TABLE}.new_profile ;;
+  }
+
+  measure: new_profile_sum {
+    label: "New Profiles"
+    type: sum
+    sql: ${TABLE}.new_profile ;;
+  }
+
+  measure: activation_rate {
+    label: "Activation Rate"
+    type: number
+    value_format_name: percent_2
+    sql: ${activated_sum}/ NULLIF(${new_profile_sum},0) ;;
+  }
+
+}


### PR DESCRIPTION
Create explores for the new [mobile activation metric](https://docs.google.com/document/d/1ab2bRcmOdkxgLu-Xin7fZ25qFZGY5IyyMEkVCB1jSoQ/edit#).

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
