### PR TITLE
add ad cost breakdowns explore

### DIFF
--- a/duet/explores/ad_cost_breakdowns.explore.lkml
+++ b/duet/explores/ad_cost_breakdowns.explore.lkml
@@ -1,3 +1,5 @@
 include: "../views/ad_cost_breakdowns.view"
 
-explore: ad_cost_breakdowns {}
+explore: ad_cost_breakdowns {
+
+}

--- a/duet/explores/ad_cost_breakdowns.explore.lkml
+++ b/duet/explores/ad_cost_breakdowns.explore.lkml
@@ -1,0 +1,3 @@
+include: "../views/ad_cost_breakdowns.view"
+
+explore: ad_cost_breakdowns {}

--- a/duet/views/ad_cost_breakdowns.view.lkml
+++ b/duet/views/ad_cost_breakdowns.view.lkml
@@ -2,6 +2,10 @@ include: "//looker-hub/revenue/views/ad_cost_breakdowns.view"
 
 view: +ad_cost_breakdowns {
 
+  dimension: campaign_name {
+    sql: ${TABLE}.campaign_name ;;
+    type: string
+  }
 
   dimension: ad_conversions {
     sql: ${TABLE}.ad_conversions ;;
@@ -12,7 +16,8 @@ view: +ad_cost_breakdowns {
   measure: measure_ad_conversions {
     label: "ad_conversions"
     sql: ${TABLE}.ad_conversions ;;
-    type: number
+    type: sum_distinct
+    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 
   dimension: ad_impressions {
@@ -24,12 +29,8 @@ view: +ad_cost_breakdowns {
   measure: measure_ad_impressions {
     label: "ad_impressions"
     sql: ${TABLE}.ad_impressions ;;
-    type: number
-  }
-
-  dimension: campaign_name {
-    sql: ${TABLE}.campaign_name ;;
-    type: string
+    type: sum_distinct
+    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 
   dimension: campaign_spend_in_micros {
@@ -41,55 +42,8 @@ view: +ad_cost_breakdowns {
   measure: measure_campaign_spend_in_micros {
     label: "campaign_spend_in_micros"
     sql: ${TABLE}.campaign_spend_in_micros ;;
-    type: number
-  }
-
-  dimension: cost_per_dou_micros {
-    sql: ${TABLE}.cost_per_dou_micros ;;
-    type: number
-    hidden: yes
-  }
-
-  measure: measure_cost_per_dou_micros {
-    label: "cost_per_dou_micros"
-    sql: ${TABLE}.cost_per_dou_micros ;;
-    type: number
-  }
-
-  dimension: cost_per_install_micros {
-    sql: ${TABLE}.cost_per_install_micros ;;
-    type: number
-    hidden: yes
-  }
-
-  measure: measure_cost_per_install_micros {
-    label: "cost_per_install_micros"
-    sql: ${TABLE}.cost_per_install_micros ;;
-    type: number
-  }
-
-  dimension: cost_per_marketing_ad_click_micros {
-    sql: ${TABLE}.cost_per_marketing_ad_click_micros ;;
-    type: number
-    hidden: yes
-  }
-
-  measure: measure_cost_per_marketing_ad_click_micros {
-    label: "cost_per_marketing_ad_click_micros"
-    sql: ${TABLE}.cost_per_marketing_ad_click_micros ;;
-    type: number
-  }
-
-  dimension: cost_per_revenue_generating_ad_click_micros {
-    sql: ${TABLE}.cost_per_revenue_generating_ad_click_micros ;;
-    type: number
-    hidden: yes
-  }
-
-  measure: measure_cost_per_revenue_generating_ad_click_micros {
-    label: "cost_per_revenue_generating_ad_click_micros"
-    sql: ${TABLE}.cost_per_revenue_generating_ad_click_micros ;;
-    type: number
+    type: sum_distinct
+    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 
   dimension: dous {
@@ -101,7 +55,8 @@ view: +ad_cost_breakdowns {
   measure: measure_dous {
     label: "dous"
     sql: ${TABLE}.dous ;;
-    type: number
+    type: sum_distinct
+    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 
   dimension: installs {
@@ -113,7 +68,8 @@ view: +ad_cost_breakdowns {
   measure: measure_installs {
     label: "installs"
     sql: ${TABLE}.installs ;;
-    type: number
+    type: sum_distinct
+    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 
   dimension: marketing_ad_clicks {
@@ -125,7 +81,8 @@ view: +ad_cost_breakdowns {
   measure: measure_marketing_ad_clicks {
     label: "marketing_ad_clicks"
     sql: ${TABLE}.marketing_ad_clicks ;;
-    type: number
+    type: sum_distinct
+    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 
   dimension: revenue_generating_ad_clicks {
@@ -137,6 +94,7 @@ view: +ad_cost_breakdowns {
   measure: measure_revenue_generating_ad_clicks {
     label: "revenue_generating_ad_clicks"
     sql: ${TABLE}.revenue_generating_ad_clicks ;;
-    type: number
+    type: sum_distinct
+    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 }

--- a/duet/views/ad_cost_breakdowns.view.lkml
+++ b/duet/views/ad_cost_breakdowns.view.lkml
@@ -36,23 +36,9 @@ view: +ad_cost_breakdowns {
     type: number
   }
 
-  measure: measure_ad_conversions {
-    label: "ad_conversions"
-    sql: ${TABLE}.ad_conversions ;;
-    type: sum_distinct
-    sql_distinct_key: ${TABLE}.campaign_name ;;
-  }
-
   dimension: ad_impressions {
     sql: ${TABLE}.ad_impressions ;;
     type: number
-  }
-
-  measure: measure_ad_impressions {
-    label: "ad_impressions"
-    sql: ${TABLE}.ad_impressions ;;
-    type: sum_distinct
-    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 
   dimension: campaign_spend_in_micros {
@@ -60,23 +46,9 @@ view: +ad_cost_breakdowns {
     type: number
   }
 
-  measure: measure_campaign_spend_in_micros {
-    label: "campaign_spend_in_micros"
-    sql: ${TABLE}.campaign_spend_in_micros ;;
-    type: sum_distinct
-    sql_distinct_key: ${TABLE}.campaign_name ;;
-  }
-
   dimension: dous {
     sql: ${TABLE}.dous ;;
     type: number
-  }
-
-  measure: measure_dous {
-    label: "dous"
-    sql: ${TABLE}.dous ;;
-    type: sum_distinct
-    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 
   dimension: installs {
@@ -84,23 +56,9 @@ view: +ad_cost_breakdowns {
     type: number
   }
 
-  measure: measure_installs {
-    label: "installs"
-    sql: ${TABLE}.installs ;;
-    type: sum_distinct
-    sql_distinct_key: ${TABLE}.campaign_name ;;
-  }
-
   dimension: marketing_ad_clicks {
     sql: ${TABLE}.marketing_ad_clicks ;;
     type: number
-  }
-
-  measure: measure_marketing_ad_clicks {
-    label: "marketing_ad_clicks"
-    sql: ${TABLE}.marketing_ad_clicks ;;
-    type: sum_distinct
-    sql_distinct_key: ${TABLE}.campaign_name ;;
   }
 
   dimension: revenue_generating_ad_clicks {
@@ -108,10 +66,4 @@ view: +ad_cost_breakdowns {
     type: number
   }
 
-  measure: measure_revenue_generating_ad_clicks {
-    label: "revenue_generating_ad_clicks"
-    sql: ${TABLE}.revenue_generating_ad_clicks ;;
-    type: sum_distinct
-    sql_distinct_key: ${TABLE}.campaign_name ;;
-  }
 }

--- a/duet/views/ad_cost_breakdowns.view.lkml
+++ b/duet/views/ad_cost_breakdowns.view.lkml
@@ -60,7 +60,6 @@ view: +ad_cost_breakdowns {
   dimension: campaign_spend_in_micros {
     sql: ${TABLE}.campaign_spend_in_micros ;;
     type: number
-    hidden: yes
   }
 
   measure: measure_campaign_spend_in_micros {
@@ -73,7 +72,6 @@ view: +ad_cost_breakdowns {
   dimension: dous {
     sql: ${TABLE}.dous ;;
     type: number
-    hidden: yes
   }
 
   measure: measure_dous {

--- a/duet/views/ad_cost_breakdowns.view.lkml
+++ b/duet/views/ad_cost_breakdowns.view.lkml
@@ -7,6 +7,30 @@ view: +ad_cost_breakdowns {
     type: string
   }
 
+  dimension: cost_per_dou_micros {
+    sql: ${TABLE}.cost_per_dou_micros ;;
+    type: number
+    hidden: yes
+  }
+
+  dimension: cost_per_install_micros {
+    sql: ${TABLE}.cost_per_install_micros ;;
+    type: number
+    hidden: yes
+  }
+
+  dimension: cost_per_marketing_ad_click_micros {
+    sql: ${TABLE}.cost_per_marketing_ad_click_micros ;;
+    type: number
+    hidden: yes
+  }
+
+  dimension: cost_per_revenue_generating_ad_click_micros {
+    sql: ${TABLE}.cost_per_revenue_generating_ad_click_micros ;;
+    type: number
+    hidden: yes
+  }
+
   dimension: ad_conversions {
     sql: ${TABLE}.ad_conversions ;;
     type: number

--- a/duet/views/ad_cost_breakdowns.view.lkml
+++ b/duet/views/ad_cost_breakdowns.view.lkml
@@ -1,3 +1,142 @@
 include: "//looker-hub/revenue/views/ad_cost_breakdowns.view"
 
-view: +ad_cost_breakdowns {}
+view: +ad_cost_breakdowns {
+
+
+  dimension: ad_conversions {
+    sql: ${TABLE}.ad_conversions ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_ad_conversions {
+    label: "ad_conversions"
+    sql: ${TABLE}.ad_conversions ;;
+    type: number
+  }
+
+  dimension: ad_impressions {
+    sql: ${TABLE}.ad_impressions ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_ad_impressions {
+    label: "ad_impressions"
+    sql: ${TABLE}.ad_impressions ;;
+    type: number
+  }
+
+  dimension: campaign_name {
+    sql: ${TABLE}.campaign_name ;;
+    type: string
+  }
+
+  dimension: campaign_spend_in_micros {
+    sql: ${TABLE}.campaign_spend_in_micros ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_campaign_spend_in_micros {
+    label: "campaign_spend_in_micros"
+    sql: ${TABLE}.campaign_spend_in_micros ;;
+    type: number
+  }
+
+  dimension: cost_per_dou_micros {
+    sql: ${TABLE}.cost_per_dou_micros ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_cost_per_dou_micros {
+    label: "cost_per_dou_micros"
+    sql: ${TABLE}.cost_per_dou_micros ;;
+    type: number
+  }
+
+  dimension: cost_per_install_micros {
+    sql: ${TABLE}.cost_per_install_micros ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_cost_per_install_micros {
+    label: "cost_per_install_micros"
+    sql: ${TABLE}.cost_per_install_micros ;;
+    type: number
+  }
+
+  dimension: cost_per_marketing_ad_click_micros {
+    sql: ${TABLE}.cost_per_marketing_ad_click_micros ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_cost_per_marketing_ad_click_micros {
+    label: "cost_per_marketing_ad_click_micros"
+    sql: ${TABLE}.cost_per_marketing_ad_click_micros ;;
+    type: number
+  }
+
+  dimension: cost_per_revenue_generating_ad_click_micros {
+    sql: ${TABLE}.cost_per_revenue_generating_ad_click_micros ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_cost_per_revenue_generating_ad_click_micros {
+    label: "cost_per_revenue_generating_ad_click_micros"
+    sql: ${TABLE}.cost_per_revenue_generating_ad_click_micros ;;
+    type: number
+  }
+
+  dimension: dous {
+    sql: ${TABLE}.dous ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_dous {
+    label: "dous"
+    sql: ${TABLE}.dous ;;
+    type: number
+  }
+
+  dimension: installs {
+    sql: ${TABLE}.installs ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_installs {
+    label: "installs"
+    sql: ${TABLE}.installs ;;
+    type: number
+  }
+
+  dimension: marketing_ad_clicks {
+    sql: ${TABLE}.marketing_ad_clicks ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_marketing_ad_clicks {
+    label: "marketing_ad_clicks"
+    sql: ${TABLE}.marketing_ad_clicks ;;
+    type: number
+  }
+
+  dimension: revenue_generating_ad_clicks {
+    sql: ${TABLE}.revenue_generating_ad_clicks ;;
+    type: number
+    hidden: yes
+  }
+
+  measure: measure_revenue_generating_ad_clicks {
+    label: "revenue_generating_ad_clicks"
+    sql: ${TABLE}.revenue_generating_ad_clicks ;;
+    type: number
+  }
+}

--- a/duet/views/ad_cost_breakdowns.view.lkml
+++ b/duet/views/ad_cost_breakdowns.view.lkml
@@ -1,0 +1,3 @@
+include: "//looker-hub/revenue/views/ad_cost_breakdowns.view"
+
+view: +ad_cost_breakdowns {}

--- a/duet/views/ad_cost_breakdowns.view.lkml
+++ b/duet/views/ad_cost_breakdowns.view.lkml
@@ -34,7 +34,6 @@ view: +ad_cost_breakdowns {
   dimension: ad_conversions {
     sql: ${TABLE}.ad_conversions ;;
     type: number
-    hidden: yes
   }
 
   measure: measure_ad_conversions {
@@ -47,7 +46,6 @@ view: +ad_cost_breakdowns {
   dimension: ad_impressions {
     sql: ${TABLE}.ad_impressions ;;
     type: number
-    hidden: yes
   }
 
   measure: measure_ad_impressions {
@@ -84,7 +82,6 @@ view: +ad_cost_breakdowns {
   dimension: installs {
     sql: ${TABLE}.installs ;;
     type: number
-    hidden: yes
   }
 
   measure: measure_installs {
@@ -97,7 +94,6 @@ view: +ad_cost_breakdowns {
   dimension: marketing_ad_clicks {
     sql: ${TABLE}.marketing_ad_clicks ;;
     type: number
-    hidden: yes
   }
 
   measure: measure_marketing_ad_clicks {
@@ -110,7 +106,6 @@ view: +ad_cost_breakdowns {
   dimension: revenue_generating_ad_clicks {
     sql: ${TABLE}.revenue_generating_ad_clicks ;;
     type: number
-    hidden: yes
   }
 
   measure: measure_revenue_generating_ad_clicks {

--- a/google_ad_cost_per_dou.view.lkml
+++ b/google_ad_cost_per_dou.view.lkml
@@ -1,0 +1,39 @@
+view: google_ad_cost_per_dou {
+  derived_table: {
+    sql: SELECT
+          ad_cost_breakdowns.campaign_name  AS ad_cost_breakdowns_campaign_name,
+          SUM(ad_cost_breakdowns.campaign_spend_in_micros) AS ad_cost_breakdowns_measure_campaign_spend_in_micros,
+          SUM(ad_cost_breakdowns.dous) AS ad_cost_breakdowns_measure_dous
+      FROM `moz-fx-data-shared-prod.fenix_derived.google_ads_campaign_cost_breakdowns_v1`  AS ad_cost_breakdowns
+      GROUP BY
+          1
+      ORDER BY
+          2 DESC
+      LIMIT 500
+       ;;
+  }
+
+  measure: count {
+    type: count
+    drill_fields: [detail*]
+  }
+
+  dimension: ad_cost_breakdowns_campaign_name {
+    type: string
+    sql: ${TABLE}.ad_cost_breakdowns_campaign_name ;;
+  }
+
+  dimension: ad_cost_breakdowns_measure_campaign_spend_in_micros {
+    type: number
+    sql: ${TABLE}.ad_cost_breakdowns_measure_campaign_spend_in_micros ;;
+  }
+
+  dimension: ad_cost_breakdowns_measure_dous {
+    type: number
+    sql: ${TABLE}.ad_cost_breakdowns_measure_dous ;;
+  }
+
+  set: detail {
+    fields: [ad_cost_breakdowns_campaign_name, ad_cost_breakdowns_measure_campaign_spend_in_micros, ad_cost_breakdowns_measure_dous]
+  }
+}


### PR DESCRIPTION
Adds ad_cost_breakdowns explore so I can create tables for the CPA dashboard! 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
