### PR TITLE
DO-947, DENG-784 Rollups and add topsites metrics for Newtab interactions 

### DIFF
--- a/firefox_desktop/explores/newtab_interactions.explore.lkml
+++ b/firefox_desktop/explores/newtab_interactions.explore.lkml
@@ -1,8 +1,9 @@
 include: "../views/newtab_interactions.view.lkml"
 include: "../../shared/views/countries.view.lkml"
-include: "//looker-hub/firefox_desktop/datagroups/newtab_interactions_v1_last_updated.datagroup.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/newtab_interactions_v1_last_updated.datagroup"
 
 explore: newtab_interactions {
+  persist_with: newtab_interactions_v1_last_updated
   sql_always_where: ${newtab_interactions.submission_date} >= '2022-07-01' ;;
   label: "New Tab Interactions"
   from: newtab_interactions

--- a/firefox_desktop/explores/newtab_interactions.explore.lkml
+++ b/firefox_desktop/explores/newtab_interactions.explore.lkml
@@ -1,9 +1,8 @@
 include: "../views/newtab_interactions.view.lkml"
 include: "../../shared/views/countries.view.lkml"
-include: "//looker-hub/firefox_desktop/datagroups/newtab_interactions_v1_last_updated.datagroup"
+include: "//looker-hub/firefox_desktop/datagroups/newtab_interactions_v1_last_updated.datagroup.lkml"
 
 explore: newtab_interactions {
-  persist_with: newtab_interactions_v1_last_updated
   sql_always_where: ${newtab_interactions.submission_date} >= '2022-07-01' ;;
   label: "New Tab Interactions"
   from: newtab_interactions
@@ -32,6 +31,8 @@ explore: newtab_interactions {
         newtab_interactions.pocket_sponsored_stories_enabled,
         newtab_interactions.topsites_enabled,
         countries.tier,
+        countries.name,
+        countries.pocket_available_on_newtab,
       ]
       measures: [
         newtab_interactions.visits,
@@ -41,13 +42,7 @@ explore: newtab_interactions {
     }
 
     materialization: {
-      sql_trigger_value:
-      SELECT
-        MAX(last_modified_time)
-      FROM
-        moz-fx-data-shared-prod.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
-      WHERE
-        table_name = "newtab_interactions_v1";;
+      datagroup_trigger: newtab_interactions_v1_last_updated
       increment_key: newtab_interactions.submission_date
       increment_offset: 1
     }
@@ -61,6 +56,8 @@ explore: newtab_interactions {
         newtab_interactions.country_code,
         newtab_interactions.pocket_story_position,
         countries.tier,
+        countries.name,
+        countries.pocket_available_on_newtab,
       ]
       measures: [
         newtab_interactions.visits_with_pocket_impressions,
@@ -97,13 +94,7 @@ explore: newtab_interactions {
     }
 
     materialization: {
-      sql_trigger_value:
-      SELECT
-        MAX(last_modified_time)
-      FROM
-        moz-fx-data-shared-prod.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
-      WHERE
-        table_name = "newtab_interactions_v1";;
+      datagroup_trigger: newtab_interactions_v1_last_updated
       increment_key: newtab_interactions.submission_date
       increment_offset: 1
     }
@@ -117,6 +108,8 @@ explore: newtab_interactions {
         newtab_interactions.country_code,
         newtab_interactions.search_engine,
         countries.tier,
+        countries.name,
+        countries.pocket_available_on_newtab,
       ]
       measures: [
         newtab_interactions.visits_with_search,
@@ -147,13 +140,7 @@ explore: newtab_interactions {
     }
 
     materialization: {
-      sql_trigger_value:
-      SELECT
-        MAX(last_modified_time)
-      FROM
-        moz-fx-data-shared-prod.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
-      WHERE
-        table_name = "newtab_interactions_v1";;
+      datagroup_trigger: newtab_interactions_v1_last_updated
       increment_key: newtab_interactions.submission_date
       increment_offset: 1
     }
@@ -166,6 +153,7 @@ explore: newtab_interactions {
         newtab_interactions.channel,
         newtab_interactions.country_code,
         countries.tier,
+        countries.name,
       ]
       measures: [
         newtab_interactions.visits_with_topsite_click,
@@ -185,13 +173,7 @@ explore: newtab_interactions {
     }
 
     materialization: {
-      sql_trigger_value:
-      SELECT
-        MAX(last_modified_time)
-      FROM
-        moz-fx-data-shared-prod.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
-      WHERE
-        table_name = "newtab_interactions_v1";;
+      datagroup_trigger: newtab_interactions_v1_last_updated
       increment_key: newtab_interactions.submission_date
       increment_offset: 1
     }

--- a/firefox_desktop/explores/newtab_interactions.explore.lkml
+++ b/firefox_desktop/explores/newtab_interactions.explore.lkml
@@ -19,4 +19,182 @@ explore: newtab_interactions {
     relationship: one_to_one
     sql_on: ${newtab_interactions.country_code} = ${countries.code} ;;
   }
+
+  aggregate_table: rollup__newtab_interactions_general_per_day {
+    query: {
+      dimensions: [
+        newtab_interactions.submission_date,
+        newtab_interactions.channel,
+        newtab_interactions.country_code,
+        newtab_interactions.activity_segment,
+        newtab_interactions.pocket_enabled,
+        newtab_interactions.pocket_is_signed_in,
+        newtab_interactions.pocket_sponsored_stories_enabled,
+        newtab_interactions.topsites_enabled,
+        countries.tier,
+      ]
+      measures: [
+        newtab_interactions.visits,
+        newtab_interactions.clients,
+      ]
+      filters: [newtab_interactions.submission_date: "after 2022-07-01"]
+    }
+
+    materialization: {
+      sql_trigger_value:
+      SELECT
+        MAX(last_modified_time)
+      FROM
+        moz-fx-data-shared-prod.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
+      WHERE
+        table_name = "newtab_interactions_v1";;
+      increment_key: newtab_interactions.submission_date
+      increment_offset: 1
+    }
+  }
+
+  aggregate_table: rollup__newtab_interactions_pocket_per_day {
+    query: {
+      dimensions: [
+        newtab_interactions.submission_date,
+        newtab_interactions.channel,
+        newtab_interactions.country_code,
+        newtab_interactions.pocket_story_position,
+        countries.tier,
+      ]
+      measures: [
+        newtab_interactions.visits_with_pocket_impressions,
+        newtab_interactions.visits_with_pocket_saves,
+        newtab_interactions.visits_with_pocket_clicks,
+        newtab_interactions.visits_with_organic_pocket_impressions,
+        newtab_interactions.visits_with_organic_pocket_saves,
+        newtab_interactions.visits_with_organic_pocket_clicks,
+        newtab_interactions.visits_with_sponsored_pocket_impressions,
+        newtab_interactions.visits_with_sponsored_pocket_saves,
+        newtab_interactions.visits_with_sponsored_pocket_clicks,
+
+        newtab_interactions.sum_pocket_impressions,
+        newtab_interactions.sum_pocket_saves,
+        newtab_interactions.sum_pocket_clicks,
+        newtab_interactions.sum_organic_pocket_impressions,
+        newtab_interactions.sum_organic_pocket_saves,
+        newtab_interactions.sum_organic_pocket_clicks,
+        newtab_interactions.sum_sponsored_pocket_impressions,
+        newtab_interactions.sum_sponsored_pocket_saves,
+        newtab_interactions.sum_sponsored_pocket_clicks,
+
+        newtab_interactions.clients_with_pocket_impressions,
+        newtab_interactions.clients_with_pocket_saves,
+        newtab_interactions.clients_with_pocket_clicks,
+        newtab_interactions.clients_with_organic_pocket_impressions,
+        newtab_interactions.clients_with_organic_pocket_saves,
+        newtab_interactions.clients_with_organic_pocket_clicks,
+        newtab_interactions.clients_with_sponsored_pocket_impressions,
+        newtab_interactions.clients_with_sponsored_pocket_saves,
+        newtab_interactions.clients_with_sponsored_pocket_clicks,
+      ]
+      filters: [newtab_interactions.submission_date: "after 2022-07-01"]
+    }
+
+    materialization: {
+      sql_trigger_value:
+      SELECT
+        MAX(last_modified_time)
+      FROM
+        moz-fx-data-shared-prod.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
+      WHERE
+        table_name = "newtab_interactions_v1";;
+      increment_key: newtab_interactions.submission_date
+      increment_offset: 1
+    }
+  }
+
+  aggregate_table: rollup__newtab_interactions_search_per_day {
+    query: {
+      dimensions: [
+        newtab_interactions.submission_date,
+        newtab_interactions.channel,
+        newtab_interactions.country_code,
+        newtab_interactions.search_engine,
+        countries.tier,
+      ]
+      measures: [
+        newtab_interactions.visits_with_search,
+        newtab_interactions.visits_with_tagged_search_ad_impression,
+        newtab_interactions.visits_with_tagged_search_ad_click,
+        newtab_interactions.visits_with_tagged_follow_on_search_ad_impression,
+        newtab_interactions.visits_with_tagged_follow_on_search_ad_click,
+        newtab_interactions.visits_with_any_ad_click,
+        newtab_interactions.visits_with_any_ad_impression,
+
+        newtab_interactions.sum_searches,
+        newtab_interactions.sum_tagged_search_ad_impressions,
+        newtab_interactions.sum_tagged_search_ad_clicks,
+        newtab_interactions.sum_tagged_follow_on_search_ad_impressions,
+        newtab_interactions.sum_tagged_follow_on_search_ad_clicks,
+        newtab_interactions.sum_all_search_ad_clicks,
+        newtab_interactions.sum_all_search_ad_impressions,
+
+        newtab_interactions.clients_with_search,
+        newtab_interactions.clients_with_tagged_search_ad_impression,
+        newtab_interactions.clients_with_tagged_search_ad_click,
+        newtab_interactions.clients_with_tagged_follow_on_search_ad_impression,
+        newtab_interactions.clients_with_tagged_follow_on_search_ad_click,
+        newtab_interactions.clients_with_any_ad_click,
+        newtab_interactions.clients_with_any_ad_impression,
+      ]
+      filters: [newtab_interactions.submission_date: "after 2022-07-01"]
+    }
+
+    materialization: {
+      sql_trigger_value:
+      SELECT
+        MAX(last_modified_time)
+      FROM
+        moz-fx-data-shared-prod.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
+      WHERE
+        table_name = "newtab_interactions_v1";;
+      increment_key: newtab_interactions.submission_date
+      increment_offset: 1
+    }
+  }
+
+  aggregate_table: rollup__newtab_interactions_topsites_per_day {
+    query: {
+      dimensions: [
+        newtab_interactions.submission_date,
+        newtab_interactions.channel,
+        newtab_interactions.country_code,
+        countries.tier,
+      ]
+      measures: [
+        newtab_interactions.visits_with_topsite_click,
+        newtab_interactions.visits_with_topsite_impression,
+        newtab_interactions.visits_with_sponsored_topsite_click,
+        newtab_interactions.visits_with_sponsored_topsite_impression,
+        newtab_interactions.sum_topsite_clicks,
+        newtab_interactions.sum_topsite_impressions,
+        newtab_interactions.sum_sponsored_topsite_clicks,
+        newtab_interactions.sum_sponsored_topsite_impressions,
+        newtab_interactions.clients_with_topsite_click,
+        newtab_interactions.clients_with_topsite_impression,
+        newtab_interactions.clients_with_sponsored_topsite_click,
+        newtab_interactions.clients_with_sponsored_topsite_impression,
+      ]
+      filters: [newtab_interactions.submission_date: "after 2022-07-01"]
+    }
+
+    materialization: {
+      sql_trigger_value:
+      SELECT
+        MAX(last_modified_time)
+      FROM
+        moz-fx-data-shared-prod.telemetry_derived.INFORMATION_SCHEMA.PARTITIONS
+      WHERE
+        table_name = "newtab_interactions_v1";;
+      increment_key: newtab_interactions.submission_date
+      increment_offset: 1
+    }
+  }
+
 }

--- a/firefox_desktop/explores/newtab_interactions.explore.lkml
+++ b/firefox_desktop/explores/newtab_interactions.explore.lkml
@@ -31,6 +31,7 @@ explore: newtab_interactions {
         newtab_interactions.pocket_is_signed_in,
         newtab_interactions.pocket_sponsored_stories_enabled,
         newtab_interactions.topsites_enabled,
+        newtab_interactions.topsites_rows,
         countries.tier,
         countries.name,
         countries.pocket_available_on_newtab,
@@ -153,22 +154,30 @@ explore: newtab_interactions {
         newtab_interactions.submission_date,
         newtab_interactions.channel,
         newtab_interactions.country_code,
+        newtab_interactions.topsites_rows,
         countries.tier,
         countries.name,
+        countries.pocket_available_on_newtab,
       ]
       measures: [
         newtab_interactions.visits_with_topsite_click,
         newtab_interactions.visits_with_topsite_impression,
         newtab_interactions.visits_with_sponsored_topsite_click,
+        newtab_interactions.visits_with_organic_topsite_click,
         newtab_interactions.visits_with_sponsored_topsite_impression,
+        newtab_interactions.visits_with_organic_topsite_impression,
         newtab_interactions.sum_topsite_clicks,
         newtab_interactions.sum_topsite_impressions,
         newtab_interactions.sum_sponsored_topsite_clicks,
+        newtab_interactions.sum_organic_topsite_clicks,
         newtab_interactions.sum_sponsored_topsite_impressions,
+        newtab_interactions.sum_organic_topsite_impressions,
         newtab_interactions.clients_with_topsite_click,
         newtab_interactions.clients_with_topsite_impression,
         newtab_interactions.clients_with_sponsored_topsite_click,
+        newtab_interactions.clients_with_organic_topsite_click,
         newtab_interactions.clients_with_sponsored_topsite_impression,
+        newtab_interactions.clients_with_organic_topsite_impression
       ]
       filters: [newtab_interactions.submission_date: "after 2022-07-01"]
     }

--- a/firefox_desktop/views/newtab_interactions.view.lkml
+++ b/firefox_desktop/views/newtab_interactions.view.lkml
@@ -20,7 +20,15 @@ view: newtab_interactions {
     hidden: yes
   }
 
+  dimension: organic_topsite_clicks {
+    hidden: yes
+  }
+
   dimension: sponsored_topsite_impressions {
+    hidden: yes
+  }
+
+  dimension: organic_topsite_impressions {
     hidden: yes
   }
 
@@ -130,6 +138,11 @@ view: newtab_interactions {
   dimension: newtab_search_enabled {
     sql: ${TABLE}.newtab_search_enabled ;;
     type: yesno
+  }
+
+  dimension: topsites_rows {
+    sql: ${TABLE}.topsites_rows ;;
+    type: number
   }
 
   measure: visits {
@@ -309,6 +322,13 @@ view: newtab_interactions {
     sql: ${sponsored_topsite_clicks} ;;
   }
 
+  measure: sum_organic_topsite_clicks {
+    group_label: "Topsites"
+    label: "Organic Topsite Clicks"
+    type: sum
+    sql: ${organic_topsite_clicks} ;;
+  }
+
   measure: sum_topsite_impressions {
     group_label: "Topsites"
     label: "Topsite Impressions"
@@ -323,6 +343,13 @@ view: newtab_interactions {
     sql: ${sponsored_topsite_impressions} ;;
   }
 
+  measure: sum_organic_topsite_impressions {
+    group_label: "Topsites"
+    label: "Organic Topsite Impressions"
+    type: sum
+    sql: ${organic_topsite_impressions} ;;
+  }
+
   measure: visits_with_topsite_click {
     group_label: "Topsites"
     type: count_distinct
@@ -334,6 +361,13 @@ view: newtab_interactions {
     group_label: "Topsites"
     type: count_distinct
     sql: IF(${sponsored_topsite_clicks} > 0, ${newtab_visit_id}, NULL) ;;
+    approximate: yes
+  }
+
+  measure: visits_with_organic_topsite_click {
+    group_label: "Topsites"
+    type: count_distinct
+    sql: IF(${organic_topsite_clicks} > 0, ${newtab_visit_id}, NULL) ;;
     approximate: yes
   }
 
@@ -351,6 +385,13 @@ view: newtab_interactions {
     approximate: yes
   }
 
+  measure: visits_with_organic_topsite_impression {
+    group_label: "Topsites"
+    type: count_distinct
+    sql: IF(${organic_topsite_impressions} > 0, ${newtab_visit_id}, NULL) ;;
+    approximate: yes
+  }
+
   measure: clients_with_topsite_click {
     group_label: "Topsites"
     type: count_distinct
@@ -365,6 +406,13 @@ view: newtab_interactions {
     approximate: yes
   }
 
+  measure: clients_with_organic_topsite_click {
+    group_label: "Topsites"
+    type: count_distinct
+    sql: IF(${organic_topsite_clicks} > 0, ${client_id}, NULL) ;;
+    approximate: yes
+  }
+
   measure: clients_with_topsite_impression {
     group_label: "Topsites"
     type: count_distinct
@@ -376,6 +424,13 @@ view: newtab_interactions {
     group_label: "Topsites"
     type: count_distinct
     sql: IF(${sponsored_topsite_impressions} > 0, ${client_id}, NULL) ;;
+    approximate: yes
+  }
+
+  measure: clients_with_organic_topsite_impression {
+    group_label: "Topsites"
+    type: count_distinct
+    sql: IF(${organic_topsite_impressions} > 0, ${client_id}, NULL) ;;
     approximate: yes
   }
 


### PR DESCRIPTION
RE: https://mozilla-hub.atlassian.net/browse/DO-947, https://mozilla-hub.atlassian.net/browse/DENG-784

Introducing some pre-aggregations for newtab Looker performance. I did a best effort at picking dimensions and measures that are used in dashboards, tagging folks for a second opinion.


----

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
