### PR TITLE
cleaned up version codes and events

### DIFF
--- a/websites/views/firefox_whatsnew_summary.view.lkml
+++ b/websites/views/firefox_whatsnew_summary.view.lkml
@@ -1,0 +1,38 @@
+include: "//looker-hub/websites/views/firefox_whatsnew_summary.view.lkml"
+
+view: +firefox_whatsnew_summary {
+
+  dimension_group: date {
+    type: time
+    # view_label: "Date/Period Selection"
+    timeframes: [
+      raw,
+      date,
+      day_of_month,
+      day_of_year,
+      week,
+      week_of_year,
+      month,
+      month_name,
+      month_num,
+      quarter,
+      year
+    ]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.date ;;
+  }
+
+  measure: wnp_visits {
+    description: "Unique visits to the wnp page"
+    type: sum
+    sql: ${TABLE}.visits ;;
+  }
+
+  measure: wnp_bounces {
+    description: "Bounces on the wnp page"
+    type: sum
+    sql: ${TABLE}.bounces ;;
+  }
+
+}

--- a/websites/views/whats_new_page_events.view.lkml
+++ b/websites/views/whats_new_page_events.view.lkml
@@ -9,8 +9,8 @@ view: whats_new_page_events {
              sum(total_events) as total_events,
             sum(unique_events) as unique_events
      FROM `moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics_v1`
-     WHERE page_name LIKE '/firefox/%/whatsnew%'
-    AND page_level_1 = 'firefox'
+     WHERE page_level_1 = 'firefox'
+    AND REGEXP_CONTAINS(page_level_2, r'^\d{1,3}(\.\d{1,3}){1,3}((a|b(eta)?)\d*)?(pre\d*)?(esr)?$')
     AND page_level_3 = 'whatsnew'
      GROUP by 1, 2, 3, 4, 5
       ;;
@@ -61,4 +61,4 @@ view: whats_new_page_events {
     type: sum
     sql: ${TABLE}.unique_events ;;
   }
- }
+}

--- a/websites/websites.model.lkml
+++ b/websites/websites.model.lkml
@@ -12,3 +12,5 @@ explore: moz_org_page_metrics{}
 explore: whats_new_page_events {}
 explore: firefox_whats_new_page_summary {}
 explore: website_conv_with_pop {}
+explore: www_site_events_metrics {}
+explore: firefox_whatsnew_summary {}


### PR DESCRIPTION
This PR will get all my changes to views I have already merged visible. This PR is a follower up PR which became necessary as a result of internal feedback loop for Whats New Dashboard

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
