### PR TITLE
site events metric view and firefox whats new page summary view were …

### DIFF
--- a/websites/views/firefox_whats_new_page_summary.view.lkml
+++ b/websites/views/firefox_whats_new_page_summary.view.lkml
@@ -28,7 +28,7 @@ view: firefox_whats_new_page_summary {
 
   dimension_group: date {
     type: time
-    view_label: "Date/Period Selection"
+    # view_label: "Date/Period Selection"
     timeframes: [
       raw,
       date,

--- a/websites/views/www_site_events_metrics.view.lkml
+++ b/websites/views/www_site_events_metrics.view.lkml
@@ -1,0 +1,54 @@
+include: "//looker-hub/websites/views/www_site_events_metrics.view.lkml"
+
+view: +www_site_events_metrics {
+
+  dimension: version {
+    view_label: "WNP"
+    label: "Version"
+    sql: ${TABLE}.page_level_2;;
+    type: string
+  }
+
+  dimension: locale {
+    view_label: "WNP"
+    label: "locale"
+    sql: TRIM(${TABLE}.locale, '/');;
+    type: string
+  }
+
+  dimension: country {
+    view_label: "WNP"
+    label: "country"
+    sql: ${TABLE}.country;;
+    type: string
+  }
+
+  dimension: whats_new_flag {
+    hidden:  yes
+    case: {
+      when: {
+        sql: ${TABLE}.page_level_1 = "firefox"
+            AND REGEXP_CONTAINS(${TABLE}.page_level_2, r'^\d{1,3}(\.\d{1,3}){1,3}((a|b(eta)?)\d*)?(pre\d*)?(esr)?$')
+            AND ${TABLE}.page_level_3 = 'whatsnew';;
+        label: "yes"
+      }
+      else: "no"
+    }
+  }
+
+  measure: wnp_total_events {
+    view_label: "WNP"
+    label: "Whats New Page total events"
+    type: sum
+    sql: ${TABLE}.total_events ;;
+    filters: [whats_new_flag: "yes"]
+  }
+
+  measure: wnp_unique_events {
+    view_label: "WNP"
+    label: "Whats New Page unique events"
+    type: sum
+    sql: ${TABLE}.unique_events ;;
+    filters: [whats_new_flag: "yes"]
+  }
+}


### PR DESCRIPTION
…modified firefox whats new page summary view and adding the missing view that is throwing the error

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
