### PR TITLE
feat(DENG-713): tweaked fxa_flow_aggregates looker view to use fxa_all_events instead of fxa_content_auth_* bq view

### DIFF
--- a/firefox_accounts/views/fxa_flow_aggregates.view.lkml
+++ b/firefox_accounts/views/fxa_flow_aggregates.view.lkml
@@ -20,9 +20,10 @@ view: fxa_flow_aggregates {
                   ANY_VALUE(ua_version) AS browser_version,
                   ANY_VALUE(os_name) AS os_name,
                   MIN(DATE(timestamp)) AS flow_start_date,
-              FROM firefox_accounts.fxa_content_auth_oauth_events
+              FROM firefox_accounts.fxa_all_events
               WHERE DATE(timestamp) >= DATE(2022,9,1)
               AND event_type = 'fxa_email_first - view'
+              AND event_category IN ('content', 'auth', 'oauth')
               GROUP BY 1
           ),
 
@@ -42,9 +43,10 @@ view: fxa_flow_aggregates {
           e.event_type,
           COUNT(*) as n_events
         FROM flow_ids f
-        LEFT JOIN firefox_accounts.fxa_content_auth_oauth_events e
+        LEFT JOIN firefox_accounts.fxa_all_events e
         USING(flow_id)
         WHERE DATE(e.timestamp) >= DATE(2022,9,1)
+        AND e.event_category IN ('content', 'auth', 'oauth')
       GROUP BY
           f.flow_id,
           f.entrypoint,


### PR DESCRIPTION
# feat(DENG-713): tweaked fxa_flow_aggregates looker view to use fxa_all_events instead of fxa_content_auth_* bq view

This is part of the work to have a single view for accessing fxa logs.