### PR TITLE
Add datagroups to some frequently used Explores

### DIFF
--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -1,7 +1,9 @@
 include: "../views//active_users_aggregates.view.lkml"
+include: "//looker-hub/combined_browser_metrics/datagroups/active_users_aggregates_v1_last_updated.datagroup.lkml"
 include: "/shared/views/*"
 
 explore: active_users_aggregates {
+  persist_with: active_users_aggregates_v1_last_updated
   always_filter: {
     filters: [active_users_aggregates.app_name: "Firefox Desktop, Fenix, Fenix BrowserStack, Firefox iOS, Firefox iOS BrowserStack,
       Focus Android,  Focus iOS, Focus iOS BrowserStack",

--- a/firefox_desktop/explores/clients_daily_search.explore.lkml
+++ b/firefox_desktop/explores/clients_daily_search.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/clients_daily_search.view.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/clients_daily_joined_v1_last_updated.datagroup.lkml"
 
 explore: clients_daily_search {
+  persist_with: clients_daily_joined_v1_last_updated
   sql_always_where: ${clients_daily_search.submission_date} >= '2010-01-01' ;;
   view_name: clients_daily_search
   description: "Daily search aggregates for desktop clients."


### PR DESCRIPTION
Additional datagroup usage with some simple, frequently used Explores that point to only a single table.