### PR TITLE
[DS-2653] Redefining original subscription start date dimension in subscriptions.view file

### DIFF
--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -58,6 +58,19 @@ view: +subscriptions {
     hidden: yes
   }
 
+  dimension_group: original_subscription_start {
+    sql: COALESCE(${TABLE}.original_subscription_start_date, ${TABLE}.subscription_start_date) ;;
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+  }
   dimension: is_ended {
     description: "Indicates if subscription has ended"
     type: yesno


### PR DESCRIPTION
The `original_subscription_start_date` had been set to be `NULL` for iOS and Android subscriptions in `mozilla_vpn.all_subscriptions` not to add any complexity to the mobile subscription data. However, the `original_subscription_start_date` is used as a filter in Retention/Churn SaaSboard and the mobile subscriptions get excluded because of it. 
So I redefined the  `original_subscription_start_date` to be filled with `subscription_start_date` value when it is NULL. 

I checked that `original_subscription_months_retained` and `current_months_since_original_subscription_start` get calculated using   `COALESCE(original_subscription_start_date, subscription_start_date)` as the start of the period calculations. 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
