### PR TITLE
Add link to platform health dashboard

### DIFF
--- a/monitoring/views/distinct_docids.view.lkml
+++ b/monitoring/views/distinct_docids.view.lkml
@@ -67,7 +67,24 @@ view: distinct_docids {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=General&bug_status=NEW&bug_type=defect&short_desc=Investigate+distinct+docId+mismatche+on+{{ submission_date }}+in+%60{{ namespace }}.{{ doc_type }}%60"
+      url: "{{
+        'https://bugzilla.mozilla.org/enter_bug.cgi?'
+      }}{{
+        'product=Data+Platform+and+Tools'
+      }}{{
+        '&component=General'
+      }}{{
+        '&bug_type=defect'
+      }}{{
+        '&status_whiteboard=%5Bdata-quality%5D'
+      }}{{
+        '&short_desc=distinct+docId+mismatch+on'
+      }}{{
+        submission_date
+      }}{{
+        '+in+%60'
+      }}{{
+        namespace }}.{{ doc_type }}%60"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }

--- a/monitoring/views/grouped_schema_error_counts.view.lkml
+++ b/monitoring/views/grouped_schema_error_counts.view.lkml
@@ -18,7 +18,25 @@ view: +schema_error_counts {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=General&bug_status=NEW&bug_type=defect&short_desc=Investigate+schema+error+in+%60{{ document_namespace }}.{{ document_type }}%60+for+%60{{ path | encode_uri }}%60"
+      url: "{{
+        'https://bugzilla.mozilla.org/enter_bug.cgi?'
+      }}{{
+        'product=Data+Platform+and+Tools'
+      }}{{
+        '&component=General'
+      }}{{
+        '&bug_type=defect'
+      }}{{
+        '&status_whiteboard=%5Bdata-quality%5D'
+      }}{{
+        '&short_desc=schema+error+in+%60'
+      }}{{
+        document_namespace }}.{{ document_type }}_v{{ document_version
+      }}{{
+        '%60+for+'
+      }}{{
+        path | encode_uri
+      }}"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }

--- a/monitoring/views/missing_namespaces_and_document_types.view.lkml
+++ b/monitoring/views/missing_namespaces_and_document_types.view.lkml
@@ -109,7 +109,23 @@ view: missing_namespaces_and_document_types {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=General&bug_status=NEW&bug_type=defect&short_desc=Investigate+missing+namespaces+and+document+types+in+%60{{ document_namespace }}%60+ADD+LIST+OF+DOCUMENT+TYPES+HERE"
+      url: "{{
+        'https://bugzilla.mozilla.org/enter_bug.cgi?'
+      }}{{
+        'product=Data+Platform+and+Tools'
+      }}{{
+        '&component=General'
+      }}{{
+        '&bug_type=defect'
+      }}{{
+        '&status_whiteboard=%5Bdata-quality%5D'
+      }}{{
+        '&short_desc=missing+namespaces+and+document+types+in+%60'
+      }}{{
+        document_namespace
+      }}{{
+        '%60+ADD+LIST+OF+DOCUMENT+TYPES+HERE'
+      }}"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }
@@ -120,7 +136,20 @@ view: missing_namespaces_and_document_types {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=General&bug_status=NEW&bug_type=defect&short_desc=Investigate+missing+namespaces+and+document+types+in+%60{{ document_namespace }}+{{ document_type }}%60"
+      url: "{{
+        'https://bugzilla.mozilla.org/enter_bug.cgi?'
+      }}{{
+        'product=Data+Platform+and+Tools'
+      }}{{
+        '&component=General'
+      }}{{
+        '&bug_type=defect'
+      }}{{
+        '&status_whiteboard=%5Bdata-quality%5D'
+      }}{{
+        '&short_desc=missing+namespace+and+document+types+in+%60'
+      }}{{
+        document_namespace }}.{{ document_type }}%60"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }

--- a/monitoring/views/structured_missing_columns.view.lkml
+++ b/monitoring/views/structured_missing_columns.view.lkml
@@ -8,7 +8,25 @@ view: +structured_missing_columns {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=General&bug_status=NEW&bug_type=defect&short_desc=Investigate+structured+missing+columns+in+%60{{ document_namespace }}.{{ document_type }}%60+for+{{ path | encode_uri }}"
+      url: "{{
+        'https://bugzilla.mozilla.org/enter_bug.cgi?'
+      }}{{
+        'product=Data+Platform+and+Tools'
+      }}{{
+        '&component=General'
+      }}{{
+        '&bug_type=defect'
+      }}{{
+        '&status_whiteboard=%5Bdata-quality%5D'
+      }}{{
+        '&short_desc=structured+missing+columns+in+%60'
+      }}{{
+        document_namespace }}.{{ document_type }}_v{{ document_version
+      }}{{
+        '%60+for+'
+      }}{{
+        path | encode_uri
+      }}"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }

--- a/monitoring/views/telemetry_missing_columns.view.lkml
+++ b/monitoring/views/telemetry_missing_columns.view.lkml
@@ -8,7 +8,25 @@ view: +telemetry_missing_columns {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "https://bugzilla.mozilla.org/enter_bug.cgi?product=Data+Platform+and+Tools&component=General&bug_status=NEW&bug_type=defect&short_desc=Investigate+telemetry+missing+columns+in+%60{{ document_namespace }}.{{ document_type }}%60+for+{{ path | encode_uri }}"
+      url: "{{
+          'https://bugzilla.mozilla.org/enter_bug.cgi?'
+          }}{{
+            'product=Data+Platform+and+Tools'
+          }}{{
+            '&component=General'
+          }}{{
+            '&bug_type=defect'
+          }}{{
+            '&status_whiteboard=%5Bdata-quality%5D'
+          }}{{
+            '&short_desc=telemetry+missing+columns+in+%60'
+          }}{{
+            document_namespace }}.{{ document_type }}_v{{ document_version
+          }}{{
+            '%60+for+'
+          }}{{
+            path | encode_uri
+          }}"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }


### PR DESCRIPTION
cleaning up the links for the health dashboard and adding the whiteboard=[data-quality]

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
