### PR TITLE
Add measures to platform health dashboard

### DIFF
--- a/monitoring/views/grouped_schema_error_counts.view.lkml
+++ b/monitoring/views/grouped_schema_error_counts.view.lkml
@@ -2,10 +2,10 @@ include: "//looker-hub/monitoring/views/schema_error_counts.view.lkml"
 
 view: +schema_error_counts {
 
+  # Dimensions
   dimension: document_namespace{
     type: string
     sql: replace(${TABLE}.document_namespace, "-", "_") ;;
-
   }
 
   dimension:  document_type{
@@ -13,8 +13,28 @@ view: +schema_error_counts {
     sql: concat(replace(${TABLE}.document_type, "-", "_"), "_v", coalesce(${TABLE}.document_version, if(${TABLE}.document_namespace="telemetry", "4", "1"))) ;;
     }
 
+  # Measures
   measure: error_counts_sum {
     type: sum
     sql: (${error_count}) ;;
   }
+
+  measure: error_count_last_week {
+    type: sum
+    sql: ${error_count} ;;
+    filters: [submission_date: "7 days ago for 7 days"]
+  }
+
+  measure: error_count_prev_week {
+    type: sum
+    sql: ${error_count} ;;
+    filters: [submission_date: "14 days ago for 7 days"]
+  }
+
+  measure: percent_change {
+    type: number
+    sql: (${error_count_last_week} - ${error_count_prev_week}) / nullif(${error_count_last_week}, 0)  ;;
+    value_format_name: percent_2
+  }
+
 }

--- a/monitoring/views/structured_missing_columns.view.lkml
+++ b/monitoring/views/structured_missing_columns.view.lkml
@@ -12,4 +12,36 @@ view: +structured_missing_columns {
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }
+
+  dimension: path_count {
+    hidden: yes
+  }
+
+  # Measures
+  measure: sum_path_count {
+    label: "Path Count"
+    type: sum
+    sql: ${path_count} ;;
+  }
+
+  measure: path_count_last_week {
+    label: "Path Count (last 7 days)"
+    type: sum
+    sql: ${path_count} ;;
+    filters: [submission_date: "7 days ago for 7 days"]
+  }
+
+  measure: path_count_prev_week {
+    label: "Path Count (2 weeks ago)"
+    type: sum
+    sql: ${path_count} ;;
+    filters: [submission_date: "14 days ago for 7 days"]
+  }
+
+  measure: percent_change {
+    label: "Diff % to two weeks ago"
+    type: number
+    sql: (${path_count_last_week} - ${path_count_prev_week}) / nullif(${path_count_last_week}, 0)  ;;
+    value_format_name: percent_2
+  }
 }

--- a/monitoring/views/telemetry_missing_columns.view.lkml
+++ b/monitoring/views/telemetry_missing_columns.view.lkml
@@ -12,4 +12,36 @@ view: +telemetry_missing_columns {
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }
+
+  dimension: path_count {
+    hidden: yes
+  }
+
+  # Measures
+  measure: sum_path_count {
+    label: "Path Count"
+    type: sum
+    sql: ${path_count} ;;
+  }
+
+  measure: path_count_last_week {
+    label: "Path Count (last 7 days)"
+    type: sum
+    sql: ${path_count} ;;
+    filters: [submission_date: "7 days ago for 7 days"]
+  }
+
+  measure: path_count_prev_week {
+    label: "Path Count (2 weeks ago)"
+    type: sum
+    sql: ${path_count} ;;
+    filters: [submission_date: "14 days ago for 7 days"]
+  }
+
+  measure: percent_change {
+    label: "Diff % to two weeks ago"
+    type: number
+    sql: (${path_count_last_week} - ${path_count_prev_week}) / nullif(${path_count_last_week}, 0)  ;;
+    value_format_name: percent_2
+  }
 }


### PR DESCRIPTION
This will allow us to compare the changes from last week to 2 weeks ago in the Health dashboard without having to merge tables for the missing columns, and adding this to the schema errors as well 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
