### PR TITLE
[DS-2633] adding dimensions related to message status and message id

### DIFF
--- a/mozilla_vpn/views/events.view.lkml
+++ b/mozilla_vpn/views/events.view.lkml
@@ -1,0 +1,15 @@
+include: "//looker-hub/mozilla_vpn/views/events.view.lkml"
+view: +events {
+  # Some events have more than one extra keys and these multiple values are essential to be combined together to monitor the events correctly.
+
+  dimension: message_state {
+    sql: mozfun.map.get_key(${event_extra},'message_state') ;;
+    description: "message_state value in event_extra key = 'message_state' for event_name = 'addon_message_state_changed' "
+    group_label: "Granular Event Category"
+  }
+  dimension: message_id {
+    sql: mozfun.map.get_key(${event_extra},'message_id') ;;
+    description: "message_state value(Addon identifier) in event_extra key = 'message_id' for event_name = 'addon_message_state_changed' "
+    group_label: "Granular Event Category"
+  }
+}

--- a/mozilla_vpn/views/events.view.lkml
+++ b/mozilla_vpn/views/events.view.lkml
@@ -9,7 +9,7 @@ view: +events {
   }
   dimension: message_id {
     sql: mozfun.map.get_key(${event_extra},'message_id') ;;
-    description: "message_state value(Addon identifier) in event_extra key = 'message_id' for event_name = 'addon_message_state_changed' "
+    description: "message_state value (Addon identifier) in event_extra key = 'message_id' for event_name = 'addon_message_state_changed' "
     group_label: "Granular Event Category"
   }
 }


### PR DESCRIPTION
Some events have more than one extra keys and these multiple values are essential to be combined together to monitor the events correctly. One of the events is [`add_on_message_state_changed`](https://dictionary.telemetry.mozilla.org/apps/mozilla_vpn/metrics/sample_addon_message_state_changed). To filter/display the message state and message id together, I created a refined view file from `//looker-hub/mozilla_vpn/views/events.view.lkml` and added two dimensions, `message_state` and `message_id` under the **Granular Event Category** label. 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
