### PR TITLE
Update search clients explores

### DIFF
--- a/search/views/mobile_search_clients_engines_sources_daily.view.lkml
+++ b/search/views/mobile_search_clients_engines_sources_daily.view.lkml
@@ -255,4 +255,38 @@ view: +mobile_search_clients_engines_sources_daily {
     sql: ${ad_click_organic} ;;
     description: "Total organic ad clicks."
   }
+
+## hide numeric search dimensions ##
+
+  dimension: ad_click {
+    hidden:  yes
+  }
+
+  dimension: ad_click_organic {
+    hidden: yes
+  }
+
+  dimension: organic {
+    hidden: yes
+  }
+
+  dimension: sap {
+    hidden: yes
+  }
+
+  dimension: search_count {
+    hidden: yes
+  }
+
+  dimension: search_with_ads {
+    hidden: yes
+  }
+
+  dimension: tagged_sap {
+    hidden:  yes
+  }
+
+  dimension: tagged_follow_on {
+    hidden: yes
+  }
 }

--- a/search/views/search_clients_engine_sources_daily.view.lkml
+++ b/search/views/search_clients_engine_sources_daily.view.lkml
@@ -289,4 +289,12 @@ view: +search_clients_engines_sources_daily {
     hidden:  yes
   }
 
+  dimension: tagged_follow_on {
+    hidden: yes
+  }
+
+dimension: tagged_sap {
+  hidden: yes
+}
+
 }

--- a/search/views/search_clients_engine_sources_daily.view.lkml
+++ b/search/views/search_clients_engine_sources_daily.view.lkml
@@ -262,4 +262,31 @@ view: +search_clients_engines_sources_daily {
     sql: ${ad_click_organic} ;;
     description: "Total organic ad clicks."
   }
+
+## hide numeric search dimensions ##
+
+  dimension: ad_click {
+    hidden: yes
+  }
+
+  dimension: ad_click_organic {
+    hidden:  yes
+  }
+
+  dimension: organic {
+    hidden:  yes
+  }
+
+  dimension: sap {
+    hidden:  yes
+  }
+
+  dimension: search_with_ads {
+    hidden:  yes
+  }
+
+  dimension: search_with_ads_organic {
+    hidden:  yes
+  }
+
 }


### PR DESCRIPTION
These changes are to hide the numeric search metrics as dimensions from the Desktop Search Counts and Mobile Search Counts Explores as defined in [this ticket](https://mozilla-hub.atlassian.net/browse/RS-640). 
