### PR TITLE
[DS-2566] Add explore and view for history sidebar

### DIFF
--- a/firefox_desktop/explores/history_sidebar_telemetry.explore.lkml
+++ b/firefox_desktop/explores/history_sidebar_telemetry.explore.lkml
@@ -1,0 +1,12 @@
+include: "../views/history_sidebar_clients_daily.view.lkml"
+
+explore: history_sidebar_interactions {
+  sql_always_where: ${history_sidebar_clients_daily.submission_date} >= '2023-01-01' ;;
+  view_name: history_sidebar_clients_daily
+
+  always_filter: {
+    filters: [
+      submission_date: "28 days",
+    ]
+  }
+}

--- a/firefox_desktop/views/history_sidebar_clients_daily.view.lkml
+++ b/firefox_desktop/views/history_sidebar_clients_daily.view.lkml
@@ -11,7 +11,7 @@ view: history_sidebar_clients_daily {
   dimension: submission_date {
     type: date
     sql: CAST(${TABLE}.submission_date AS TIMESTAMP);;
-    description: "Submission date of the crash"
+    description: "Submission date of the interaction"
   }
 
   dimension: major_version {

--- a/firefox_desktop/views/history_sidebar_clients_daily.view.lkml
+++ b/firefox_desktop/views/history_sidebar_clients_daily.view.lkml
@@ -1,0 +1,86 @@
+view: history_sidebar_clients_daily {
+
+  sql_table_name: `moz-fx-data-shared-prod`.telemetry_derived.clients_daily_joined_v1 ;;
+
+  dimension: client_id {
+    type: string
+    sql: ${TABLE}.client_id ;;
+    hidden: yes
+  }
+
+  dimension: submission_date {
+    type: date
+    sql: CAST(${TABLE}.submission_date AS TIMESTAMP);;
+    description: "Submission date of the crash"
+  }
+
+  dimension: major_version {
+    type: number
+    sql: mozfun.norm.browser_version_info(${TABLE}.app_version).major_version ;;
+    description: "The major version of the application, as a number."
+    group_label: "Browser Version"
+  }
+
+  dimension: minor_version {
+    type: number
+    sql: mozfun.norm.browser_version_info(${TABLE}.app_version).minor_version ;;
+    description: "The minor version of the application, as a number."
+    group_label: "Browser Version"
+  }
+
+  dimension: channel {
+    type: string
+    sql: ${TABLE}.normalized_channel ;;
+    suggestions: ["release", "beta", "nightly", "esr", "aurora", "Other"]
+    description: "Release channel for the associated installation."
+  }
+
+  measure: sidebar_history_opened {
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_sidebar_opened_sum, "history");;
+    type: sum
+    description: "Number of times sidebar history was opened"
+  }
+
+  measure: sidebar_bookmarks_opened {
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_sidebar_opened_sum, "bookmarks");;
+    type: sum
+    description: "Number of times sidebar bookmarks was opened"
+  }
+
+  measure: sidebar_history_searched {
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_sidebar_search_sum, "history");;
+    type: sum
+    description: "Number of times sidebar history was searched"
+  }
+
+  measure: sidebar_bookmarks_searched {
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_sidebar_search_sum, "bookmarks");;
+    type: sum
+    description: "Number of times sidebar bookmarks was searched"
+  }
+
+  measure: sidebar_history_link_clicked {
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_sidebar_link_sum, "history");;
+    type: sum
+    description: "Number of times sidebar history link was clicked"
+  }
+
+  measure: sidebar_bookmarks_link_clicked {
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_sidebar_link_sum, "bookmarks");;
+    type: sum
+    description: "Number of times sidebar bookmark link was clicked"
+  }
+
+  measure: searchbar_cumulative_searches {
+    sql: ${TABLE}.places_searchbar_cumulative_searches_sum ;;
+    type: sum
+    description: "Cumulative searches in the sidebar before action"
+  }
+
+  measure: searchbar_cumulative_filters {
+    sql: ${TABLE}.places_searchbar_cumulative_filter_count_sum ;;
+    type: sum
+    description: "Cumulative filters in the sidebar before action"
+  }
+
+}


### PR DESCRIPTION
Adds a view and an explore based on that view that includes fields related to history and bookmark sidebar interactions.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
