### PR TITLE
Rename data-quality whiteboard tag to dataquality

### DIFF
--- a/monitoring/dashboards/platform_health_check.dashboard.lookml
+++ b/monitoring/dashboards/platform_health_check.dashboard.lookml
@@ -2161,8 +2161,8 @@
   - name: Open Issues
     type: text
     title_text: Open Issues
-    subtitle_text: All open issues tagged with [data-quality], P1-P3
-    body_text: <center> <a href="https://bugzilla.mozilla.org/buglist.cgi?bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&classification=Client%20Software&classification=Developer%20Infrastructure&classification=Components&classification=Server%20Software&classification=Other&priority=P1&priority=P2&priority=P3&priority=--&resolution=---&status_whiteboard=[data-quality]&status_whiteboard_type=allwordssubstr&list_id=15652480">
+    subtitle_text: All open issues tagged with [dataquality], P1-P3
+    body_text: <center> <a href="https://bugzilla.mozilla.org/buglist.cgi?bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&classification=Client%20Software&classification=Developer%20Infrastructure&classification=Components&classification=Server%20Software&classification=Other&priority=P1&priority=P2&priority=P3&priority=--&resolution=---&status_whiteboard=[dataquality]&status_whiteboard_type=allwordssubstr&list_id=15652480">
       Bugzilla</a> </center>
     row: 0
     col: 0

--- a/monitoring/views/distinct_docids.view.lkml
+++ b/monitoring/views/distinct_docids.view.lkml
@@ -76,7 +76,7 @@ view: distinct_docids {
       }}{{
         '&bug_type=defect'
       }}{{
-        '&status_whiteboard=%5Bdata-quality%5D'
+        '&status_whiteboard=%5Bdataquality%5D'
       }}{{
         '&short_desc=distinct+docId+mismatch+on+'
       }}{{

--- a/monitoring/views/grouped_schema_error_counts.view.lkml
+++ b/monitoring/views/grouped_schema_error_counts.view.lkml
@@ -27,7 +27,7 @@ view: +schema_error_counts {
       }}{{
         '&bug_type=defect'
       }}{{
-        '&status_whiteboard=%5Bdata-quality%5D'
+        '&status_whiteboard=%5Bdataquality%5D'
       }}{{
         '&short_desc=schema+error+in+%60'
       }}{{

--- a/monitoring/views/missing_namespaces_and_document_types.view.lkml
+++ b/monitoring/views/missing_namespaces_and_document_types.view.lkml
@@ -118,7 +118,7 @@ view: missing_namespaces_and_document_types {
       }}{{
         '&bug_type=defect'
       }}{{
-        '&status_whiteboard=%5Bdata-quality%5D'
+        '&status_whiteboard=%5Bdataquality%5D'
       }}{{
         '&short_desc=missing+namespaces+and+document+types+in+%60'
       }}{{
@@ -145,7 +145,7 @@ view: missing_namespaces_and_document_types {
       }}{{
         '&bug_type=defect'
       }}{{
-        '&status_whiteboard=%5Bdata-quality%5D'
+        '&status_whiteboard=%5Bdataquality%5D'
       }}{{
         '&short_desc=missing+namespace+and+document+types+in+%60'
       }}{{

--- a/monitoring/views/structured_missing_columns.view.lkml
+++ b/monitoring/views/structured_missing_columns.view.lkml
@@ -17,7 +17,7 @@ view: +structured_missing_columns {
       }}{{
         '&bug_type=defect'
       }}{{
-        '&status_whiteboard=%5Bdata-quality%5D'
+        '&status_whiteboard=%5Bdataquality%5D'
       }}{{
         '&short_desc=structured+missing+columns+in+%60'
       }}{{

--- a/monitoring/views/telemetry_missing_columns.view.lkml
+++ b/monitoring/views/telemetry_missing_columns.view.lkml
@@ -17,7 +17,7 @@ view: +telemetry_missing_columns {
           }}{{
             '&bug_type=defect'
           }}{{
-            '&status_whiteboard=%5Bdata-quality%5D'
+            '&status_whiteboard=%5Bdataquality%5D'
           }}{{
             '&short_desc=telemetry+missing+columns+in+%60'
           }}{{


### PR DESCRIPTION
We have to rename the `[data-quality]` whiteboard tag to `[dataquality]` for jbi to sync issues between bugzilla and jira (it doesn't support dashes in tag names...)
