### PR TITLE
comment out filters on parameters to see if this will trigger a rebui…

### DIFF
--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -21,10 +21,10 @@ explore: active_users_aggregates {
       dimensions: [period_over_period_pivot, period_over_period_row, active_users_aggregates.app_name, active_users_aggregates.submission_date]
       measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, ad_click, organic_search_counts, search_counts, search_with_ad, uri_counts, active_hour]
       filters: [
-        active_users_aggregates.choose_breakdown: "Month^_Day",
-        active_users_aggregates.choose_comparison: "Year",
+        # active_users_aggregates.choose_breakdown: "Month^_Day",
+        # active_users_aggregates.choose_comparison: "Year",
         active_users_aggregates.submission_date: "after 1 year ago",
-        active_users_aggregates.ytd_only: "Yes"
+        # active_users_aggregates.ytd_only: "Yes"
       ]
     }
 


### PR DESCRIPTION
…ld of the aggregate_table.rollup__period_over_period with all the dates we want

Addressing the bug found i[DS-2882](https://mozilla-hub.atlassian.net/browse/DS-2822).

After a conversation with Looker help, they recommended that we take out the filters on the parameters and see if that would address the problem of missing data for January 26, 2022 to current day for 2022

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
