### PR TITLE
Adjusted the dau goal calculations

### DIFF
--- a/duet/views/kpi_dau.view.lkml
+++ b/duet/views/kpi_dau.view.lkml
@@ -128,11 +128,34 @@ view: kpi_dau {
     filters: [period_filtered_measures: "last"]
   }
 
+  measure: dau_goal {
+    view_label: "KPI filtered metrics"
+    type: sum
+    sql: CASE WHEN ${country} = "CA" AND ${app_name} = "Firefox Desktop" THEN ${TABLE}.dau * .9679
+              WHEN ${country} = "IT" AND ${app_name} = "Firefox Desktop" THEN ${TABLE}.dau * .9565
+              WHEN ${country} = "PL" AND ${app_name} = "Firefox Desktop" THEN ${TABLE}.dau * .9576
+              WHEN ${country} = "US" AND ${app_name} = "Firefox Desktop" THEN ${TABLE}.dau * .9703
+              WHEN ${country} = "DE" AND ${app_name} = "Firefox Desktop" THEN ${TABLE}.dau * .9549
+              WHEN ${country} = "ES" AND ${app_name} = "Firefox Desktop" THEN ${TABLE}.dau * .98
+              WHEN ${country} = "FR" AND ${app_name} = "Firefox Desktop" THEN ${TABLE}.dau * .9685
+              WHEN ${country} = "GB" AND ${app_name} = "Firefox Desktop" THEN ${TABLE}.dau * .9679
+              WHEN ${country} NOT IN   ("US", "GB", "DE", "FR", "CA", "PL", "IT", "ES") AND ${app_name} = "Firefox Desktop" THEN ${TABLE}.dau * .9661
+              ELSE ${TABLE}.dau * 1.1 END;;
+    filters: [period_filtered_measures: "last"]
+  }
+
   measure:  unique_days_prefiltered {
     label: "Number of unique days in period"
     type: count_distinct
     sql: ${submission_date};;
     filters: [period_filtered_measures: "this"]
+  }
+
+  measure:  unique_days_prev_prefiltered {
+    label: "Number of unique days previous period"
+    type: count_distinct
+    sql: ${submission_date};;
+    filters: [period_filtered_measures: "last"]
   }
 
   measure:  unique_days {
@@ -183,4 +206,5 @@ view: kpi_dau {
               WHEN ${os} LIKE "%iOS%" THEN "iOS"
               ELSE "Other" END ;;
   }
+
 }


### PR DESCRIPTION
Checklist for reviewer:

I remember Anna pulled you into a PR that I assigned to her. For this PR, I simply added a new measure in the view that I added.

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
