### PR TITLE
Eu kpi tracker

### DIFF
--- a/duet/duet.model.lkml
+++ b/duet/duet.model.lkml
@@ -24,5 +24,5 @@ explore: kpi_dau {
 }
 
 explore: kpi_downloads {
-  sql_always_where: ${submission_date} >= "2022-01-01" AND ${period_filtered_measures} in ("this", "last");;
+  sql_always_where: ${submission_date} >= "2022-01-01" AND ${period_filtered_measures} in ("this", "last") AND ${device_category} = "desktop" ;;
 }

--- a/duet/duet.model.lkml
+++ b/duet/duet.model.lkml
@@ -22,3 +22,7 @@ explore: releases {
 explore: kpi_dau {
   sql_always_where: ${submission_date} >= "2022-01-01" AND ${period_filtered_measures} in ("this", "last");;
 }
+
+explore: kpi_downloads {
+  sql_always_where: ${submission_date} >= "2022-01-01" AND ${period_filtered_measures} in ("this", "last");;
+}

--- a/duet/views/kpi_downloads.view.lkml
+++ b/duet/views/kpi_downloads.view.lkml
@@ -1,0 +1,172 @@
+include: "/websites/views/moz_org_metrics_summary.view.lkml"
+
+view: kpi_downloads {
+  extends: [moz_org_metrics_summary]
+
+  filter: current_date {
+    type: date
+    view_label: "KPI date filter"
+    label: "1. Current Date"
+    description: "Select the last date of the period you are interested in"
+    convert_tz: no
+  }
+
+  dimension: day_month {
+    description: "this dimension will help us trend well period over period analysis for YoY, MoM and QoQ at daily granularity"
+    type:  string
+    hidden: no
+    view_label: "KPI date axis"
+    sql: FORMAT_DATE("%m-%d", ${submission_date});;
+  }
+
+  dimension: month {
+    description: "this dimension will help us trend period over period analysis for YoY, MoM and QoQ at monthly granularity"
+    type:  string
+    hidden: no
+    view_label: "KPI date axis"
+    sql: FORMAT_DATE("%m-%B", ${submission_date});;
+  }
+
+  dimension: quarter_abr {
+    description: "this dimension will help us trend period over period analysis for QR"
+    type:  string
+    hidden: no
+    view_label: "KPI date axis"
+    sql: CASE WHEN FORMAT_DATE("%m",  DATE_TRUNC(${submission_date}, QUARTER)) = "01" then "Q1"
+              WHEN FORMAT_DATE("%m",  DATE_TRUNC(${submission_date}, QUARTER)) = "04" then "Q2"
+              WHEN FORMAT_DATE("%m",  DATE_TRUNC(${submission_date}, QUARTER)) = "07" then "Q3"
+              ELSE "Q4" end;;
+  }
+
+  dimension: filter_end_date {
+    type: date
+    hidden: yes
+    description: "Select the last date of the period you are interested in"
+    sql: {% date_end current_date%};;
+  }
+
+  parameter: compare_to {
+    view_label: "KPI date filter"
+    description: "Select the templated previous period you would like to compare to. Must be used with Current Date filter"
+    label: "2. Compare To:"
+    type: unquoted
+    # allowed_value: {
+    #   label: "Previous Period"
+    #   value: "Period"
+    # }
+    allowed_value: {
+      label: "Previous Week"
+      value: "Week"
+    }
+    allowed_value: {
+      label: "Previous Month"
+      value: "Month"
+    }
+    allowed_value: {
+      label: "Previous Quarter"
+      value: "Quarter"
+    }
+    allowed_value: {
+      label: "Previous Year"
+      value: "Year"
+    }
+    default_value: "Year"
+  }
+
+  dimension: first_date_in_period {
+    description: "For a well defined period (YoY, QoQ, MoM, WoW), we use date trunc to get the period start date, for arbitrary period modify this dimension to use date sub and number of days in period"
+    type: date
+    hidden: yes
+    sql: DATE_TRUNC(${filter_end_date}, {% parameter compare_to %});;
+  }
+
+  dimension: period_2_start {
+    hidden:  yes
+    description: "Calculates the start of the previous period"
+    type: date
+    sql:
+        DATE_SUB(${first_date_in_period}, INTERVAL 1 {% parameter compare_to %});;
+    convert_tz: no
+  }
+
+  dimension: period_2_end {
+    hidden:  yes
+    description: "Calculates the end of the previous period"
+    type: date
+    sql:
+        DATE_SUB(${filter_end_date}, INTERVAL 1 {% parameter compare_to %});;
+    convert_tz: no
+  }
+
+  dimension: period_filtered_measures {
+    hidden: yes
+    description: "We just use this to create the measures for the respective periods (this = current period, last = previous period)"
+    type: string
+    sql:
+        {% if current_date._is_filtered %}
+            CASE
+            WHEN DATE(${submission_date}) BETWEEN DATE(${first_date_in_period}) AND DATE(${filter_end_date}) THEN 'this'
+            WHEN DATE(${submission_date}) between ${period_2_start} and ${period_2_end} THEN 'last' END
+        {% else %} NULL {% endif %} ;;
+  }
+
+
+  measure: current_period_downloads {
+    view_label: "KPI filtered metrics"
+    type: sum
+    sql: ${non_fx_downloads};;
+    filters: [period_filtered_measures: "this"]
+  }
+
+  measure: previous_period_downloads {
+    view_label: "KPI filtered metrics"
+    type: sum
+    sql: ${non_fx_downloads};;
+    filters: [period_filtered_measures: "last"]
+  }
+
+  measure:  unique_days_prefiltered {
+    label: "Number of unique days in period"
+    type: count_distinct
+    sql: ${submission_date};;
+    filters: [period_filtered_measures: "this"]
+  }
+
+  measure:  unique_days_prev_prefiltered {
+    label: "Number of unique days previous period"
+    type: count_distinct
+    sql: ${submission_date};;
+    filters: [period_filtered_measures: "last"]
+  }
+
+  dimension: country_filter {
+    description: "Normalizing country name to the names we want"
+    type: string
+    hidden: no
+    sql: CASE WHEN ${country} = "United States" THEN "US"
+              WHEN ${country} = "Germany" THEN "DE"
+              WHEN ${country} = "France" THEN "FR"
+              WHEN ${country} = "Poland" THEN "PL"
+              WHEN ${country} = "Italy" THEN "IT"
+              WHEN ${country} = "Spain" THEN "ES"
+              WHEN ${country} = "United Kingdom" THEN "GB"
+              WHEN ${country} = "Canada" THEN "CA"
+              ELSE ${country} = "Other" END ;;
+  }
+
+  measure: download_goal {
+    view_label: "KPI filtered metrics"
+    type: sum
+    sql: CASE WHEN ${country} = "Canada" THEN ${non_fx_downloads}  * 1.0375
+              WHEN ${country} = "Germany" THEN ${non_fx_downloads} * 1.099
+              WHEN ${country} = "France" THEN ${non_fx_downloads} * 1.0607
+              WHEN ${country} = "Poland" THEN ${non_fx_downloads} * 1.1011
+              WHEN ${country} = "Italy" THEN ${non_fx_downloads} * 1.093
+              WHEN ${country} = "Spain" THEN ${non_fx_downloads} * 1.0224
+              WHEN ${country} = "United Kingdom" THEN ${non_fx_downloads} * 1.0418
+              WHEN ${country} = "United States" THEN ${non_fx_downloads} * 1.428
+              ELSE ${non_fx_downloads} * 1.0102 END;;
+    filters: [period_filtered_measures: "last"]
+  }
+
+}


### PR DESCRIPTION
Checklist for reviewer:
Extended a view in the websites folder. The extension included creating measures to allow us to do previous and current year.


When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
