### PR TITLE
VPN-3934 - Add filter to events on mozilla_vpn

### DIFF
--- a/mozilla_vpn/explores/events.explore.lkml
+++ b/mozilla_vpn/explores/events.explore.lkml
@@ -1,6 +1,6 @@
-include: "//looker-hub/mozilla_vpn/views/events.view.lkml"
+include: "//looker-hub/mozilla_vpn/explores/events.explore.lkml"
 
-explore: events {
+explore: +event_counts {
   sql_always_where:  ${events.submission_date} >= '2010-01-01'
     AND (
       ${events.metadata__header__x_telemetry_agent} LIKE "%Kotlin%"

--- a/mozilla_vpn/explores/events.explore.lkml
+++ b/mozilla_vpn/explores/events.explore.lkml
@@ -1,0 +1,9 @@
+include: "//looker-hub/mozilla_vpn/views/events.view.lkml"
+
+explore: events {
+  sql_always_where:  ${events.submission_date} >= '2010-01-01'
+    AND (
+      ${events.metadata__header__x_telemetry_agent} LIKE "%Kotlin%"
+      OR ${events.metadata__header__x_telemetry_agent} LIKE "%JS%"
+    ) ;;
+}

--- a/mozilla_vpn/explores/funnel_analysis.explore.lkml
+++ b/mozilla_vpn/explores/funnel_analysis.explore.lkml
@@ -1,0 +1,9 @@
+include: "//looker-hub/mozilla_vpn/explores/funnel_analysis.explore.lkml"
+
+explore: +funnel_analysis {
+  sql_always_where: ${funnel_analysis.submission_date} >= '2010-01-01'
+    AND (
+      ${funnel_analysis.telemetry_agent} LIKE "%Kotlin%"
+      OR ${funnel_analysis.telemetry_agent} LIKE "%JS%"
+    ) ;;
+}


### PR DESCRIPTION
Overdue continuation for https://github.com/mozilla/bigquery-etl/pull/3603.

@sean-rose over Slack you [told me](https://mozilla.slack.com/archives/C04QLK11G64/p1677088814029549?thread_ts=1677082113.228959&cid=C04QLK11G64) 

> Once that's merged and deployed you'll want to do the same thing to the VPN [events](https://github.com/mozilla/looker-hub/blob/main/mozilla_vpn/explores/events.explore.lkml) and [funnel_analysis](https://github.com/mozilla/looker-hub/blob/main/mozilla_vpn/explores/funnel_analysis.explore.lkml) explores that we did to the main explore, adding refinements for them in looker-spoke-default to apply the WHERE clause filters.

I am afraid the telemetry agent info is no available for funnel_analysis. Does that sound correct?  Is this filter all that is missing? Thanks!

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
