### PR TITLE
DENG-784 - Version 1 of newtab_visits 

### DIFF
--- a/firefox_desktop/explores/newtab_visits.explore.lkml
+++ b/firefox_desktop/explores/newtab_visits.explore.lkml
@@ -1,0 +1,28 @@
+include: "../views/newtab_visits.view.lkml"
+include: "../../shared/views/countries.view.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/newtab_visits_v1_last_updated.datagroup"
+
+explore: newtab_visits {
+  persist_with: newtab_visits_v1_last_updated
+  sql_always_where: ${newtab_visits.submission_date} >= '2022-07-01' ;;
+  label: "New Tab Visits"
+  from: newtab_visits
+
+  always_filter: {
+    filters: [
+      submission_date: "28 days",
+    ]
+  }
+
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${newtab_visits.country_code} = ${countries.code} ;;
+  }
+
+  join: newtab_visits_table__topsite_tile_interactions {
+    relationship: one_to_many
+    view_label: "Topsite Interactions"
+    sql: LEFT JOIN UNNEST(${newtab_visits.topsite_tile_interactions}) AS newtab_visits_table__topsite_tile_interactions ;;
+  }
+}

--- a/firefox_desktop/views/newtab_visits.view.lkml
+++ b/firefox_desktop/views/newtab_visits.view.lkml
@@ -1,0 +1,137 @@
+include: "//looker-hub/firefox_desktop/views/newtab_visits_table.view.lkml"
+
+view: newtab_visits {
+  extends: [newtab_visits_table]
+
+    dimension: newtab_visit_id {
+      hidden: yes
+      primary_key: yes
+    }
+
+    dimension: client_id {
+      hidden: yes
+    }
+
+    dimension: legacy_telemetry_id {
+      hidden: yes
+    }
+
+    dimension: pocket_story_position {
+      sql: ${TABLE}.pocket_story_position ;;
+      type: number
+    }
+
+    dimension: pocket_enabled {
+      sql: ${TABLE}.pocket_enabled ;;
+      type: yesno
+    }
+
+    dimension: pocket_is_signed_in {
+      sql: ${TABLE}.pocket_is_signed_in ;;
+      type: yesno
+    }
+
+    dimension: pocket_sponsored_stories_enabled {
+      sql: ${TABLE}.pocket_sponsored_stories_enabled ;;
+      type: yesno
+    }
+
+    dimension: topsites_enabled {
+      sql: ${TABLE}.topsites_enabled ;;
+      type: yesno
+    }
+
+    dimension: newtab_homepage_category {
+      sql: ${TABLE}.newtab_homepage_category ;;
+      type: string
+    }
+
+    dimension: newtab_newtab_category {
+      sql: ${TABLE}.newtab_newtab_category ;;
+      type: string
+    }
+
+    dimension: newtab_search_enabled {
+      sql: ${TABLE}.newtab_search_enabled ;;
+      type: yesno
+    }
+
+    dimension: topsites_rows {
+      sql: ${TABLE}.topsites_rows ;;
+      type: number
+    }
+
+    measure: visits {
+      type: count
+    }
+
+    measure: clients {
+      type: count_distinct
+      sql: ${client_id} ;;
+      approximate: yes
+    }
+
+  }
+
+view: +newtab_visits_table__topsite_tile_interactions {
+
+  dimension: primary_key {
+    sql: CONCAT(${topsite_tile_position}, ${topsite_tile_advertiser_name}, ${topsite_tile_id}) ;;
+    hidden: yes
+    primary_key: yes
+  }
+
+  dimension: organic_topsite_tile_clicks {
+    hidden: yes
+  }
+
+  measure: sum_organic_topsite_tile_clicks {
+    sql: ${TABLE}.organic_topsite_tile_clicks ;;
+    type: sum
+  }
+
+  dimension: organic_topsite_tile_impressions {
+    hidden: yes
+  }
+
+  measure: sum_organic_topsite_tile_impressions {
+    sql: ${TABLE}.organic_topsite_tile_impressions ;;
+    type: sum
+  }
+
+  dimension: sponsored_topsite_tile_clicks {
+    hidden: yes
+  }
+
+  measure: sum_sponsored_topsite_tile_clicks {
+    sql: ${TABLE}.sponsored_topsite_tile_clicks ;;
+    type: sum
+  }
+
+  dimension: sponsored_topsite_tile_impressions {
+    hidden: yes
+  }
+
+  measure: sum_sponsored_topsite_tile_impressions {
+    sql: ${TABLE}.sponsored_topsite_tile_impressions ;;
+    type: sum
+  }
+
+  dimension: topsite_tile_clicks {
+    hidden: yes
+  }
+
+  measure: sum_topsite_tile_clicks {
+    sql: ${TABLE}.topsite_tile_clicks ;;
+    type: sum
+  }
+
+  dimension: topsite_tile_impressions {
+    hidden: yes
+  }
+
+  measure: sum_topsite_tile_impressions {
+    sql: ${TABLE}.topsite_tile_impressions ;;
+    type: sum
+  }
+}


### PR DESCRIPTION
Including topsites and top-level metrics/dimensions, including `had_non_impression_engagement` for counting some visits

This will eventually replace `newtab_interactions` - will add pocket and search metrics as a fast-follow but this is to unblock some immediate needs.
