### PR TITLE
View for activation/$ for UAC android campaigns

### DIFF
--- a/duet/explores/google_uac_android_activation.explore.lkml
+++ b/duet/explores/google_uac_android_activation.explore.lkml
@@ -1,0 +1,9 @@
+include: "../views/google_uac_android_activation.view.lkml"
+include: "/shared/views/*"
+
+explore: google_uac_android_activation {
+  label: "Google UAC Android campaign activation"
+  description: "Activation and cost for Google UAC campaigns for Firefox Android"
+  view_name: google_uac_android_activation
+
+}

--- a/duet/views/google_uac_android_activation.view.lkml
+++ b/duet/views/google_uac_android_activation.view.lkml
@@ -1,0 +1,123 @@
+view: google_uac_android_activation {
+
+  derived_table: {
+    sql: WITH uac AS (
+         SELECT
+           date,
+           REGEXP_REPLACE(campaign_name, '(.*) - NULL', '\\1') as campaign,
+           SUM(spend) as cost
+         FROM
+           mozdata.google_ads.daily_campaign_stats
+         WHERE
+            campaign_name NOT LIKE '%iOS%'
+            AND date >= '2022-12-01'
+         GROUP BY
+            1, 2
+        ), activation AS (
+         SELECT
+           first_seen_date as date,
+           REGEXP_REPLACE(adjust_campaign, '([\\w]+).*', '\\1') as campaign,
+           SUM(activated) as activated,
+           COUNT(*) as new_profiles,
+         FROM `moz-fx-data-shared-prod.fenix.new_profile_activation`
+         WHERE submission_date >= '2022-12-01'
+           AND first_seen_date >= '2022-12-01'
+           AND adjust_network = 'Google Ads ACI'
+           AND adjust_campaign LIKE 'Mozilla_%'
+         GROUP BY 1, 2
+        )
+        SELECT
+          date,
+          campaign,
+          CASE WHEN campaign LIKE '%_US_%' OR campaign LIKE '%_CA_%' OR campaign LIKE '%NA%' THEN 'NA' ELSE 'EU' END AS region,
+          REGEXP_EXTRACT(campaign, '.*(Event\\d).*') as event,
+          REGEXP_EXTRACT(campaign, '.*(Group\\d).*') as group_number,
+          REGEXP_EXTRACT(campaign, 'Mozilla_FF_UAC_[\\w]{2}_([\\w]{2})_[\\w]{2}_Group\\d_Event\\d') as country_code,
+          SUM(new_profiles) as new_profiles,
+          SUM(activated) as activated,
+          SUM(cost) as cost
+        FROM uac
+        LEFT JOIN activation USING (date, campaign)
+        WHERE date < DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY)
+        GROUP BY date, campaign
+    ;;
+  }
+
+  dimension: region {
+    description: "Region of the campaign: NA or EU"
+    type: string
+    sql: ${TABLE}.region ;;
+  }
+
+  dimension: event {
+    description: "Event number used for campaign optimization"
+    type: string
+    sql: ${TABLE}.event ;;
+  }
+
+  dimension: group {
+    description: "Group of locations targeted in the campaign"
+    type: string
+    sql: ${TABLE}.group_number ;;
+  }
+
+  dimension: country_code {
+    description: "Country code from campaign name"
+    type: string
+    sql: ${TABLE}.country_code ;;
+  }
+
+  dimension: campaign {
+    description: "Campaign name"
+    type: string
+    sql: ${TABLE}.campaign ;;
+  }
+
+  dimension_group: campaign_date {
+    description: "Date of campaign spend"
+    type: time
+    datatype: date
+    timeframes: [date, week, month, year]
+    sql: ${TABLE}.date ;;
+  }
+
+  measure: new_profiles {
+    description: "First run profiles"
+    type: sum
+    sql: ${TABLE}.new_profiles ;;
+  }
+
+  measure: activated {
+    description: "First run activations"
+    type: sum
+    sql: ${TABLE}.activated ;;
+  }
+
+  measure: cost {
+    description: "Campaign cost"
+    type: sum
+    sql: ${TABLE}.cost ;;
+  }
+
+  measure: activation_rate {
+    label: "Activation Rate"
+    type: number
+    value_format_name: percent_2
+    sql: ${activated}/ NULLIF(${new_profiles},0) ;;
+  }
+
+  measure: activated_per_dollar {
+    label: "Activated/$"
+    type: number
+    value_format_name: decimal_4
+    sql: ${activated}/ NULLIF(${cost},0) ;;
+  }
+
+  measure: cost_per_activation {
+    label: "Cost per activation"
+    type: number
+    value_format_name: usd
+    sql: ${cost}/ NULLIF(${activated},0) ;;
+  }
+
+}

--- a/duet/views/google_uac_android_activation.view.lkml
+++ b/duet/views/google_uac_android_activation.view.lkml
@@ -79,6 +79,7 @@ view: google_uac_android_activation {
     datatype: date
     timeframes: [date, week, month, year]
     sql: ${TABLE}.date ;;
+    convert_tz: no
   }
 
   measure: new_profiles {

--- a/duet/views/google_uac_android_activation.view.lkml
+++ b/duet/views/google_uac_android_activation.view.lkml
@@ -33,7 +33,7 @@ view: google_uac_android_activation {
           CASE WHEN campaign LIKE '%_US_%' OR campaign LIKE '%_CA_%' OR campaign LIKE '%NA%' THEN 'NA' ELSE 'EU' END AS region,
           REGEXP_EXTRACT(campaign, '.*(Event\\d).*') as event,
           REGEXP_EXTRACT(campaign, '.*(Group\\d).*') as group_number,
-          REGEXP_EXTRACT(campaign, 'Mozilla_FF_UAC_[\\w]{2}_([\\w]{2})_[\\w]{2}_Group\\d_Event\\d') as country_code,
+          REGEXP_EXTRACT(campaign, 'Mozilla_FF_UAC_[\\w]{2}_([\\w]{2})_[\\w]{2}_Group\\d_Event\\d') as campaign_country_code,
           SUM(new_profiles) as new_profiles,
           SUM(activated) as activated,
           SUM(cost) as cost
@@ -64,10 +64,10 @@ view: google_uac_android_activation {
     sql: ${TABLE}.group_number ;;
   }
 
-  dimension: country_code {
+  dimension: campaign_country_code {
     description: "Country code from campaign name"
     type: string
-    sql: ${TABLE}.country_code ;;
+    sql: ${TABLE}.campaign_country_code ;;
   }
 
   dimension: campaign {


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
