### PR TITLE
Adding MRR and ARPU plot on SaaSboard revenue

### DIFF
--- a/mozilla_vpn/dashboards/vpn_saasboard_revenue.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_revenue.dashboard.lookml
@@ -79,13 +79,13 @@
     hidden_fields: [active_subscriptions.count_sum, active_subscriptions.annual_recurring_revenue,
       active_subscriptions.monthly_recurring_revenue]
     listen:
-      Pricing Plan: active_subscriptions.pricing_plan
-      Active Date: active_subscriptions.active_date
-      Country: active_subscriptions.country_name
       Provider: active_subscriptions.provider
+      Pricing Plan: active_subscriptions.pricing_plan
+      Country: active_subscriptions.country_name
+      Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
-    row: 24
-    col: 0
+    row: 33
+    col: 12
     width: 12
     height: 9
   - name: ''
@@ -100,7 +100,6 @@
   - name: " (2)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: "<p style='background-color: #ffffdd; padding: 5px 10px; border: solid\
       \ 3px #ededed; border-radius: 5px; height:150px'>\n\nThis dashboard captures\
       \ <strong>revenue</strong> for each active subscription.  Note that revenue\
@@ -180,12 +179,12 @@
     note_display: hover
     note_text: Country is based on customer billing address.
     listen:
-      Pricing Plan: active_subscriptions.pricing_plan
-      Active Date: active_subscriptions.active_date
-      Country: active_subscriptions.country_name
       Provider: active_subscriptions.provider
+      Pricing Plan: active_subscriptions.pricing_plan
+      Country: active_subscriptions.country_name
+      Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
-    row: 15
+    row: 24
     col: 0
     width: 12
     height: 9
@@ -251,19 +250,18 @@
     interpolation: linear
     defaults_version: 1
     listen:
-      Pricing Plan: active_subscriptions.pricing_plan
-      Active Date: active_subscriptions.active_date
-      Country: active_subscriptions.country_name
       Provider: active_subscriptions.provider
+      Pricing Plan: active_subscriptions.pricing_plan
+      Country: active_subscriptions.country_name
+      Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
-    row: 15
+    row: 24
     col: 12
     width: 12
     height: 9
   - name: " (3)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |
       <div style="border-radius: 5px; padding: 5px 10px; background: #412399; height: 60px; color: red;">
 
@@ -301,7 +299,6 @@
     type: single_value
     fields: [metadata.last_modified_date]
     fill_fields: [metadata.last_modified_date]
-    filters: {}
     sorts: [metadata.last_modified_date desc]
     limit: 3
     column_limit: 50
@@ -350,12 +347,7 @@
     note_state: collapsed
     note_display: below
     hidden_fields: [metadata.last_modified_date]
-    listen:
-      Provider: active_subscriptions.provider
-      Pricing Plan: active_subscriptions.pricing_plan
-      Country: active_subscriptions.country_name
-      Active Date: active_subscriptions.active_date
-      Plan Interval Type: active_subscriptions.plan_interval_type
+    listen: {}
     row: 2
     col: 18
     width: 6
@@ -426,12 +418,12 @@
     note_display: hover
     note_text: Country is based on customer billing address.
     listen:
-      Pricing Plan: active_subscriptions.pricing_plan
-      Active Date: active_subscriptions.active_date
-      Country: active_subscriptions.country_name
       Provider: active_subscriptions.provider
+      Pricing Plan: active_subscriptions.pricing_plan
+      Country: active_subscriptions.country_name
+      Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
-    row: 6
+    row: 15
     col: 0
     width: 12
     height: 9
@@ -497,14 +489,99 @@
     interpolation: linear
     defaults_version: 1
     listen:
-      Pricing Plan: active_subscriptions.pricing_plan
-      Active Date: active_subscriptions.active_date
-      Country: active_subscriptions.country_name
       Provider: active_subscriptions.provider
+      Pricing Plan: active_subscriptions.pricing_plan
+      Country: active_subscriptions.country_name
+      Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
-    row: 6
+    row: 15
     col: 12
     width: 12
+    height: 9
+  - title: Monthly Recurring Revenue and Average Revenue Per Unit
+    name: Monthly Recurring Revenue and Average Revenue Per Unit
+    model: mozilla_vpn
+    explore: active_subscriptions
+    type: looker_column
+    fields: [active_subscriptions.active_month, active_subscriptions.monthly_recurring_revenue,
+      active_subscriptions.count_sum]
+    fill_fields: [active_subscriptions.active_month]
+    filters:
+      active_subscriptions.is_end_of_month: 'Yes'
+    sorts: [active_subscriptions.active_month desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields: [{category: table_calculation, expression: "${active_subscriptions.monthly_recurring_revenue}/${active_subscriptions.count_sum}",
+        label: ARPU(MRR/EoM Active subs), value_format: !!null '', value_format_name: decimal_1,
+        _kind_hint: measure, table_calculation: arpumrreom_active_subs, _type_hint: number}]
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: normal
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: circle
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: desc
+    show_null_labels: false
+    show_totals_labels: true
+    show_silhouette: false
+    totals_color: "#808080"
+    color_application:
+      collection_id: legacy
+      palette_id: looker_classic
+      options:
+        steps: 5
+        reverse: false
+    y_axes: [{label: "$ in thousands", orientation: left, series: [{axisId: active_subscriptions.monthly_recurring_revenue,
+            id: active_subscriptions.monthly_recurring_revenue, name: Monthly Recurring
+              Revenue}], showLabels: true, showValues: true, valueFormat: '$#, "K"',
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear},
+      {label: ARPU in$, orientation: right, series: [{axisId: arpumrreom_active_subs,
+            id: arpumrreom_active_subs, name: ARPU(MRR/EoM Active subs)}], showLabels: true,
+        showValues: true, valueFormat: "$0.0", unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    x_axis_label: Month
+    x_axis_zoom: true
+    y_axis_zoom: true
+    font_size: 13px
+    label_value_format: $#, "K"
+    series_types:
+      arpumrreom_active_subs: line
+    series_colors:
+      USA - active_subscriptions.annual_recurring_revenue: "#347be3"
+    x_axis_datetime_label: ''
+    trend_lines: []
+    show_null_points: true
+    interpolation: linear
+    defaults_version: 1
+    note_state: collapsed
+    note_display: hover
+    note_text: Country is based on customer billing address.
+    hidden_fields: [active_subscriptions.count_sum]
+    listen:
+      Provider: active_subscriptions.provider
+      Pricing Plan: active_subscriptions.pricing_plan
+      Country: active_subscriptions.country_name
+      Active Date: active_subscriptions.active_date
+      Plan Interval Type: active_subscriptions.plan_interval_type
+    row: 6
+    col: 0
+    width: 24
     height: 9
   filters:
   - name: Provider
@@ -516,7 +593,6 @@
     ui_config:
       type: checkboxes
       display: popover
-      options: []
     model: mozilla_vpn
     explore: active_subscriptions
     listens_to_filters: [Plan Interval Type, Active Date, Country, Pricing Plan]
@@ -530,7 +606,6 @@
     ui_config:
       type: checkboxes
       display: popover
-      options: []
     model: mozilla_vpn
     explore: active_subscriptions
     listens_to_filters: [Plan Interval Type, Active Date, Country, Provider]
@@ -544,7 +619,6 @@
     ui_config:
       type: checkboxes
       display: popover
-      options: []
     model: mozilla_vpn
     explore: active_subscriptions
     listens_to_filters: [Plan Interval Type, Active Date, Pricing Plan, Provider]
@@ -572,7 +646,6 @@
     ui_config:
       type: checkboxes
       display: popover
-      options: []
     model: mozilla_vpn
     explore: active_subscriptions
     listens_to_filters: [Active Date, Country, Pricing Plan, Provider]


### PR DESCRIPTION
No need to check LookML codes as they are copied from the autogenerated one from Looker GUI that I used to add the plot.  
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
