### PR TITLE
VPN-4726 - Hide Glean.js data from Mozilla VPN views

### DIFF
--- a/mozilla_vpn/explores/events.explore.lkml
+++ b/mozilla_vpn/explores/events.explore.lkml
@@ -1,9 +1,12 @@
 include: "//looker-hub/mozilla_vpn/explores/events.explore.lkml"
 
-explore: +event_counts {
+explore: event_counts {
   sql_always_where:  ${events.submission_date} >= '2010-01-01'
-    AND (
-      ${events.metadata__header__x_telemetry_agent} LIKE "%Kotlin%"
-      OR ${events.metadata__header__x_telemetry_agent} LIKE "%JS%"
-    ) ;;
+      -- For version below 2.16 Kotlin and JS were the main Glean integrations
+      (CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) < 2 OR (CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) < 16 )
+        AND (${events.metadata__header__x_telemetry_agent} LIKE "%Kotlin%" OR ${events.metadata__header__x_telemetry_agent} LIKE "%JS%"))
+      OR
+      -- For version above 2.16 Kotlin, Swift and Rust are the main Glean integrations
+      (CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) > 2 OR (CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) >= 16)
+        AND (${events.metadata__header__x_telemetry_agent} LIKE "%Kotlin%" OR ${events.metadata__header__x_telemetry_agent} LIKE "%Swift%" OR ${events.metadata__header__x_telemetry_agent} LIKE "%Rust%")) ;;
 }

--- a/mozilla_vpn/explores/events.explore.lkml
+++ b/mozilla_vpn/explores/events.explore.lkml
@@ -1,12 +1,11 @@
 include: "//looker-hub/mozilla_vpn/explores/events.explore.lkml"
 
-explore: event_counts {
+explore: +event_counts {
   sql_always_where:  ${events.submission_date} >= '2010-01-01'
-      -- For version below 2.16 Kotlin and JS were the main Glean integrations
-      (CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) < 2 OR (CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) < 16 )
-        AND (${events.metadata__header__x_telemetry_agent} LIKE "%Kotlin%" OR ${events.metadata__header__x_telemetry_agent} LIKE "%JS%"))
-      OR
-      -- For version above 2.16 Kotlin, Swift and Rust are the main Glean integrations
-      (CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) > 2 OR (CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) >= 16)
-        AND (${events.metadata__header__x_telemetry_agent} LIKE "%Kotlin%" OR ${events.metadata__header__x_telemetry_agent} LIKE "%Swift%" OR ${events.metadata__header__x_telemetry_agent} LIKE "%Rust%")) ;;
+      AND (
+        CASE WHEN (SAFE_CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) < 2 OR (SAFE_CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) = 2 AND SAFE_CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_ORDINAL(2)] AS INTEGER) < 16 ))
+        THEN (${events.metadata__header__x_telemetry_agent} LIKE ANY ("%Kotlin%", "%JS%"))
+        ELSE (${events.metadata__header__x_telemetry_agent} LIKE ANY ("%Kotlin%", "%Swift%", "%Rust%"))
+        END
+      ) ;;
 }

--- a/mozilla_vpn/explores/events.explore.lkml
+++ b/mozilla_vpn/explores/events.explore.lkml
@@ -3,6 +3,8 @@ include: "//looker-hub/mozilla_vpn/explores/events.explore.lkml"
 explore: +event_counts {
   sql_always_where:  ${events.submission_date} >= '2010-01-01'
       AND (
+        -- For version below 2.16 Kotlin and JS were the main Glean integrations.
+        -- For version 2.16 and above Kotlin, Swift, and Rust are the main Glean integrations.
         CASE WHEN (SAFE_CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) < 2 OR (SAFE_CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) = 2 AND SAFE_CAST(SPLIT(${events.client_info__app_display_version}, '.')[SAFE_ORDINAL(2)] AS INTEGER) < 16 ))
         THEN (${events.metadata__header__x_telemetry_agent} LIKE ANY ("%Kotlin%", "%JS%"))
         ELSE (${events.metadata__header__x_telemetry_agent} LIKE ANY ("%Kotlin%", "%Swift%", "%Rust%"))

--- a/mozilla_vpn/explores/funnel_analysis.explore.lkml
+++ b/mozilla_vpn/explores/funnel_analysis.explore.lkml
@@ -3,7 +3,12 @@ include: "//looker-hub/mozilla_vpn/explores/funnel_analysis.explore.lkml"
 explore: +funnel_analysis {
   sql_always_where: ${funnel_analysis.submission_date} >= '2010-01-01'
     AND (
-      ${funnel_analysis.telemetry_agent} LIKE "%Kotlin%"
-      OR ${funnel_analysis.telemetry_agent} LIKE "%JS%"
+      -- For version below 2.16 Kotlin and JS were the main Glean integrations
+      (CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) < 2 OR (CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) < 16 )
+        AND (${funnel_analysis.telemetry_agent} LIKE "%Kotlin%" OR ${funnel_analysis.telemetry_agent} LIKE "%JS%"))
+      OR
+      -- For version above 2.16 Kotlin, Swift and Rust are the main Glean integrations
+      (CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) > 2 OR (CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) >= 16)
+        AND (${funnel_analysis.telemetry_agent} LIKE "%Kotlin%" OR ${funnel_analysis.telemetry_agent} LIKE "%Swift%" OR ${funnel_analysis.telemetry_agent} LIKE "%Rust%"))
     ) ;;
 }

--- a/mozilla_vpn/explores/funnel_analysis.explore.lkml
+++ b/mozilla_vpn/explores/funnel_analysis.explore.lkml
@@ -3,12 +3,9 @@ include: "//looker-hub/mozilla_vpn/explores/funnel_analysis.explore.lkml"
 explore: +funnel_analysis {
   sql_always_where: ${funnel_analysis.submission_date} >= '2010-01-01'
     AND (
-      -- For version below 2.16 Kotlin and JS were the main Glean integrations
-      (CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) < 2 OR (CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) < 16 )
-        AND (${funnel_analysis.telemetry_agent} LIKE "%Kotlin%" OR ${funnel_analysis.telemetry_agent} LIKE "%JS%"))
-      OR
-      -- For version above 2.16 Kotlin, Swift and Rust are the main Glean integrations
-      (CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) > 2 OR (CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) >= 16)
-        AND (${funnel_analysis.telemetry_agent} LIKE "%Kotlin%" OR ${funnel_analysis.telemetry_agent} LIKE "%Swift%" OR ${funnel_analysis.telemetry_agent} LIKE "%Rust%"))
+      CASE WHEN (SAFE_CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) < 2 OR (SAFE_CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) = 2 AND SAFE_CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_ORDINAL(2)] AS INTEGER) < 16 ))
+      THEN (${funnel_analysis.telemetry_agent} LIKE ANY ("%Kotlin%", "%JS%"))
+      ELSE (${funnel_analysis.telemetry_agent} LIKE ANY ("%Kotlin%", "%Swift%", "%Rust%"))
+      END
     ) ;;
 }

--- a/mozilla_vpn/explores/funnel_analysis.explore.lkml
+++ b/mozilla_vpn/explores/funnel_analysis.explore.lkml
@@ -3,6 +3,8 @@ include: "//looker-hub/mozilla_vpn/explores/funnel_analysis.explore.lkml"
 explore: +funnel_analysis {
   sql_always_where: ${funnel_analysis.submission_date} >= '2010-01-01'
     AND (
+      -- For version below 2.16 Kotlin and JS were the main Glean integrations.
+      -- For version 2.16 and above Kotlin, Swift, and Rust are the main Glean integrations.
       CASE WHEN (SAFE_CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) < 2 OR (SAFE_CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) = 2 AND SAFE_CAST(SPLIT(${funnel_analysis.app_display_version}, '.')[SAFE_ORDINAL(2)] AS INTEGER) < 16 ))
       THEN (${funnel_analysis.telemetry_agent} LIKE ANY ("%Kotlin%", "%JS%"))
       ELSE (${funnel_analysis.telemetry_agent} LIKE ANY ("%Kotlin%", "%Swift%", "%Rust%"))

--- a/mozilla_vpn/explores/main.explore.lkml
+++ b/mozilla_vpn/explores/main.explore.lkml
@@ -3,12 +3,9 @@ include: "//looker-hub/mozilla_vpn/explores/*"
 explore: +main {
   sql_always_where:  ${main.submission_date} >= '2010-01-01'
     AND (
-      -- For version below 2.16 Kotlin and JS were the main Glean integrations
-      (CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) < 2 OR (CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) < 16 )
-        AND (${metadata__header__x_telemetry_agent} LIKE "%Kotlin%" OR ${metadata__header__x_telemetry_agent} LIKE "%JS%"))
-      OR
-      -- For version avoce 2.16 Kotlin, Swift and Rust are the main Glean integrations
-      (CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) > 2 OR (CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) >= 16)
-        AND (${metadata__header__x_telemetry_agent} LIKE "%Kotlin%" OR ${metadata__header__x_telemetry_agent} LIKE "%Swift%" OR ${metadata__header__x_telemetry_agent} LIKE "%Rust%"))
-     ) ;;
+      CASE WHEN (SAFE_CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) < 2 OR (SAFE_CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) = 2 AND SAFE_CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_ORDINAL(2)] AS INTEGER) < 16 ))
+      THEN (${metadata__header__x_telemetry_agent} LIKE ANY ("%Kotlin%", "%JS%"))
+      ELSE (${metadata__header__x_telemetry_agent} LIKE ANY ("%Kotlin%", "%Swift%", "%Rust%"))
+      END
+    ) ;;
 }

--- a/mozilla_vpn/explores/main.explore.lkml
+++ b/mozilla_vpn/explores/main.explore.lkml
@@ -3,7 +3,12 @@ include: "//looker-hub/mozilla_vpn/explores/*"
 explore: +main {
   sql_always_where:  ${main.submission_date} >= '2010-01-01'
     AND (
-      ${metadata__header__x_telemetry_agent} LIKE "%Kotlin%"
-      OR ${metadata__header__x_telemetry_agent} LIKE "%JS%"
-    ) ;;
+      -- For version below 2.16 Kotlin and JS were the main Glean integrations
+      (CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) < 2 OR (CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) < 16 )
+        AND (${metadata__header__x_telemetry_agent} LIKE "%Kotlin%" OR ${metadata__header__x_telemetry_agent} LIKE "%JS%"))
+      OR
+      -- For version avoce 2.16 Kotlin, Swift and Rust are the main Glean integrations
+      (CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) > 2 OR (CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(1)] AS INTEGER) = 2 AND CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_OFFSET(2)] AS INTEGER) >= 16)
+        AND (${metadata__header__x_telemetry_agent} LIKE "%Kotlin%" OR ${metadata__header__x_telemetry_agent} LIKE "%Swift%" OR ${metadata__header__x_telemetry_agent} LIKE "%Rust%"))
+     ) ;;
 }

--- a/mozilla_vpn/explores/main.explore.lkml
+++ b/mozilla_vpn/explores/main.explore.lkml
@@ -3,6 +3,8 @@ include: "//looker-hub/mozilla_vpn/explores/*"
 explore: +main {
   sql_always_where:  ${main.submission_date} >= '2010-01-01'
     AND (
+      -- For version below 2.16 Kotlin and JS were the main Glean integrations.
+      -- For version 2.16 and above Kotlin, Swift, and Rust are the main Glean integrations.
       CASE WHEN (SAFE_CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) < 2 OR (SAFE_CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_ORDINAL(1)] AS INTEGER) = 2 AND SAFE_CAST(SPLIT(${client_info__app_display_version}, '.')[SAFE_ORDINAL(2)] AS INTEGER) < 16 ))
       THEN (${metadata__header__x_telemetry_agent} LIKE ANY ("%Kotlin%", "%JS%"))
       ELSE (${metadata__header__x_telemetry_agent} LIKE ANY ("%Kotlin%", "%Swift%", "%Rust%"))


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
