### PR TITLE
Add Sponsored Tiles Ad Request Fill Rate

### DIFF
--- a/contextual_services/explores/sponsored_tiles_ad_request_fill.explore.lkml
+++ b/contextual_services/explores/sponsored_tiles_ad_request_fill.explore.lkml
@@ -1,0 +1,15 @@
+include: "/contextual_services/views/sponsored_tiles_ad_request_fill.view.lkml"
+
+explore: sponsored_tiles_ad_request_fill {
+
+  view_name: sponsored_tiles_ad_request_fill
+  view_label: "Sponsored Tiles ad request fill"
+  description: "Sponsored tiles advertising request fill rate from advertising partners."
+
+  # always_filter: {
+  #   filters: [
+  #     revenue_data_admarketplace.date_date: "3 months"
+  #   ]
+  # }
+
+}

--- a/contextual_services/views/sponsored_tiles_ad_request_fill.view.lkml
+++ b/contextual_services/views/sponsored_tiles_ad_request_fill.view.lkml
@@ -1,0 +1,41 @@
+include: "//looker-hub/contextual_services/views/sponsored_tiles_ad_request_fill.view.lkml"
+
+view: +sponsored_tiles_ad_request_fill {
+
+  dimension: adm_empty_response_sum {
+    hidden: yes
+  }
+
+  measure: adm_empty_response_sum {
+    sql: ${TABLE}.adm_empty_response_sum ;;
+    type: sum
+  }
+
+  dimension: adm_request_sum {
+    hidden: yes
+  }
+
+  measure: adm_request_sum {
+    sql: ${TABLE}.adm_request_sum ;;
+    type: sum
+  }
+
+  dimension: adm_response_rate {
+    hidden:  yes
+  }
+
+  measure: adm_response_rate {
+    sql: ${TABLE}.adm_response_rate ;;
+    type: sum
+  }
+
+  dimension: adm_response_tiles_min {
+    hidden:  yes
+  }
+
+  measure: adm_response_tiles_min {
+    sql: ${TABLE}.adm_response_tiles_min ;;
+    type: min
+  }
+
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
