### PR TITLE
add goal line to overview and 2 cards showing active rows per connect…

### DIFF
--- a/fivetran/dashboards/fivetran_connector_costs.dashboard.lookml
+++ b/fivetran/dashboards/fivetran_connector_costs.dashboard.lookml
@@ -4,7 +4,7 @@
   preferred_viewer: dashboards-next
   crossfilter_enabled: true
   description: ''
-  preferred_slug: wMc2jUrfMsnEMbXoTEzQDF
+  preferred_slug: lyQwwJDGYBrn6B2y5QDKTI
   elements:
   - title: Total Costs
     name: Total Costs
@@ -28,8 +28,8 @@
     listen:
       Project: connector_costs.destination
       Connector: connector_costs.connector
-      Measured Month: connector_costs.measured_month
       Billing Type: connector_costs.billing_type
+      Measured Month: connector_costs.measured_month
     row: 11
     col: 0
     width: 5
@@ -39,11 +39,12 @@
     model: fivetran
     explore: connector_costs
     type: looker_column
-    fields: [connector_costs.measured_month, connector_costs.paid_active_rows, connector_costs.cost_in_USD,
+    fields: [connector_costs.measured_month, connector_costs.cost_in_USD, connector_costs.paid_active_rows,
       connector_costs.spent_rate]
     fill_fields: [connector_costs.measured_month]
     sorts: [connector_costs.measured_month]
     limit: 500
+    column_limit: 50
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -84,6 +85,9 @@
     y_axis_zoom: true
     series_types:
       connector_costs.spent_rate: line
+    reference_lines: [{reference_type: line, range_start: max, range_end: min, margin_top: deviation,
+        margin_value: mean, margin_bottom: deviation, label_position: left, color: "#FF2A8A",
+        line_value: '14000', label: Spending Limit}]
     show_null_points: true
     interpolation: linear
     defaults_version: 1
@@ -113,12 +117,11 @@
     conditional_formatting_include_nulls: false
     show_view_names: false
     defaults_version: 1
-    series_types: {}
     listen:
       Project: connector_costs.destination
       Connector: connector_costs.connector
-      Measured Month: connector_costs.measured_month
       Billing Type: connector_costs.billing_type
+      Measured Month: connector_costs.measured_month
     row: 11
     col: 10
     width: 5
@@ -142,13 +145,12 @@
     conditional_formatting_include_nulls: false
     show_view_names: false
     defaults_version: 1
-    series_types: {}
     hidden_pivots: {}
     listen:
       Project: connector_costs.destination
       Connector: connector_costs.connector
-      Measured Month: connector_costs.measured_month
       Billing Type: connector_costs.billing_type
+      Measured Month: connector_costs.measured_month
     row: 11
     col: 5
     width: 5
@@ -193,7 +195,6 @@
     totals_color: "#808080"
     x_axis_zoom: true
     y_axis_zoom: true
-    series_types: {}
     show_null_points: true
     interpolation: linear
     defaults_version: 1
@@ -201,8 +202,8 @@
     listen:
       Project: connector_costs.destination
       Connector: connector_costs.connector
-      Measured Month: connector_costs.measured_month
       Billing Type: connector_costs.billing_type
+      Measured Month: connector_costs.measured_month
     row: 16
     col: 0
     width: 24
@@ -260,7 +261,6 @@
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
-    series_types: {}
     series_column_widths:
       connector_costs.destination: 126
       connector_costs.connector_group: 118
@@ -270,8 +270,8 @@
     listen:
       Project: connector_costs.destination
       Connector: connector_costs.connector
-      Measured Month: connector_costs.measured_month
       Billing Type: connector_costs.billing_type
+      Measured Month: connector_costs.measured_month
     row: 25
     col: 0
     width: 24
@@ -279,7 +279,6 @@
   - name: ''
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: '[{"type":"p","children":[{"text":""}],"id":1677007226682},{"type":"h1","children":[{"text":"Overview"}],"align":"center"}]'
     rich_content_json: '{"format":"slate"}'
     row: 0
@@ -289,7 +288,6 @@
   - name: " (2)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: '[{"type":"p","children":[{"text":""}],"id":1677007228625},{"type":"h1","children":[{"text":"Details
       for selected Filters"}],"align":"center"}]'
     rich_content_json: '{"format":"slate"}'
@@ -303,7 +301,6 @@
     explore: connector_costs
     type: single_value
     fields: [connector_costs.total_active_rows, connector_costs.time_frame]
-    filters: {}
     limit: 500
     column_limit: 50
     custom_color_enabled: true
@@ -317,13 +314,12 @@
     conditional_formatting_include_nulls: false
     show_view_names: false
     defaults_version: 1
-    series_types: {}
     hidden_pivots: {}
     listen:
       Project: connector_costs.destination
       Connector: connector_costs.connector
-      Measured Month: connector_costs.measured_month
       Billing Type: connector_costs.billing_type
+      Measured Month: connector_costs.measured_month
     row: 11
     col: 15
     width: 5
@@ -364,16 +360,462 @@
     show_null_points: true
     interpolation: linear
     defaults_version: 1
-    series_types: {}
     listen:
       Project: connector_costs.destination
       Connector: connector_costs.connector
-      Measured Month: connector_costs.measured_month
       Billing Type: connector_costs.billing_type
+      Measured Month: connector_costs.measured_month
     row: 11
     col: 20
     width: 4
     height: 5
+  - title: 'Paid Active Rows per Connetor Group over Time '
+    name: 'Paid Active Rows per Connetor Group over Time '
+    model: fivetran
+    explore: connector_costs
+    type: looker_line
+    fields: [connector_costs.measured_month, connector_costs.paid_active_rows, connector_costs.connector_group]
+    pivots: [connector_costs.connector_group]
+    fill_fields: [connector_costs.measured_month]
+    sorts: [connector_costs.measured_month, connector_costs.connector_group]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: connector_costs.paid_active_rows,
+            id: acoustic_connector_dev - connector_costs.paid_active_rows, name: acoustic_connector_dev},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_connector_dev_2
+              - connector_costs.paid_active_rows, name: acoustic_connector_dev_2},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_contacts_export
+              - connector_costs.paid_active_rows, name: acoustic_contacts_export},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_export_dev_3 - connector_costs.paid_active_rows,
+            name: acoustic_export_dev_3}, {axisId: connector_costs.paid_active_rows,
+            id: acoustic_export_dev_4 - connector_costs.paid_active_rows, name: acoustic_export_dev_4},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp_test.contact_export
+              - connector_costs.paid_active_rows, name: acoustic_sftp_test.contact_export},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.contact_export
+              - connector_costs.paid_active_rows, name: acoustic_sftp.contact_export},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.contact_export_2
+              - connector_costs.paid_active_rows, name: acoustic_sftp.contact_export_2},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.contact_export_v1
+              - connector_costs.paid_active_rows, name: acoustic_sftp.contact_export_v1},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.raw_recipient_export
+              - connector_costs.paid_active_rows, name: acoustic_sftp.raw_recipient_export},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.raw_recipient_export_
+              - connector_costs.paid_active_rows, name: acoustic_sftp.raw_recipient_export_},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.raw_recipient_export_v1
+              - connector_costs.paid_active_rows, name: acoustic_sftp.raw_recipient_export_v1},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_test_schema - connector_costs.paid_active_rows,
+            name: acoustic_test_schema}, {axisId: connector_costs.paid_active_rows,
+            id: admarket - connector_costs.paid_active_rows, name: admarket}, {axisId: connector_costs.paid_active_rows,
+            id: admarket_place - connector_costs.paid_active_rows, name: admarket_place},
+          {axisId: connector_costs.paid_active_rows, id: admarketplace_rpm_sftp -
+              connector_costs.paid_active_rows, name: admarketplace_rpm_sftp}, {axisId: connector_costs.paid_active_rows,
+            id: admarketplace_sftp - connector_costs.paid_active_rows, name: admarketplace_sftp},
+          {axisId: connector_costs.paid_active_rows, id: airflow_metadata - connector_costs.paid_active_rows,
+            name: airflow_metadata}, {axisId: connector_costs.paid_active_rows, id: akomar_bing
+              - connector_costs.paid_active_rows, name: akomar_bing}, {axisId: connector_costs.paid_active_rows,
+            id: akomar_bing_gross_update - connector_costs.paid_active_rows, name: akomar_bing_gross_update},
+          {axisId: connector_costs.paid_active_rows, id: akomar_bing_test_2019 - connector_costs.paid_active_rows,
+            name: akomar_bing_test_2019}, {axisId: connector_costs.paid_active_rows,
+            id: amazon - connector_costs.paid_active_rows, name: amazon}, {axisId: connector_costs.paid_active_rows,
+            id: apple_app_store - connector_costs.paid_active_rows, name: apple_app_store},
+          {axisId: connector_costs.paid_active_rows, id: apple_search_ads - connector_costs.paid_active_rows,
+            name: apple_search_ads}, {axisId: connector_costs.paid_active_rows, id: bing
+              - connector_costs.paid_active_rows, name: bing}, {axisId: connector_costs.paid_active_rows,
+            id: bing_operational_tmp - connector_costs.paid_active_rows, name: bing_operational_tmp},
+          {axisId: connector_costs.paid_active_rows, id: box_test - connector_costs.paid_active_rows,
+            name: box_test}, {axisId: connector_costs.paid_active_rows, id: bugzilla
+              - connector_costs.paid_active_rows, name: bugzilla}, {axisId: connector_costs.paid_active_rows,
+            id: buzilla_test_ak - connector_costs.paid_active_rows, name: buzilla_test_ak},
+          {axisId: connector_costs.paid_active_rows, id: canonical - connector_costs.paid_active_rows,
+            name: canonical}, {axisId: connector_costs.paid_active_rows, id: casa
+              - connector_costs.paid_active_rows, name: casa}, {axisId: connector_costs.paid_active_rows,
+            id: casatest - connector_costs.paid_active_rows, name: casatest}, {axisId: connector_costs.paid_active_rows,
+            id: duck_duck_go - connector_costs.paid_active_rows, name: duck_duck_go},
+          {axisId: connector_costs.paid_active_rows, id: ecosia - connector_costs.paid_active_rows,
+            name: ecosia}, {axisId: connector_costs.paid_active_rows, id: ecosia_dev
+              - connector_costs.paid_active_rows, name: ecosia_dev}, {axisId: connector_costs.paid_active_rows,
+            id: ecosia_temp - connector_costs.paid_active_rows, name: ecosia_temp},
+          {axisId: connector_costs.paid_active_rows, id: firefox_android_google_play
+              - connector_costs.paid_active_rows, name: firefox_android_google_play},
+          {axisId: connector_costs.paid_active_rows, id: firefox_app_store - connector_costs.paid_active_rows,
+            name: firefox_app_store}, {axisId: connector_costs.paid_active_rows, id: fivetran_log
+              - connector_costs.paid_active_rows, name: fivetran_log}, {axisId: connector_costs.paid_active_rows,
+            id: google - connector_costs.paid_active_rows, name: google}, {axisId: connector_costs.paid_active_rows,
+            id: google_ads - connector_costs.paid_active_rows, name: google_ads},
+          {axisId: connector_costs.paid_active_rows, id: google_dev_v2 - connector_costs.paid_active_rows,
+            name: google_dev_v2}, {axisId: connector_costs.paid_active_rows, id: google_play_store
+              - connector_costs.paid_active_rows, name: google_play_store}, {axisId: connector_costs.paid_active_rows,
+            id: google_search_console - connector_costs.paid_active_rows, name: google_search_console},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_addons
+              - connector_costs.paid_active_rows, name: google_search_console_addons},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_blog
+              - connector_costs.paid_active_rows, name: google_search_console_blog},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_pocket
+              - connector_costs.paid_active_rows, name: google_search_console_pocket},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_support
+              - connector_costs.paid_active_rows, name: google_search_console_support},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_www
+              - connector_costs.paid_active_rows, name: google_search_console_www},
+          {axisId: connector_costs.paid_active_rows, id: google_sheets.finance_revenue_by_month
+              - connector_costs.paid_active_rows, name: google_sheets.finance_revenue_by_month},
+          {axisId: connector_costs.paid_active_rows, id: google_sheets.sales_deals
+              - connector_costs.paid_active_rows, name: google_sheets.sales_deals},
+          {axisId: connector_costs.paid_active_rows, id: greenhouse - connector_costs.paid_active_rows,
+            name: greenhouse}, {axisId: connector_costs.paid_active_rows, id: helpscout
+              - connector_costs.paid_active_rows, name: helpscout}, {axisId: connector_costs.paid_active_rows,
+            id: mailru - connector_costs.paid_active_rows, name: mailru}, {axisId: connector_costs.paid_active_rows,
+            id: microsoft_api - connector_costs.paid_active_rows, name: microsoft_api},
+          {axisId: connector_costs.paid_active_rows, id: microsoft_pubcenter_api -
+              connector_costs.paid_active_rows, name: microsoft_pubcenter_api}, {
+            axisId: connector_costs.paid_active_rows, id: netsuite - connector_costs.paid_active_rows,
+            name: netsuite}, {axisId: connector_costs.paid_active_rows, id: netsuite_test_1
+              - connector_costs.paid_active_rows, name: netsuite_test_1}, {axisId: connector_costs.paid_active_rows,
+            id: qwant - connector_costs.paid_active_rows, name: qwant}, {axisId: connector_costs.paid_active_rows,
+            id: rakuten - connector_costs.paid_active_rows, name: rakuten}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_amazon - connector_costs.paid_active_rows, name: revenue_amazon},
+          {axisId: connector_costs.paid_active_rows, id: revenue_bing - connector_costs.paid_active_rows,
+            name: revenue_bing}, {axisId: connector_costs.paid_active_rows, id: revenue_bing_operational
+              - connector_costs.paid_active_rows, name: revenue_bing_operational},
+          {axisId: connector_costs.paid_active_rows, id: revenue_canonical - connector_costs.paid_active_rows,
+            name: revenue_canonical}, {axisId: connector_costs.paid_active_rows, id: revenue_ddg_v2
+              - connector_costs.paid_active_rows, name: revenue_ddg_v2}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_duck_duck_go - connector_costs.paid_active_rows, name: revenue_duck_duck_go},
+          {axisId: connector_costs.paid_active_rows, id: revenue_duck_duck_go_v2 -
+              connector_costs.paid_active_rows, name: revenue_duck_duck_go_v2}, {
+            axisId: connector_costs.paid_active_rows, id: revenue_ebay - connector_costs.paid_active_rows,
+            name: revenue_ebay}, {axisId: connector_costs.paid_active_rows, id: revenue_ecosia
+              - connector_costs.paid_active_rows, name: revenue_ecosia}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_ecosia_v2 - connector_costs.paid_active_rows, name: revenue_ecosia_v2},
+          {axisId: connector_costs.paid_active_rows, id: revenue_google - connector_costs.paid_active_rows,
+            name: revenue_google}, {axisId: connector_costs.paid_active_rows, id: revenue_google_v2
+              - connector_costs.paid_active_rows, name: revenue_google_v2}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_mailru - connector_costs.paid_active_rows, name: revenue_mailru},
+          {axisId: connector_costs.paid_active_rows, id: revenue_qwant - connector_costs.paid_active_rows,
+            name: revenue_qwant}, {axisId: connector_costs.paid_active_rows, id: revenue_rakuten
+              - connector_costs.paid_active_rows, name: revenue_rakuten}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_seznam - connector_costs.paid_active_rows, name: revenue_seznam},
+          {axisId: connector_costs.paid_active_rows, id: revenue_united - connector_costs.paid_active_rows,
+            name: revenue_united}, {axisId: connector_costs.paid_active_rows, id: revenue_yahoo_japan
+              - connector_costs.paid_active_rows, name: revenue_yahoo_japan}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_australia - connector_costs.paid_active_rows, name: sage_intacct_australia},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_belgium - connector_costs.paid_active_rows,
+            name: sage_intacct_belgium}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_canada - connector_costs.paid_active_rows, name: sage_intacct_canada},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_china_vie -
+              connector_costs.paid_active_rows, name: sage_intacct_china_vie}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_china_wofe - connector_costs.paid_active_rows, name: sage_intacct_china_wofe},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_denmark - connector_costs.paid_active_rows,
+            name: sage_intacct_denmark}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_finland - connector_costs.paid_active_rows, name: sage_intacct_finland},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_france - connector_costs.paid_active_rows,
+            name: sage_intacct_france}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_germany - connector_costs.paid_active_rows, name: sage_intacct_germany},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_moz - connector_costs.paid_active_rows,
+            name: sage_intacct_moz}, {axisId: connector_costs.paid_active_rows, id: sage_intacct_netherlands
+              - connector_costs.paid_active_rows, name: sage_intacct_netherlands},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_nz - connector_costs.paid_active_rows,
+            name: sage_intacct_nz}, {axisId: connector_costs.paid_active_rows, id: sage_intacct_pocket
+              - connector_costs.paid_active_rows, name: sage_intacct_pocket}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_spain - connector_costs.paid_active_rows, name: sage_intacct_spain},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_sweden - connector_costs.paid_active_rows,
+            name: sage_intacct_sweden}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_taiwan - connector_costs.paid_active_rows, name: sage_intacct_taiwan},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_uk - connector_costs.paid_active_rows,
+            name: sage_intacct_uk}, {axisId: connector_costs.paid_active_rows, id: seznam
+              - connector_costs.paid_active_rows, name: seznam}, {axisId: connector_costs.paid_active_rows,
+            id: stripe - connector_costs.paid_active_rows, name: stripe}, {axisId: connector_costs.paid_active_rows,
+            id: stripe_dev_relud - connector_costs.paid_active_rows, name: stripe_dev_relud},
+          {axisId: connector_costs.paid_active_rows, id: stripe_nonprod - connector_costs.paid_active_rows,
+            name: stripe_nonprod}, {axisId: connector_costs.paid_active_rows, id: test_test_test_leli
+              - connector_costs.paid_active_rows, name: test_test_test_leli}, {axisId: connector_costs.paid_active_rows,
+            id: test_test_test_leli.test_merged - connector_costs.paid_active_rows,
+            name: test_test_test_leli.test_merged}, {axisId: connector_costs.paid_active_rows,
+            id: united - connector_costs.paid_active_rows, name: united}, {axisId: connector_costs.paid_active_rows,
+            id: workday - connector_costs.paid_active_rows, name: workday}, {axisId: connector_costs.paid_active_rows,
+            id: workday_hcm - connector_costs.paid_active_rows, name: workday_hcm},
+          {axisId: connector_costs.paid_active_rows, id: workday_raas.employee_details_report
+              - connector_costs.paid_active_rows, name: workday_raas.employee_details_report},
+          {axisId: connector_costs.paid_active_rows, id: workday_raas.open_position_details_report
+              - connector_costs.paid_active_rows, name: workday_raas.open_position_details_report},
+          {axisId: connector_costs.paid_active_rows, id: workday_raas.promotions_in_date_range_report
+              - connector_costs.paid_active_rows, name: workday_raas.promotions_in_date_range_report},
+          {axisId: connector_costs.paid_active_rows, id: workday_raas.total_staffing_report
+              - connector_costs.paid_active_rows, name: workday_raas.total_staffing_report},
+          {axisId: connector_costs.paid_active_rows, id: zendesk - connector_costs.paid_active_rows,
+            name: zendesk}], showLabels: true, showValues: true, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}]
+    x_axis_zoom: true
+    y_axis_zoom: true
+    hide_legend: false
+    swap_axes: false
+    defaults_version: 1
+    hidden_pivots: {}
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    listen:
+      Project: connector_costs.destination
+      Connector: connector_costs.connector
+      Billing Type: connector_costs.billing_type
+    row: 37
+    col: 0
+    width: 24
+    height: 8
+  - name: " (3)"
+    type: text
+    title_text: ''
+    subtitle_text: ''
+    body_text: '[{"type":"h1","children":[{"text":"Over Time"}],"align":"center"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 35
+    col: 0
+    width: 24
+    height: 2
+  - title: Paid Active Rows per Connector over Time
+    name: Paid Active Rows per Connector over Time
+    model: fivetran
+    explore: connector_costs
+    type: looker_line
+    fields: [connector_costs.measured_month, connector_costs.paid_active_rows, connector_costs.connector]
+    pivots: [connector_costs.connector]
+    fill_fields: [connector_costs.measured_month]
+    filters: {}
+    sorts: [connector_costs.measured_month, connector_costs.connector]
+    limit: 500
+    column_limit: 500
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: '', orientation: left, series: [{axisId: connector_costs.paid_active_rows,
+            id: acoustic_connector_dev - connector_costs.paid_active_rows, name: acoustic_connector_dev},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_connector_dev_2
+              - connector_costs.paid_active_rows, name: acoustic_connector_dev_2},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_contacts_export
+              - connector_costs.paid_active_rows, name: acoustic_contacts_export},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_export_dev_3 - connector_costs.paid_active_rows,
+            name: acoustic_export_dev_3}, {axisId: connector_costs.paid_active_rows,
+            id: acoustic_export_dev_4 - connector_costs.paid_active_rows, name: acoustic_export_dev_4},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp_test.contact_export
+              - connector_costs.paid_active_rows, name: acoustic_sftp_test.contact_export},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.contact_export
+              - connector_costs.paid_active_rows, name: acoustic_sftp.contact_export},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.contact_export_2
+              - connector_costs.paid_active_rows, name: acoustic_sftp.contact_export_2},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.contact_export_v1
+              - connector_costs.paid_active_rows, name: acoustic_sftp.contact_export_v1},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.raw_recipient_export
+              - connector_costs.paid_active_rows, name: acoustic_sftp.raw_recipient_export},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.raw_recipient_export_
+              - connector_costs.paid_active_rows, name: acoustic_sftp.raw_recipient_export_},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_sftp.raw_recipient_export_v1
+              - connector_costs.paid_active_rows, name: acoustic_sftp.raw_recipient_export_v1},
+          {axisId: connector_costs.paid_active_rows, id: acoustic_test_schema - connector_costs.paid_active_rows,
+            name: acoustic_test_schema}, {axisId: connector_costs.paid_active_rows,
+            id: admarket - connector_costs.paid_active_rows, name: admarket}, {axisId: connector_costs.paid_active_rows,
+            id: admarket_place - connector_costs.paid_active_rows, name: admarket_place},
+          {axisId: connector_costs.paid_active_rows, id: admarketplace_rpm_sftp -
+              connector_costs.paid_active_rows, name: admarketplace_rpm_sftp}, {axisId: connector_costs.paid_active_rows,
+            id: admarketplace_sftp - connector_costs.paid_active_rows, name: admarketplace_sftp},
+          {axisId: connector_costs.paid_active_rows, id: airflow_metadata - connector_costs.paid_active_rows,
+            name: airflow_metadata}, {axisId: connector_costs.paid_active_rows, id: akomar_bing
+              - connector_costs.paid_active_rows, name: akomar_bing}, {axisId: connector_costs.paid_active_rows,
+            id: akomar_bing_gross_update - connector_costs.paid_active_rows, name: akomar_bing_gross_update},
+          {axisId: connector_costs.paid_active_rows, id: akomar_bing_test_2019 - connector_costs.paid_active_rows,
+            name: akomar_bing_test_2019}, {axisId: connector_costs.paid_active_rows,
+            id: amazon - connector_costs.paid_active_rows, name: amazon}, {axisId: connector_costs.paid_active_rows,
+            id: apple_app_store - connector_costs.paid_active_rows, name: apple_app_store},
+          {axisId: connector_costs.paid_active_rows, id: apple_search_ads - connector_costs.paid_active_rows,
+            name: apple_search_ads}, {axisId: connector_costs.paid_active_rows, id: bing
+              - connector_costs.paid_active_rows, name: bing}, {axisId: connector_costs.paid_active_rows,
+            id: bing_operational_tmp - connector_costs.paid_active_rows, name: bing_operational_tmp},
+          {axisId: connector_costs.paid_active_rows, id: box_test - connector_costs.paid_active_rows,
+            name: box_test}, {axisId: connector_costs.paid_active_rows, id: bugzilla
+              - connector_costs.paid_active_rows, name: bugzilla}, {axisId: connector_costs.paid_active_rows,
+            id: buzilla_test_ak - connector_costs.paid_active_rows, name: buzilla_test_ak},
+          {axisId: connector_costs.paid_active_rows, id: canonical - connector_costs.paid_active_rows,
+            name: canonical}, {axisId: connector_costs.paid_active_rows, id: casa
+              - connector_costs.paid_active_rows, name: casa}, {axisId: connector_costs.paid_active_rows,
+            id: casatest - connector_costs.paid_active_rows, name: casatest}, {axisId: connector_costs.paid_active_rows,
+            id: duck_duck_go - connector_costs.paid_active_rows, name: duck_duck_go},
+          {axisId: connector_costs.paid_active_rows, id: ecosia - connector_costs.paid_active_rows,
+            name: ecosia}, {axisId: connector_costs.paid_active_rows, id: ecosia_dev
+              - connector_costs.paid_active_rows, name: ecosia_dev}, {axisId: connector_costs.paid_active_rows,
+            id: ecosia_temp - connector_costs.paid_active_rows, name: ecosia_temp},
+          {axisId: connector_costs.paid_active_rows, id: firefox_android_google_play
+              - connector_costs.paid_active_rows, name: firefox_android_google_play},
+          {axisId: connector_costs.paid_active_rows, id: firefox_app_store - connector_costs.paid_active_rows,
+            name: firefox_app_store}, {axisId: connector_costs.paid_active_rows, id: fivetran_log
+              - connector_costs.paid_active_rows, name: fivetran_log}, {axisId: connector_costs.paid_active_rows,
+            id: google - connector_costs.paid_active_rows, name: google}, {axisId: connector_costs.paid_active_rows,
+            id: google_ads - connector_costs.paid_active_rows, name: google_ads},
+          {axisId: connector_costs.paid_active_rows, id: google_dev_v2 - connector_costs.paid_active_rows,
+            name: google_dev_v2}, {axisId: connector_costs.paid_active_rows, id: google_play_store
+              - connector_costs.paid_active_rows, name: google_play_store}, {axisId: connector_costs.paid_active_rows,
+            id: google_search_console - connector_costs.paid_active_rows, name: google_search_console},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_addons
+              - connector_costs.paid_active_rows, name: google_search_console_addons},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_blog
+              - connector_costs.paid_active_rows, name: google_search_console_blog},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_pocket
+              - connector_costs.paid_active_rows, name: google_search_console_pocket},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_support
+              - connector_costs.paid_active_rows, name: google_search_console_support},
+          {axisId: connector_costs.paid_active_rows, id: google_search_console_www
+              - connector_costs.paid_active_rows, name: google_search_console_www},
+          {axisId: connector_costs.paid_active_rows, id: google_sheets.finance_revenue_by_month
+              - connector_costs.paid_active_rows, name: google_sheets.finance_revenue_by_month},
+          {axisId: connector_costs.paid_active_rows, id: google_sheets.sales_deals
+              - connector_costs.paid_active_rows, name: google_sheets.sales_deals},
+          {axisId: connector_costs.paid_active_rows, id: greenhouse - connector_costs.paid_active_rows,
+            name: greenhouse}, {axisId: connector_costs.paid_active_rows, id: helpscout
+              - connector_costs.paid_active_rows, name: helpscout}, {axisId: connector_costs.paid_active_rows,
+            id: mailru - connector_costs.paid_active_rows, name: mailru}, {axisId: connector_costs.paid_active_rows,
+            id: microsoft_api - connector_costs.paid_active_rows, name: microsoft_api},
+          {axisId: connector_costs.paid_active_rows, id: microsoft_pubcenter_api -
+              connector_costs.paid_active_rows, name: microsoft_pubcenter_api}, {
+            axisId: connector_costs.paid_active_rows, id: netsuite - connector_costs.paid_active_rows,
+            name: netsuite}, {axisId: connector_costs.paid_active_rows, id: netsuite_test_1
+              - connector_costs.paid_active_rows, name: netsuite_test_1}, {axisId: connector_costs.paid_active_rows,
+            id: qwant - connector_costs.paid_active_rows, name: qwant}, {axisId: connector_costs.paid_active_rows,
+            id: rakuten - connector_costs.paid_active_rows, name: rakuten}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_amazon - connector_costs.paid_active_rows, name: revenue_amazon},
+          {axisId: connector_costs.paid_active_rows, id: revenue_bing - connector_costs.paid_active_rows,
+            name: revenue_bing}, {axisId: connector_costs.paid_active_rows, id: revenue_bing_operational
+              - connector_costs.paid_active_rows, name: revenue_bing_operational},
+          {axisId: connector_costs.paid_active_rows, id: revenue_canonical - connector_costs.paid_active_rows,
+            name: revenue_canonical}, {axisId: connector_costs.paid_active_rows, id: revenue_ddg_v2
+              - connector_costs.paid_active_rows, name: revenue_ddg_v2}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_duck_duck_go - connector_costs.paid_active_rows, name: revenue_duck_duck_go},
+          {axisId: connector_costs.paid_active_rows, id: revenue_duck_duck_go_v2 -
+              connector_costs.paid_active_rows, name: revenue_duck_duck_go_v2}, {
+            axisId: connector_costs.paid_active_rows, id: revenue_ebay - connector_costs.paid_active_rows,
+            name: revenue_ebay}, {axisId: connector_costs.paid_active_rows, id: revenue_ecosia
+              - connector_costs.paid_active_rows, name: revenue_ecosia}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_ecosia_v2 - connector_costs.paid_active_rows, name: revenue_ecosia_v2},
+          {axisId: connector_costs.paid_active_rows, id: revenue_google - connector_costs.paid_active_rows,
+            name: revenue_google}, {axisId: connector_costs.paid_active_rows, id: revenue_google_v2
+              - connector_costs.paid_active_rows, name: revenue_google_v2}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_mailru - connector_costs.paid_active_rows, name: revenue_mailru},
+          {axisId: connector_costs.paid_active_rows, id: revenue_qwant - connector_costs.paid_active_rows,
+            name: revenue_qwant}, {axisId: connector_costs.paid_active_rows, id: revenue_rakuten
+              - connector_costs.paid_active_rows, name: revenue_rakuten}, {axisId: connector_costs.paid_active_rows,
+            id: revenue_seznam - connector_costs.paid_active_rows, name: revenue_seznam},
+          {axisId: connector_costs.paid_active_rows, id: revenue_united - connector_costs.paid_active_rows,
+            name: revenue_united}, {axisId: connector_costs.paid_active_rows, id: revenue_yahoo_japan
+              - connector_costs.paid_active_rows, name: revenue_yahoo_japan}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_australia - connector_costs.paid_active_rows, name: sage_intacct_australia},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_belgium - connector_costs.paid_active_rows,
+            name: sage_intacct_belgium}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_canada - connector_costs.paid_active_rows, name: sage_intacct_canada},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_china_vie -
+              connector_costs.paid_active_rows, name: sage_intacct_china_vie}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_china_wofe - connector_costs.paid_active_rows, name: sage_intacct_china_wofe},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_denmark - connector_costs.paid_active_rows,
+            name: sage_intacct_denmark}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_finland - connector_costs.paid_active_rows, name: sage_intacct_finland},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_france - connector_costs.paid_active_rows,
+            name: sage_intacct_france}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_germany - connector_costs.paid_active_rows, name: sage_intacct_germany},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_moz - connector_costs.paid_active_rows,
+            name: sage_intacct_moz}, {axisId: connector_costs.paid_active_rows, id: sage_intacct_netherlands
+              - connector_costs.paid_active_rows, name: sage_intacct_netherlands},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_nz - connector_costs.paid_active_rows,
+            name: sage_intacct_nz}, {axisId: connector_costs.paid_active_rows, id: sage_intacct_pocket
+              - connector_costs.paid_active_rows, name: sage_intacct_pocket}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_spain - connector_costs.paid_active_rows, name: sage_intacct_spain},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_sweden - connector_costs.paid_active_rows,
+            name: sage_intacct_sweden}, {axisId: connector_costs.paid_active_rows,
+            id: sage_intacct_taiwan - connector_costs.paid_active_rows, name: sage_intacct_taiwan},
+          {axisId: connector_costs.paid_active_rows, id: sage_intacct_uk - connector_costs.paid_active_rows,
+            name: sage_intacct_uk}, {axisId: connector_costs.paid_active_rows, id: seznam
+              - connector_costs.paid_active_rows, name: seznam}, {axisId: connector_costs.paid_active_rows,
+            id: stripe - connector_costs.paid_active_rows, name: stripe}, {axisId: connector_costs.paid_active_rows,
+            id: stripe_dev_relud - connector_costs.paid_active_rows, name: stripe_dev_relud},
+          {axisId: connector_costs.paid_active_rows, id: stripe_nonprod - connector_costs.paid_active_rows,
+            name: stripe_nonprod}, {axisId: connector_costs.paid_active_rows, id: test_test_test_leli
+              - connector_costs.paid_active_rows, name: test_test_test_leli}, {axisId: connector_costs.paid_active_rows,
+            id: test_test_test_leli.test_merged - connector_costs.paid_active_rows,
+            name: test_test_test_leli.test_merged}, {axisId: connector_costs.paid_active_rows,
+            id: united - connector_costs.paid_active_rows, name: united}, {axisId: connector_costs.paid_active_rows,
+            id: workday - connector_costs.paid_active_rows, name: workday}, {axisId: connector_costs.paid_active_rows,
+            id: workday_hcm - connector_costs.paid_active_rows, name: workday_hcm},
+          {axisId: connector_costs.paid_active_rows, id: workday_raas.employee_details_report
+              - connector_costs.paid_active_rows, name: workday_raas.employee_details_report},
+          {axisId: connector_costs.paid_active_rows, id: workday_raas.open_position_details_report
+              - connector_costs.paid_active_rows, name: workday_raas.open_position_details_report},
+          {axisId: connector_costs.paid_active_rows, id: workday_raas.promotions_in_date_range_report
+              - connector_costs.paid_active_rows, name: workday_raas.promotions_in_date_range_report},
+          {axisId: connector_costs.paid_active_rows, id: workday_raas.total_staffing_report
+              - connector_costs.paid_active_rows, name: workday_raas.total_staffing_report},
+          {axisId: connector_costs.paid_active_rows, id: zendesk - connector_costs.paid_active_rows,
+            name: zendesk}], showLabels: true, showValues: true, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}]
+    x_axis_zoom: true
+    y_axis_zoom: true
+    hide_legend: false
+    swap_axes: false
+    defaults_version: 1
+    hidden_pivots: {}
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    listen:
+      Project: connector_costs.destination
+      Connector: connector_costs.connector
+      Billing Type: connector_costs.billing_type
+    row: 45
+    col: 0
+    width: 24
+    height: 8
   filters:
   - name: Project
     title: Project


### PR DESCRIPTION
…or / connector group over time

This PR adds a goal line to the cost overview and adds two new looks to the dashboard showing the monthly active rows per connector and connector group to help see expensive connectors more easily

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
