### PR TITLE
feat(DENG-717): updated the fxa_flow_aggregates view to use the new fxa_flows_v1 table

### DIFF
--- a/firefox_accounts/views/fxa_flow_aggregates.view.lkml
+++ b/firefox_accounts/views/fxa_flow_aggregates.view.lkml
@@ -6,83 +6,45 @@ view: fxa_flow_aggregates {
     interval_trigger: "24 hours"
     increment_key: "flow_start_date"
     increment_offset: 2
-    sql: WITH
-          flow_ids AS (
-              SELECT
-                  flow_id,
-                  ANY_VALUE(entrypoint) AS entrypoint,
-                  ANY_VALUE(utm_source) AS utm_source,
-                  ANY_VALUE(utm_medium) AS utm_medium,
-                  ANY_VALUE(utm_term) AS utm_term,
-                  ANY_VALUE(utm_campaign) AS utm_campaign,
-                  ANY_VALUE(country) AS country,
-                  ANY_VALUE(ua_browser) AS browser_name,
-                  ANY_VALUE(ua_version) AS browser_version,
-                  ANY_VALUE(os_name) AS os_name,
-                  MIN(DATE(timestamp)) AS flow_start_date,
-              FROM firefox_accounts.fxa_all_events
-              WHERE DATE(timestamp) >= DATE(2022,9,1)
-              AND event_type = 'fxa_email_first - view'
-              AND fxa_log IN ('content', 'auth', 'oauth')
-              GROUP BY 1
-          ),
+    sql: WITH unnested_base AS (
+      SELECT *
+      FROM firefox_accounts.fxa_flows_v1,
+      UNNEST(flow_events) AS flow_event
+    )
 
-      flow_agg AS (
-        SELECT
-          f.flow_id,
-          f.entrypoint,
-          f.utm_source,
-          f.utm_medium,
-          f.utm_term,
-          f.utm_campaign,
-          f.country,
-          f.browser_name,
-          f.browser_version,
-          f.os_name,
-          TIMESTAMP(f.flow_start_date) AS flow_start_date,
-          e.event_type,
-          COUNT(*) as n_events
-        FROM flow_ids f
-        LEFT JOIN firefox_accounts.fxa_all_events e
-        USING(flow_id)
-        WHERE DATE(e.timestamp) >= DATE(2022,9,1)
-        AND e.fxa_log IN ('content', 'auth', 'oauth')
-      GROUP BY
-          f.flow_id,
-          f.entrypoint,
-          f.utm_source,
-          f.utm_medium,
-          f.utm_term,
-          f.utm_campaign,
-          f.country,
-          f.browser_name,
-          f.browser_version,
-          f.os_name,
-          f.flow_start_date,
-          e.event_type
-      )
-
-      SELECT
-        flow_start_date,
-        entrypoint,
-        utm_source,
-        utm_medium,
-        utm_term,
-        utm_campaign,
-        country,
-        browser_name,
-        browser_version,
-        os_name,
-        COUNT(DISTINCT flow_id) AS total_flows_started,
-        COUNTIF(event_type = 'fxa_email_first - submit') AS emails_submitted,
-        COUNTIF(event_type = 'fxa_email_first - engage') AS emails_engaged,
-        COUNTIF(event_type = 'fxa_reg - view') AS registrations_started,
-        COUNTIF(event_type = 'fxa_login - view') AS logins_started,
-        COUNTIF(event_type = 'fxa_reg - complete') AS registrations_complete,
-        COUNTIF(event_type = 'fxa_login - complete') AS logins_complete,
-      FROM flow_agg
-      WHERE {% incrementcondition %} flow_start_date {% endincrementcondition %}
-      GROUP BY 1,2,3,4,5,6,7,8,9,10;;
+    SELECT
+      flow_start_date,
+      entrypoint,
+      utm_source,
+      utm_medium,
+      utm_term,
+      utm_campaign,
+      country,
+      browser_name,
+      browser_version,
+      os_name,
+      COUNT(DISTINCT flow_id) AS total_flows_started,
+      COUNTIF(
+        flow_event.category = 'fxa_email_first' AND flow_event.`event` = 'submit'
+      ) AS emails_submitted,
+      COUNTIF(
+        flow_event.category = 'fxa_email_first' AND flow_event.`event` = 'engage'
+      ) AS emails_engaged,
+      COUNTIF(
+        flow_event.category = 'fxa_reg' AND flow_event.`event` = 'view'
+      ) AS registrations_started,
+      COUNTIF(
+        flow_event.category = 'fxa_reg' AND flow_event.`event` = 'complete'
+      ) AS registrations_complete,
+      COUNTIF(
+        flow_event.category = 'fxa_login' AND flow_event.`event` = 'view'
+      ) AS logins_started,
+      COUNTIF(
+        flow_event.category = 'fxa_login' AND flow_event.`event` = 'complete'
+      ) AS logins_complete,
+    FROM unnested_base
+    WHERE {% incrementcondition %} flow_start_date {% endincrementcondition %}
+    GROUP BY 1,2,3,4,5,6,7,8,9,10;;
   }
   dimension_group: flow_start {
     type: time


### PR DESCRIPTION
feat(DENG-717): updated the fxa_flow_aggregates view to use the new fxa_flows_v1 table

The core transformation logic has been moved to bqetl query `fxa_flows_v1`, see PR: https://github.com/mozilla/bigquery-etl/pull/3699

This change updated the fxa_flow_aggregate Looker view to use this new table and only perform simple counting and aggregatations.


depends on: https://github.com/mozilla/bigquery-etl/pull/3699

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
