### PR TITLE
fixing CVR calcuation from product page vist to subscription complete 

### DIFF
--- a/mozilla_vpn/views/funnel_product_page_to_subscribed_table.view.lkml
+++ b/mozilla_vpn/views/funnel_product_page_to_subscribed_table.view.lkml
@@ -34,19 +34,19 @@ view: +funnel_product_page_to_subscribed_table {
   measure: CTR_from_product_page_visit_to_entering_subscription_flow {
     type: number
     sql: CASE WHEN SUM(${TABLE}.vpn_site_hits)= 0 then 0
-            ELSE round(cast(SUM(${TABLE}.total_acquisition_process_start)/SUM(${TABLE}.vpn_site_hits) *100 AS Float64))
+            ELSE round(cast(SUM(${TABLE}.total_acquisition_process_start)/SUM(${TABLE}.vpn_site_hits) *100 AS Float64),1)
             END;;
   }
   measure:CVR_from_product_page_visit_to_payment_complete {
-    type: average
-    sql:CASE WHEN ${TABLE}.vpn_site_hits = 0 then 0
-            ELSE round(cast(${TABLE}.total_payment_setup_complete/${TABLE}.vpn_site_hits *100 AS Float64))
+    type: number
+    sql:CASE WHEN SUM(${TABLE}.vpn_site_hits) = 0 then 0
+            ELSE round(cast(SUM(${TABLE}.total_payment_setup_complete)/SUM(${TABLE}.vpn_site_hits) *100 AS Float64),1)
             END;;
   }
   measure: CVR_from_payment_page_visit_to_payment_complete {
     type: number
     sql:CASE WHEN SUM(${TABLE}.total_acquisition_process_start)= 0 then 0
-      ELSE round(cast(SUM(${TABLE}.total_payment_setup_complete)/SUM(${TABLE}.total_acquisition_process_start) *100 AS Float64))
+      ELSE round(cast(SUM(${TABLE}.total_payment_setup_complete)/SUM(${TABLE}.total_acquisition_process_start) *100 AS Float64),1)
       END;;
   }
   #FxA signed in
@@ -75,7 +75,7 @@ view: +funnel_product_page_to_subscribed_table {
   measure: signed_in_fxa_CVR {
     type: number
     sql:CASE WHEN SUM(${TABLE}.existing_fxa_signedin_payment_setup_view) = 0 then 0
-      ELSE round(cast(SUM(${TABLE}.existing_fxa_signedin_payment_setup_complete)/SUM(${TABLE}.existing_fxa_signedin_payment_setup_view) *100 AS Float64))
+      ELSE round(cast(SUM(${TABLE}.existing_fxa_signedin_payment_setup_complete)/SUM(${TABLE}.existing_fxa_signedin_payment_setup_view) *100 AS Float64),1)
       END;;
   }
 
@@ -111,7 +111,7 @@ view: +funnel_product_page_to_subscribed_table {
   measure: signed_out_fxa_CVR {
     type: number
     sql:CASE WHEN SUM(${TABLE}.existing_fxa_signedoff_signin_cta_click) = 0 then 0
-        ELSE round(cast(SUM(${TABLE}.existing_fxa_signedoff_payment_setup_complete)/SUM(${TABLE}.existing_fxa_signedoff_signin_cta_click) *100 AS Float64))
+        ELSE round(cast(SUM(${TABLE}.existing_fxa_signedoff_payment_setup_complete)/SUM(${TABLE}.existing_fxa_signedoff_signin_cta_click) *100 AS Float64),1)
         END;;
   }
 #new fxa users
@@ -139,7 +139,7 @@ view: +funnel_product_page_to_subscribed_table {
   measure: new_fxa_CVR {
     type: number
     sql: CASE WHEN SUM(${TABLE}.new_fxa_user_input_emails) = 0 then 0
-            ELSE round(cast(SUM(${TABLE}.new_fxa_payment_setup_complete)/SUM(${TABLE}.new_fxa_user_input_emails) *100 AS Float64))
+            ELSE round(cast(SUM(${TABLE}.new_fxa_payment_setup_complete)/SUM(${TABLE}.new_fxa_user_input_emails) *100 AS Float64),1)
             END;;
   }
   #Coupon activities


### PR DESCRIPTION
+ adjusting rounding rule for CVR calculations 

This is on changing the view file. 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
