### PR TITLE
Include Ad Group & Google Ads metrics in explore

### DIFF
--- a/duet/views/google_uac_android_activation.view.lkml
+++ b/duet/views/google_uac_android_activation.view.lkml
@@ -4,10 +4,13 @@ view: google_uac_android_activation {
     sql: WITH uac AS (
          SELECT
            date,
-           campaign_name as campaign,
-           spend as cost
+           REGEXP_REPLACE(campaign_name, '(.*) - NULL', '\\1') as campaign,
+           ad_group_name as ad_group,
+           spend as cost,
+           clicks,
+           impressions,
          FROM
-           mozdata.google_ads.daily_campaign_stats
+           mozdata.google_ads.daily_ad_group_stats
          WHERE
             campaign_name NOT LIKE '%iOS%'
             AND date >= '2022-12-01'
@@ -15,6 +18,7 @@ view: google_uac_android_activation {
          SELECT
            first_seen_date as date,
            REGEXP_REPLACE(adjust_campaign, '([\\w]+).*', '\\1') as campaign,
+           adjust_adgroup as ad_group,
            SUM(activated) as activated,
            COUNT(*) as new_profiles,
          FROM `moz-fx-data-shared-prod.fenix.new_profile_activation`
@@ -25,11 +29,13 @@ view: google_uac_android_activation {
            AND adjust_campaign LIKE 'Mozilla_%'
          GROUP BY
            date,
-           campaign
+           campaign,
+           ad_group
         )
         SELECT
           date,
           campaign,
+          ad_group,
           CASE WHEN campaign LIKE '%_US_%' OR campaign LIKE '%_CA_%' OR campaign LIKE '%NA%' THEN 'NA'
                WHEN campaign LIKE '%MGFQ3%' THEN 'Expansion'
                ELSE 'EU' END AS region,
@@ -37,15 +43,18 @@ view: google_uac_android_activation {
           REGEXP_EXTRACT(campaign, '.*(Group\\d).*') as group_number,
           REGEXP_EXTRACT(campaign, 'Mozilla_FF_UAC_[\\w]{2,5}_([\\w]{2})_[\\w]{2}_.*') AS campaign_country_code,
           REGEXP_EXTRACT(campaign, 'Mozilla_FF_UAC_[\\w]{2,5}_[\\w]{2}_([\\w]{2})_.*') AS campaign_language,
+          SUM(impressions) AS impressions,
+          SUM(clicks) AS clicks,
           SUM(new_profiles) as new_profiles,
           SUM(activated) as activated,
           SUM(cost) as cost
         FROM uac
-        LEFT JOIN activation USING (date, campaign)
+        LEFT JOIN activation USING (date, campaign, ad_group)
         WHERE date < DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY)
         GROUP BY
           date,
-          campaign
+          campaign,
+          ad_group
     ;;
   }
 
@@ -85,6 +94,12 @@ view: google_uac_android_activation {
     sql: ${TABLE}.campaign ;;
   }
 
+  dimension: ad_group {
+    description: "Ad Group - A campaign can contain multiple Ad Groups."
+    type:  string
+    sql: ${TABLE}.ad_group ;;
+  }
+
   dimension_group: campaign_date {
     description: "Date of campaign spend"
     type: time
@@ -92,6 +107,18 @@ view: google_uac_android_activation {
     timeframes: [date, week, month, year]
     sql: ${TABLE}.date ;;
     convert_tz: no
+  }
+
+  measure: ad_impressions {
+    description: "Ad Impressions - The number of impressions of ads, reported by Google Ads"
+    type: sum
+    sql: ${TABLE}.impressions ;;
+  }
+
+  measure: clicks {
+    description: "Clicks - The number of clicks on our ads, reported by Google Ads"
+    type: sum
+    sql: ${TABLE}.clicks ;;
   }
 
   measure: new_profiles {
@@ -131,6 +158,12 @@ view: google_uac_android_activation {
     type: number
     value_format_name: usd
     sql: ${cost}/ NULLIF(${activated},0) ;;
+  }
+
+  measure: cost_per_new_profile {
+    type: number
+    value_format_name: usd
+    sql: ${cost}/ NULLIF(${new_profiles},0) ;;
   }
 
 }


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
