### PR TITLE
Add App Store Data Explore

### DIFF
--- a/duet/duet.model.lkml
+++ b/duet/duet.model.lkml
@@ -30,3 +30,7 @@ explore: kpi_downloads {
 explore: kpi_installs{
   sql_always_where: ${period_filtered_measures} in ("this", "last");;
 }
+
+explore: app_store_territory_source_type_report {
+  label: "App Store Data Report"
+}

--- a/duet/views/app_store_territory_source_type_report.view.lkml
+++ b/duet/views/app_store_territory_source_type_report.view.lkml
@@ -1,0 +1,139 @@
+view: app_store_territory_source_type_report {
+  derived_table: {
+    sql:
+      SELECT
+        date,
+        territory,
+        source_type,
+        active_devices,
+        active_devices_last_30_days,
+        deletions,
+        installations,
+        sessions,
+        first_time_downloads,
+        redownloads,
+        total_downloads,
+        impressions,
+        impressions_unique_device,
+        page_views,
+        page_views_unique_device
+      FROM
+        mozdata.app_store.firefox_app_store_territory_source_type_report
+      FULL OUTER JOIN
+        mozdata.app_store.firefox_downloads_territory_source_type_report
+        USING (date, territory, source_type)
+      FULL OUTER JOIN
+        mozdata.app_store.firefox_usage_territory_source_type_report
+        USING (date, territory, source_type) ;;
+  }
+
+  dimension_group: date {
+    type: time
+    sql: ${TABLE}.date ;;
+    timeframes: [
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+    description: "The date that the associated events took place on."
+  }
+
+  dimension: country {
+    type: string
+    sql: ${TABLE}.territory ;;
+    description: "The country the events took place in."
+  }
+
+  dimension: source_type {
+    type: string
+    sql: ${TABLE}.source_type ;;
+    description: "The source type of the install, i.e. how the user ended up on the app landing page. Examples include 'App Store Search' and 'Web Referrer'."
+  }
+
+  measure: active_devices {
+    group_label: "App Metrics"
+    type: sum
+    sql: ${TABLE}.active_devices ;;
+    description: "WARNING: Opt-in only. The number of devices with at least one session during the selected period."
+  }
+
+  measure: active_devices_last_30_days {
+    group_label: "App Metrics"
+    type: sum
+    sql: ${TABLE}.active_devices_last_30_days ;;
+    description: "WARNING: Opt-in only. The number of active devices with at least one session during the previous 30 days."
+  }
+
+  measure: deletions {
+    group_label: "App Metrics"
+    type: sum
+    sql: ${TABLE}.deletions ;;
+    description: "WARNING: Opt-in only. The number of times Firefox was deleted on devices running iOS 12.3 or later."
+  }
+
+  measure: installations {
+    group_label: "App Metrics"
+    type: sum
+    sql: ${TABLE}.installations ;;
+    description: "WARNING: Opt-in only. The total number of times Firefox has been installed on devices with iOS 8 or later. Re-installs are included."
+  }
+
+  measure: sessions {
+    group_label: "App Metrics"
+    type: sum
+    sql: ${TABLE}.sessions ;;
+    description: "WARNING: Opt-in only. The number of times Firefox has been used for at least two seconds"
+  }
+
+  measure: first_time_downloads {
+    group_label: "Download Metrics"
+    type: sum
+    sql: ${TABLE}.first_time_downloads ;;
+    description: "The total number of first time downloads."
+  }
+
+  measure: redownloads {
+    group_label: "Download Metrics"
+    type: sum
+    sql: ${TABLE}.redownloads ;;
+    description: "The total number of redownloads."
+  }
+
+  measure: total_downloads {
+    group_label: "Download Metrics"
+    type: sum
+    sql: ${TABLE}.total_downloads ;;
+    description: "The total number of Firefox downloads, including first time & redownloads."
+  }
+
+  measure: impressions {
+    group_label: "App Store Listing Metrics"
+    type: sum
+    sql: ${TABLE}.impressions ;;
+    description: "The number of times the app listing was viewed on the Today, Games, Apps, and Search tabs of the App Store. Includes Product Page Views."
+  }
+
+  measure: impressions_unique_device {
+    group_label: "App Store Listing Metrics"
+    type: sum
+    sql: ${TABLE}.impressions_unique_device ;;
+    description: "The number of unique devices that have viewed the app on the Today, Games, Apps, and Search tabs of the App Store. Includes Unique Product Page views."
+  }
+
+  measure: page_views {
+    group_label: "App Store Listing Metrics"
+    type: sum
+    sql: ${TABLE}.page_views ;;
+    description: "The total number of times the App Store product page was viewed."
+  }
+
+  measure: page_views_unique_device {
+    group_label: "App Store Listing Metrics"
+    type: sum
+    sql: ${TABLE}.page_views_unique_device ;;
+    description: "The number of unique devices that have viewed your App Store product page."
+  }
+
+}

--- a/duet/views/app_store_territory_source_type_report.view.lkml
+++ b/duet/views/app_store_territory_source_type_report.view.lkml
@@ -133,7 +133,7 @@ view: app_store_territory_source_type_report {
     group_label: "App Store Listing Metrics"
     type: sum
     sql: ${TABLE}.page_views_unique_device ;;
-    description: "The number of unique devices that have viewed your App Store product page."
+    description: "The number of unique devices that have viewed the App Store product page."
   }
 
 }


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
