### PR TITLE
Betling history sidebar lookml file update

### DIFF
--- a/firefox_desktop/views/history_sidebar_clients_daily.view.lkml
+++ b/firefox_desktop/views/history_sidebar_clients_daily.view.lkml
@@ -189,4 +189,159 @@ view: history_sidebar_clients_daily {
     group_label: "Client shares"
   }
 
+#new measures
+
+  measure: history_visits_all_surfaces_mean {
+    type: average
+    sql: ${TABLE}.places_previousday_visits_mean ;;
+    description: "Average history items visited per day across all surfaces"
+  }
+
+  measure: history_library_items {
+    type: sum
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_library_link_sum, "history");;
+    description: "The number of history items opened from the Library window"
+  }
+
+  measure: bookmarks_library_items {
+    type: sum
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_library_link_sum, "bookmarks");;
+    description: "The number of bookmark items opened from the Library window"
+  }
+
+  measure: history_library_opened {
+    type: sum
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_library_opened_sum, "history");;
+    description: "The number of times the history Library window was opened"
+  }
+
+  measure: bookmarks_library_opened {
+    type: sum
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_library_opened_sum, "bookmarks");;
+    description: "The number of times the bookmarks Library window was opened"
+  }
+
+  measure: history_library_search {
+    type: sum
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_library_search_sum, "history");;
+    description: "The number of history-specific searches made from the Library window"
+  }
+
+  measure: bookmarks_library_search {
+    type: sum
+    sql: mozfun.map.get_key(${TABLE}.scalar_parent_library_search_sum, "bookmarks");;
+    description: "The number of bookmarks-specific searches made from the Library window"
+  }
+
+  measure: history_cumulative_library_searches {
+    sql: ${TABLE}.places_library_cumulative_history_searches_sum ;;
+    type: sum
+    description: "Cumulative number of history-specific searches performed before selecting a history link in the Library window"
+  }
+
+  measure: bookmarks_searchbar_cumulative_searches {
+    sql: ${TABLE}.places_bookmarks_searchbar_cumulative_searches_sum ;;
+    type: sum
+    description: "Cumulative number of bookmark searches performed before selecting a link"
+  }
+
+  measure: bookmarks_library_cumulative_searches {
+    sql: ${TABLE}.places_library_cumulative_bookmark_searches_sum ;;
+    type: sum
+    description:"Cumulative number of bookmark-specific searches performed before selecting a bookmark link in the Library window"
+  }
+
+  #new client counts
+
+  measure:  clients_with_any_history_items {
+    type: count_distinct
+    sql: IF(mozfun.map.get_key(${TABLE}.scalar_parent_library_link_sum, "history") > 0, ${client_id}, NULL) ;;
+    approximate: yes
+    description: "Count of clients that open history items from the Library window"
+    group_label: "Client counts"
+  }
+
+  measure:  clients_with_any_bookmarks_items {
+    type: count_distinct
+    sql: IF(mozfun.map.get_key(${TABLE}.scalar_parent_library_link_sum, "bookmarks") > 0, ${client_id}, NULL) ;;
+    approximate: yes
+    description: "Count of clients that open bookmark items from the Library window"
+    group_label: "Client counts"
+  }
+  measure:  clients_with_any_history_library_opened {
+    type: count_distinct
+    sql: IF(mozfun.map.get_key(${TABLE}.scalar_parent_library_opened_sum, "history") > 0, ${client_id}, NULL) ;;
+    approximate: yes
+    description: "Count of clients that open history Library window"
+    group_label: "Client counts"
+  }
+
+  measure:  clients_with_any_bookmarks_library_opened {
+    type: count_distinct
+    sql: IF(mozfun.map.get_key(${TABLE}.scalar_parent_library_opened_sum, "bookmarks") > 0, ${client_id}, NULL) ;;
+    approximate: yes
+    description: "Count of clients that open bookmarks Library window"
+    group_label: "Client counts"
+  }
+
+  measure:  clients_with_any_history_library_searches {
+    type: count_distinct
+    sql: IF(mozfun.map.get_key(${TABLE}.scalar_parent_library_search_sum, "history") > 0, ${client_id}, NULL) ;;
+    approximate: yes
+    description: "Count of clients with history-specific searches from the Library window"
+    group_label: "Client counts"
+  }
+
+  measure:  clients_with_any_bookmarks_library_searches {
+    type: count_distinct
+    sql: IF(mozfun.map.get_key(${TABLE}.scalar_parent_library_search_sum, "bookmarks") > 0, ${client_id}, NULL) ;;
+    approximate: yes
+    description: "Count of clients with bookmark-specific searches from the Library window"
+    group_label: "Client counts"
+  }
+
+  #New client share measures
+
+  measure: history_library_items_client_share {
+    type: number
+    sql: 100.0 * ${clients_with_any_history_items}/${client_count} ;;
+    description: "Percent of clients that open history items from the Library window"
+    group_label: "Client shares"
+  }
+
+  measure: bookmarks_library_items_client_share {
+    type: number
+    sql: 100.0 * ${clients_with_any_bookmarks_items}/${client_count} ;;
+    description: "Percent of clients that open bookmarks items from the Library window"
+    group_label: "Client shares"
+  }
+
+  measure: history_library_opened_client_share {
+    type: number
+    sql: 100.0 * ${clients_with_any_history_library_opened}/${client_count} ;;
+    description: "Percent of clients that open history Library window"
+    group_label: "Client shares"
+  }
+
+  measure: bookmarks_library_opened_client_share {
+    type: number
+    sql: 100.0 * ${clients_with_any_bookmarks_library_opened}/${client_count} ;;
+    description: "Percent of clients that open bookmarks Library window"
+    group_label: "Client shares"
+  }
+
+  measure: history_library_search_client_share {
+    type: number
+    sql: 100.0 * ${clients_with_any_history_library_searches}/${client_count} ;;
+    description: "Percent of clients with history-specific searches made from the Library window"
+    group_label: "Client shares"
+  }
+
+  measure: bookmarks_library_search_client_share {
+    type: number
+    sql: 100.0 * ${clients_with_any_bookmarks_library_searches}/${client_count} ;;
+    description: "Percent of clients with bookmarks-specific searches made from the Library window"
+    group_label: "Client shares"
+  }
+
 }


### PR DESCRIPTION
@m-d-bowerman can you review the metrics that were added in the lookml file.  I think I need to merge this PR before others without developer access will be able to view the updated dashboard.  Thanks.  

This is for work on this jira ticket: https://mozilla-hub.atlassian.net/browse/DS-2879

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
