### PR TITLE
Update iOS Funnel view to use table from BigQuery ETL

### DIFF
--- a/duet/explores/funnel_ios.explore.lkml
+++ b/duet/explores/funnel_ios.explore.lkml
@@ -4,12 +4,12 @@ include: "/shared/views/*"
 explore: funnel_ios {
   label: "Firefox iOS Funnel"
   description: "Firefox iOS metrics for the Mobile Funnel"
-  view_name: funnel_ios
+  view_name: app_store_funnel_table
 
   join: countries {
     type: left_outer
     relationship: one_to_one
-    sql_on: ${funnel_ios.country} = ${countries.code} ;;
+    sql_on: ${app_store_funnel_table.country} = ${countries.code} ;;
   }
 
 }

--- a/duet/views/funnel_ios.view.lkml
+++ b/duet/views/funnel_ios.view.lkml
@@ -1,86 +1,74 @@
-view: funnel_ios {
+include: "//looker-hub/firefox_ios/views/app_store_funnel_table.view.lkml"
 
-  derived_table: {
-    sql: WITH views_data AS (
-          SELECT
-            date,
-            territory AS country_name,
-            SUM(impressions_unique_device) AS views
-          FROM
-            `mozdata.analysis.firefox_app_store_territory_source_type_report`
-          WHERE
-            date >= '2022-01-01'
-          GROUP BY 1, 2
-        ), downloads_data AS (
-          SELECT
-            date,
-            territory AS country_name,
-            SUM(total_downloads) AS downloads
-          FROM
-            `mozdata.analysis.firefox_app_store_downloads_territory_source_type_report`
-          WHERE
-            date >= '2022-01-01'
-            AND source_type <> 'Institutional Purchase'
-          GROUP BY 1, 2
-        ), top AS (
-          SELECT
-            DATE(date) as date,
-            code AS country,
-            views,
-            downloads
-          FROM views_data
-          JOIN downloads_data USING (date, country_name)
-          JOIN `moz-fx-data-shared-prod.static.country_codes_v1` ON country_name = name
-        ), bottom AS (
-          SELECT
-            first_seen_date AS date,
-            country,
-            SUM(new_profile) as new_profiles,
-            SUM(activated) as activations
-          FROM `moz-fx-data-shared-prod.firefox_ios.new_profile_activation`
-          WHERE submission_date >= '2022-01-01'
-          AND first_seen_date >= '2022-01-01'
-          AND NOT (app_display_version = '107.2' AND submission_date >= '2023-02-01') -- incident filter
-          GROUP BY 1, 2
-        )
-        SELECT date, country, views, downloads, new_profiles, activations
-        FROM top
-        JOIN bottom USING (date, country)
-;;
+view: +app_store_funnel_table {
+
+  dimension: views {
+    hidden: yes
+    sql: ${TABLE}.views ;;
   }
 
-  dimension: country {
-    type: string
-    sql: ${TABLE}.country ;;
-  }
-
-  dimension_group: date {
-    type: time
-    datatype: date
-    timeframes: [date, week, month, year]
-    sql: ${TABLE}.date ;;
-    convert_tz: no
-  }
-
-  measure: views {
+  measure: views_sum {
+    label: "Views"
     description: "Unique daily impressions, counted when a customer views the app on the Today, Games, Apps, or Search tabs on the App Store, or on the product page"
     type: sum
     sql: ${TABLE}.views ;;
   }
 
-  measure: downloads {
-    description: "Total downloads, including first-time downloads and redownloads"
-    type: sum
-    sql: ${TABLE}.downloads ;;
+  dimension: total_downloads {
+    hidden: yes
+    sql: ${TABLE}.total_downloads ;;
   }
 
-  measure: new_profiles {
+  measure: total_downloads_sum {
+    label: "Total downloads"
+    description: "Total downloads, including first-time downloads and redownloads"
+    type: sum
+    sql: ${TABLE}.total_downloads ;;
+  }
+
+  dimension: first_time_downloads {
+    hidden: yes
+    sql: ${TABLE}.first_time_downloads ;;
+  }
+
+  measure: first_time_downloads_sum {
+    label: "First-time downloads"
+    description: "First-time downloads"
+    type: sum
+    sql: ${TABLE}.first_time_downloads ;;
+  }
+
+  dimension: redownloads {
+    hidden: yes
+    sql: ${TABLE}.redownloads ;;
+  }
+
+  measure: redownloads_sum {
+    label: "Redownloads"
+    description: "Redownloads"
+    type: sum
+    sql: ${TABLE}.redownloads ;;
+  }
+
+  dimension: new_profiles {
+    hidden: yes
+    sql: ${TABLE}.new_profiles ;;
+  }
+
+  measure: new_profiles_sum {
+    label: "New Profiles"
     description: "Unique Client IDs, usually generated when the app is opened for the first time"
     type: sum
     sql: ${TABLE}.new_profiles ;;
   }
 
-  measure: activations {
+  dimension: activations {
+    hidden: yes
+    sql: ${TABLE}.activations ;;
+  }
+
+  measure: activations_sum {
+    label: "Activations"
     description: "Early indicator for LTV based on days of app open and searches on the first week"
     type: sum
     sql: ${TABLE}.activations ;;
@@ -90,14 +78,14 @@ view: funnel_ios {
     label: "View Click Through Rate"
     type: number
     value_format_name: percent_2
-    sql: ${downloads}/ NULLIF(${views},0) ;;
+    sql: ${total_downloads_sum}/ NULLIF(${views_sum},0) ;;
   }
 
   measure: activation_rate {
     label: "Activation Rate"
     type: number
     value_format_name: percent_2
-    sql: ${activations}/ NULLIF(${new_profiles},0) ;;
+    sql: ${activations_sum}/ NULLIF(${new_profiles_sum},0) ;;
   }
 
 }


### PR DESCRIPTION
Use table from https://github.com/mozilla/bigquery-etl/pull/4083 by extending the view from Looker Hub.


Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
