### PR TITLE
[TEMP] Comment out increment keys to force rebuild

### DIFF
--- a/firefox_desktop/explores/crashes.explore.lkml
+++ b/firefox_desktop/explores/crashes.explore.lkml
@@ -81,7 +81,7 @@ explore: crash_usage {
     }
     materialization: {
       datagroup_trigger: clients_daily_joined_partitions
-      increment_key: "submission_date"
+      #increment_key: "submission_date"
     }
   }
 
@@ -163,7 +163,7 @@ explore: crash_usage {
     }
     materialization: {
       datagroup_trigger: clients_daily_joined_partitions
-      increment_key: "submission_date"
+      #increment_key: "submission_date"
     }
   }
 
@@ -244,7 +244,7 @@ explore: crash_usage {
     }
     materialization: {
       datagroup_trigger: clients_daily_joined_partitions
-      increment_key: "submission_date"
+      #increment_key: "submission_date"
     }
   }
 


### PR DESCRIPTION
There is no way to rebuild incremental PDTs in Looker. Instead we have to drop the increment, rebuild the PDT, then re-enable, at which point it will rebuild the incremental PDT.