### PR TITLE
Take just numeric version numbers from buildhub

### DIFF
--- a/firefox_desktop/views/crash_usage.view.lkml
+++ b/firefox_desktop/views/crash_usage.view.lkml
@@ -494,14 +494,14 @@ view: buildhub {
   derived_table: {
     sql:
       SELECT
-          build.target.version,
+          REGEXP_EXTRACT(build.target.version, r"(^\d+\.\d+(?:\.\d+)?)") AS version,
           build.target.channel,
           MIN(build.download.date) AS publish_date,
       FROM
           mozdata.telemetry.buildhub2
       GROUP BY
-          build.target.version,
-          build.target.channel
+          version,
+          channel
     ;;
   }
 


### PR DESCRIPTION
Recent builds in BuildHub often have a letter and number attached to the version to represent the build increments (e.g. `118.0.0b1` and `118.0.0b2` for two consecutive beta builds without a patch version increment). However the last part of these version numbers are not represented in telemetry, for each of these telemetry only reports `118.0.0`, with the channel as `beta`.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
