### PR TITLE
Added measures

### DIFF
--- a/firefox_ios/views/app_store_funnel_table.view.lkml
+++ b/firefox_ios/views/app_store_funnel_table.view.lkml
@@ -2,6 +2,41 @@ include: "//looker-hub/firefox_ios/views/app_store_funnel_table.view.lkml"
 
 view: +app_store_funnel_table {
 
+  measure: views_sum {
+    description: "Unique daily impressions, counted when a customer views the app on the Today, Games, Apps, or Search tabs on the App Store, or on the product page"
+    type: sum
+    sql: ${TABLE}.views ;;
+  }
+
+  measure: redownloads_sum {
+    description: "Redownloads"
+    type: sum
+    sql: ${TABLE}.redownloads ;;
+  }
+  measure: first_time_downloads_sum {
+    description: "first-time downloads"
+    type: sum
+    sql: ${TABLE}.first_time_downloads ;;
+  }
+
+  measure: downloads_sum {
+    description: "Total downloads, including first-time downloads and redownloads"
+    type: sum
+    sql: ${TABLE}.total_downloads ;;
+  }
+
+  measure: new_profiles_sum {
+    description: "Unique Client IDs, usually generated when the app is opened for the first time"
+    type: sum
+    sql: ${TABLE}.new_profiles ;;
+  }
+
+  measure: activations_sum {
+    description: "Early indicator for LTV based on days of app open and searches on the first week"
+    type: sum
+    sql: ${TABLE}.activations ;;
+  }
+
   measure: view_ctr {
     label: "View Click Through Rate"
     type: number


### PR DESCRIPTION
Checklist for reviewer:

Created measures on the dimensions that were supposed to be measures in the lookerhub view

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
