### PR TITLE
Limit fields included in logical subscription explores' "Current Subscriptions" joins (DS-3082)

### DIFF
--- a/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
@@ -11,9 +11,9 @@ explore: daily_active_logical_subscriptions {
     relationship: many_to_one
   }
 
-  join: current_subscriptions {
+  join: current_subscription_state {
     from: logical_subscriptions
-    sql_on: ${daily_active_logical_subscriptions.subscription__id} = ${current_subscriptions.id} ;;
+    sql_on: ${daily_active_logical_subscriptions.subscription__id} = ${current_subscription_state.id} ;;
     type: left_outer
     relationship: many_to_one
   }

--- a/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
@@ -16,6 +16,13 @@ explore: daily_active_logical_subscriptions {
     sql_on: ${daily_active_logical_subscriptions.subscription__id} = ${current_subscription_state.id} ;;
     type: left_outer
     relationship: many_to_one
+    fields: [
+      is_trial,
+      is_active,
+      auto_renew,
+      has_refunds,
+      has_fraudulent_charges
+    ]
   }
 
   join: table_metadata {

--- a/subscription_platform/explores/logical_subscription_events.explore.lkml
+++ b/subscription_platform/explores/logical_subscription_events.explore.lkml
@@ -11,9 +11,9 @@ explore: logical_subscription_events {
     relationship: many_to_one
   }
 
-  join: current_subscriptions {
+  join: current_subscription_state {
     from: logical_subscriptions
-    sql_on: ${logical_subscription_events.subscription__id} = ${current_subscriptions.id} ;;
+    sql_on: ${logical_subscription_events.subscription__id} = ${current_subscription_state.id} ;;
     type: left_outer
     relationship: many_to_one
   }

--- a/subscription_platform/explores/logical_subscription_events.explore.lkml
+++ b/subscription_platform/explores/logical_subscription_events.explore.lkml
@@ -16,6 +16,13 @@ explore: logical_subscription_events {
     sql_on: ${logical_subscription_events.subscription__id} = ${current_subscription_state.id} ;;
     type: left_outer
     relationship: many_to_one
+    fields: [
+      is_trial,
+      is_active,
+      auto_renew,
+      has_refunds,
+      has_fraudulent_charges
+    ]
   }
 
   join: table_metadata {

--- a/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
@@ -16,6 +16,13 @@ explore: monthly_active_logical_subscriptions {
     sql_on: ${monthly_active_logical_subscriptions.subscription__id} = ${current_subscription_state.id} ;;
     type: left_outer
     relationship: many_to_one
+    fields: [
+      is_trial,
+      is_active,
+      auto_renew,
+      has_refunds,
+      has_fraudulent_charges
+    ]
   }
 
   join: next_month_still_active_subscriptions {

--- a/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
@@ -11,9 +11,9 @@ explore: monthly_active_logical_subscriptions {
     relationship: many_to_one
   }
 
-  join: current_subscriptions {
+  join: current_subscription_state {
     from: logical_subscriptions
-    sql_on: ${monthly_active_logical_subscriptions.subscription__id} = ${current_subscriptions.id} ;;
+    sql_on: ${monthly_active_logical_subscriptions.subscription__id} = ${current_subscription_state.id} ;;
     type: left_outer
     relationship: many_to_one
   }


### PR DESCRIPTION
## [DS-3082](https://mozilla-hub.atlassian.net/browse/DS-3082): SubPlat logical subscriptions Looker explores

Some of the logical subscriptions explores for historical data include "Current Subscriptions" joins to provide access to the current state of the associated subscriptions (e.g. to see if they have been belatedly flagged as fraudulent). However, that has turned out to be a point of confusion with people using those explores (e.g. accidentally selecting a field from the "Current Subscriptions" join when they meant to select a field from the explore's primary view).

This PR greatly limits the fields included in the "Current Subscriptions" joins, and also renames those joins to "Current Subscription State", to hopefully reduce confusion.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
