### PR TITLE
Dev ruoxi zhao 67sy

### DIFF
--- a/fenix/explores/test_mobile_feature.explore.lkml
+++ b/fenix/explores/test_mobile_feature.explore.lkml
@@ -1,0 +1,7 @@
+include: "../views/test_mobile_feature.view.lkml"
+include: "/shared/views/*"
+
+explore: fenix_test_mobile_feature {
+  label: "test_mobile_feature for Android"
+  view_name: test_mobile_feature
+}

--- a/fenix/fenix.model.lkml
+++ b/fenix/fenix.model.lkml
@@ -12,6 +12,7 @@ explore: +topsites_impression {
 # https://bugzilla.mozilla.org/show_bug.cgi?id=1764332
 
 include: "//looker-hub/fenix/views/metrics.view.lkml"
+include: "/fenix/views/test_mobile_feature.view.lkml"
 
 view: +metrics {
   dimension: metrics__labeled_counter__recent_synced_tabs_recent_synced_tab_opened {

--- a/fenix/views/test_mobile_feature.view.lkml
+++ b/fenix/views/test_mobile_feature.view.lkml
@@ -37,6 +37,9 @@ view: test_mobile_feature {
       select d.submission_date
       -- credit card deleted
       , SAFE_DIVIDE(p.credit_cards_deleted, p.credit_cards_deleted_users) AS credit_cards_deleted_avg
+      , dau
+      , p.credit_cards_deleted
+      , p.currently_stored_credit_cards
       , p.credit_cards_deleted_users
       , 100*SAFE_DIVIDE(p.credit_cards_deleted_users, dau) AS credit_cards_deleted_frac
       -- credit card currently stored
@@ -54,45 +57,40 @@ view: test_mobile_feature {
     sql: ${TABLE}.submission_date ;;
   }
 
-  measure: credit_cards_deleted_avg {
-    type: number
-    sql: ${TABLE}.credit_cards_deleted_avg ;;
+  measure: dau {
+    type: sum
+    sql: ${TABLE}.dau ;;
   }
 
   measure: credit_cards_deleted_users {
-    type: number
+    type: sum
     sql: ${TABLE}.credit_cards_deleted_users ;;
   }
 
-  measure: credit_cards_deleted_frac {
-    type: number
-    sql: ${TABLE}.credit_cards_deleted_frac ;;
-  }
-
-  measure: currently_stored_credit_cards_avg {
-    type: number
-    sql: ${TABLE}.currently_stored_credit_cards_avg ;;
-  }
-
   measure: currently_stored_credit_cards_users {
-    type: number
+    type: sum
     sql: ${TABLE}.currently_stored_credit_cards_users ;;
   }
 
-  measure: currently_stored_credit_cards_frac {
-    type: number
-    sql: ${TABLE}.currently_stored_credit_cards_frac ;;
+  measure: credit_cards_deleted {
+    type: sum
+    sql: ${TABLE}.credit_cards_deleted ;;
   }
+
+  measure: currently_stored_credit_cards {
+    type: sum
+    sql: ${TABLE}.currently_stored_credit_cards ;;
+  }
+
 
   set: detail {
     fields: [
         submission_date,
-  credit_cards_deleted_avg,
+  dau,
   credit_cards_deleted_users,
-  credit_cards_deleted_frac,
-  currently_stored_credit_cards_avg,
   currently_stored_credit_cards_users,
-  currently_stored_credit_cards_frac
+  credit_cards_deleted,
+  currently_stored_credit_cards
     ]
   }
 }

--- a/fenix/views/test_mobile_feature.view.lkml
+++ b/fenix/views/test_mobile_feature.view.lkml
@@ -1,5 +1,5 @@
 
-view: test_mobile_feature_usage {
+view: test_mobile_feature {
   derived_table: {
     sql: WITH dau_segments AS 
           (SELECT submission_date, SUM(DAU) as dau

--- a/fenix/views/test_mobile_feature.view.lkml
+++ b/fenix/views/test_mobile_feature.view.lkml
@@ -1,14 +1,14 @@
 
 view: test_mobile_feature {
   derived_table: {
-    sql: WITH dau_segments AS 
+    sql: WITH dau_segments AS
           (SELECT submission_date, SUM(DAU) as dau
-          FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates` 
+          FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
           WHERE app_name = 'Fenix'
           --AND channel = 'release'
           AND submission_date >= '2022-12-04'
           GROUP BY 1),
-          
+
       product_features AS
       (SELECT
           client_info.client_id,
@@ -19,7 +19,7 @@ view: test_mobile_feature {
       where DATE(submission_timestamp) >= '2022-12-04'
       AND sample_id = 0
       group by 1,2),
-      
+
       product_features_agg AS
       (SELECT
           submission_date,
@@ -32,8 +32,8 @@ view: test_mobile_feature {
           FROM product_features
       where submission_date >= '2022-12-04'
       group by 1)
-          
-          
+
+
       select d.submission_date
       -- credit card deleted
       , SAFE_DIVIDE(p.credit_cards_deleted, p.credit_cards_deleted_users) AS credit_cards_deleted_avg
@@ -48,43 +48,38 @@ view: test_mobile_feature {
       ON d.submission_date = p.submission_date ;;
   }
 
-  measure: count {
-    type: count
-    drill_fields: [detail*]
-  }
-
   dimension: submission_date {
     type: date
     datatype: date
     sql: ${TABLE}.submission_date ;;
   }
 
-  dimension: credit_cards_deleted_avg {
+  measure: credit_cards_deleted_avg {
     type: number
     sql: ${TABLE}.credit_cards_deleted_avg ;;
   }
 
-  dimension: credit_cards_deleted_users {
+  measure: credit_cards_deleted_users {
     type: number
     sql: ${TABLE}.credit_cards_deleted_users ;;
   }
 
-  dimension: credit_cards_deleted_frac {
+  measure: credit_cards_deleted_frac {
     type: number
     sql: ${TABLE}.credit_cards_deleted_frac ;;
   }
 
-  dimension: currently_stored_credit_cards_avg {
+  measure: currently_stored_credit_cards_avg {
     type: number
     sql: ${TABLE}.currently_stored_credit_cards_avg ;;
   }
 
-  dimension: currently_stored_credit_cards_users {
+  measure: currently_stored_credit_cards_users {
     type: number
     sql: ${TABLE}.currently_stored_credit_cards_users ;;
   }
 
-  dimension: currently_stored_credit_cards_frac {
+  measure: currently_stored_credit_cards_frac {
     type: number
     sql: ${TABLE}.currently_stored_credit_cards_frac ;;
   }
@@ -92,12 +87,12 @@ view: test_mobile_feature {
   set: detail {
     fields: [
         submission_date,
-	credit_cards_deleted_avg,
-	credit_cards_deleted_users,
-	credit_cards_deleted_frac,
-	currently_stored_credit_cards_avg,
-	currently_stored_credit_cards_users,
-	currently_stored_credit_cards_frac
+  credit_cards_deleted_avg,
+  credit_cards_deleted_users,
+  credit_cards_deleted_frac,
+  currently_stored_credit_cards_avg,
+  currently_stored_credit_cards_users,
+  currently_stored_credit_cards_frac
     ]
   }
 }

--- a/test_mobile_feature_usage.view.lkml
+++ b/test_mobile_feature_usage.view.lkml
@@ -1,0 +1,103 @@
+
+view: test_mobile_feature_usage {
+  derived_table: {
+    sql: WITH dau_segments AS 
+          (SELECT submission_date, SUM(DAU) as dau
+          FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates` 
+          WHERE app_name = 'Fenix'
+          --AND channel = 'release'
+          AND submission_date >= '2022-12-04'
+          GROUP BY 1),
+          
+      product_features AS
+      (SELECT
+          client_info.client_id,
+          DATE(submission_timestamp) as submission_date,
+          COALESCE(SUM(metrics.counter.credit_cards_deleted), 0) AS credit_cards_deleted,
+          COALESCE(SUM(metrics.quantity.credit_cards_saved_all), 0) AS currently_stored_credit_cards,
+          FROM `mozdata.fenix.metrics`
+      where DATE(submission_timestamp) >= '2022-12-04'
+      AND sample_id = 0
+      group by 1,2),
+      
+      product_features_agg AS
+      (SELECT
+          submission_date,
+          --credit card deleted
+          100*COUNT(DISTINCT CASE WHEN credit_cards_deleted > 0 THEN client_id END) AS credit_cards_deleted_users,
+          100*COALESCE(SUM(credit_cards_deleted), 0) AS credit_cards_deleted,
+          --credit card currently stored
+          100*COUNT(DISTINCT CASE WHEN currently_stored_credit_cards > 0 THEN client_id END) AS currently_stored_credit_cards_users,
+          100*COALESCE(SUM(currently_stored_credit_cards), 0) AS currently_stored_credit_cards
+          FROM product_features
+      where submission_date >= '2022-12-04'
+      group by 1)
+          
+          
+      select d.submission_date
+      -- credit card deleted
+      , SAFE_DIVIDE(p.credit_cards_deleted, p.credit_cards_deleted_users) AS credit_cards_deleted_avg
+      , p.credit_cards_deleted_users
+      , 100*SAFE_DIVIDE(p.credit_cards_deleted_users, dau) AS credit_cards_deleted_frac
+      -- credit card currently stored
+      , SAFE_DIVIDE(p.currently_stored_credit_cards, currently_stored_credit_cards_users) AS currently_stored_credit_cards_avg
+      , currently_stored_credit_cards_users
+      , 100*SAFE_DIVIDE(currently_stored_credit_cards_users, dau) AS currently_stored_credit_cards_frac
+      from dau_segments d
+      LEFT JOIN product_features_agg p
+      ON d.submission_date = p.submission_date ;;
+  }
+
+  measure: count {
+    type: count
+    drill_fields: [detail*]
+  }
+
+  dimension: submission_date {
+    type: date
+    datatype: date
+    sql: ${TABLE}.submission_date ;;
+  }
+
+  dimension: credit_cards_deleted_avg {
+    type: number
+    sql: ${TABLE}.credit_cards_deleted_avg ;;
+  }
+
+  dimension: credit_cards_deleted_users {
+    type: number
+    sql: ${TABLE}.credit_cards_deleted_users ;;
+  }
+
+  dimension: credit_cards_deleted_frac {
+    type: number
+    sql: ${TABLE}.credit_cards_deleted_frac ;;
+  }
+
+  dimension: currently_stored_credit_cards_avg {
+    type: number
+    sql: ${TABLE}.currently_stored_credit_cards_avg ;;
+  }
+
+  dimension: currently_stored_credit_cards_users {
+    type: number
+    sql: ${TABLE}.currently_stored_credit_cards_users ;;
+  }
+
+  dimension: currently_stored_credit_cards_frac {
+    type: number
+    sql: ${TABLE}.currently_stored_credit_cards_frac ;;
+  }
+
+  set: detail {
+    fields: [
+        submission_date,
+	credit_cards_deleted_avg,
+	credit_cards_deleted_users,
+	credit_cards_deleted_frac,
+	currently_stored_credit_cards_avg,
+	currently_stored_credit_cards_users,
+	currently_stored_credit_cards_frac
+    ]
+  }
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [x] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [x] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [x] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [x] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
