### PR TITLE
Unnest `services` arrays from logical subscriptions (DS-3082)

### DIFF
--- a/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
@@ -25,6 +25,14 @@ explore: daily_active_logical_subscriptions {
     ]
   }
 
+  join: subscription_services {
+    from: daily_active_logical_subscriptions__subscription__services
+    sql_table_name: UNNEST(daily_active_logical_subscriptions.subscription.services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
   join: table_metadata {
     sql_on: ${table_metadata.table_name} = 'daily_active_logical_subscriptions_v1' ;;
     type: left_outer

--- a/subscription_platform/explores/logical_subscription_events.explore.lkml
+++ b/subscription_platform/explores/logical_subscription_events.explore.lkml
@@ -25,6 +25,22 @@ explore: logical_subscription_events {
     ]
   }
 
+  join: subscription_services {
+    from: logical_subscription_events__subscription__services
+    sql_table_name: UNNEST(logical_subscription_events.subscription.services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: old_subscription_services {
+    from: logical_subscription_events__old_subscription__services
+    sql_table_name: UNNEST(logical_subscription_events.old_subscription.services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
   join: table_metadata {
     sql_on: ${table_metadata.table_name} = 'logical_subscription_events_v1' ;;
     type: left_outer

--- a/subscription_platform/explores/logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/logical_subscriptions.explore.lkml
@@ -10,6 +10,14 @@ explore: logical_subscriptions {
     relationship: many_to_one
   }
 
+  join: subscription_services {
+    from: logical_subscriptions__services
+    sql_table_name: UNNEST(logical_subscriptions.services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
   join: table_metadata {
     sql_on: ${table_metadata.table_name} = 'logical_subscriptions_history_v1' ;;
     type: left_outer

--- a/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
@@ -39,6 +39,14 @@ explore: monthly_active_logical_subscriptions {
     ]
   }
 
+  join: subscription_services {
+    from: monthly_active_logical_subscriptions__subscription__services
+    sql_table_name: UNNEST(monthly_active_logical_subscriptions.subscription.services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
   join: table_metadata {
     sql_on: ${table_metadata.table_name} = 'monthly_active_logical_subscriptions_v1' ;;
     type: left_outer

--- a/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
@@ -48,44 +48,6 @@ view: +daily_active_logical_subscriptions {
     group_item_label: "Services Quantity"
   }
 
-  dimension: subscription__service_1__id {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(1)].id ;;
-    group_label: "Subscription Service 1"
-    group_item_label: "ID"
-  }
-  dimension: subscription__service_1__name {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(1)].name ;;
-    group_label: "Subscription Service 1"
-    group_item_label: "Name"
-  }
-  dimension: subscription__service_1__tier {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(1)].tier ;;
-    group_label: "Subscription Service 1"
-    group_item_label: "Tier"
-  }
-
-  dimension: subscription__service_2__id {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(2)].id ;;
-    group_label: "Subscription Service 2"
-    group_item_label: "ID"
-  }
-  dimension: subscription__service_2__name {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(2)].name ;;
-    group_label: "Subscription Service 2"
-    group_item_label: "Name"
-  }
-  dimension: subscription__service_2__tier {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(2)].tier ;;
-    group_label: "Subscription Service 2"
-    group_item_label: "Tier"
-  }
-
   dimension: subscription__provider_product_id {
     group_label: "Subscription Provider IDs"
     group_item_label: "Product ID"

--- a/subscription_platform/views/logical_subscription_events.view.lkml
+++ b/subscription_platform/views/logical_subscription_events.view.lkml
@@ -58,44 +58,6 @@ view: +logical_subscription_events {
     group_item_label: "Services Quantity"
   }
 
-  dimension: subscription__service_1__id {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(1)].id ;;
-    group_label: "Subscription Service 1"
-    group_item_label: "ID"
-  }
-  dimension: subscription__service_1__name {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(1)].name ;;
-    group_label: "Subscription Service 1"
-    group_item_label: "Name"
-  }
-  dimension: subscription__service_1__tier {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(1)].tier ;;
-    group_label: "Subscription Service 1"
-    group_item_label: "Tier"
-  }
-
-  dimension: subscription__service_2__id {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(2)].id ;;
-    group_label: "Subscription Service 2"
-    group_item_label: "ID"
-  }
-  dimension: subscription__service_2__name {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(2)].name ;;
-    group_label: "Subscription Service 2"
-    group_item_label: "Name"
-  }
-  dimension: subscription__service_2__tier {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(2)].tier ;;
-    group_label: "Subscription Service 2"
-    group_item_label: "Tier"
-  }
-
   dimension: subscription__provider_product_id {
     group_label: "Subscription Provider IDs"
     group_item_label: "Product ID"
@@ -197,44 +159,6 @@ view: +logical_subscription_events {
     sql: ARRAY_LENGTH(${TABLE}.old_subscription.services) ;;
     group_label: "Old Subscription"
     group_item_label: "Services Quantity"
-  }
-
-  dimension: old_subscription__service_1__id {
-    type: string
-    sql: ${TABLE}.old_subscription.services[SAFE_ORDINAL(1)].id ;;
-    group_label: "Old Subscription Service 1"
-    group_item_label: "ID"
-  }
-  dimension: old_subscription__service_1__name {
-    type: string
-    sql: ${TABLE}.old_subscription.services[SAFE_ORDINAL(1)].name ;;
-    group_label: "Old Subscription Service 1"
-    group_item_label: "Name"
-  }
-  dimension: old_subscription__service_1__tier {
-    type: string
-    sql: ${TABLE}.old_subscription.services[SAFE_ORDINAL(1)].tier ;;
-    group_label: "Old Subscription Service 1"
-    group_item_label: "Tier"
-  }
-
-  dimension: old_subscription__service_2__id {
-    type: string
-    sql: ${TABLE}.old_subscription.services[SAFE_ORDINAL(2)].id ;;
-    group_label: "Old Subscription Service 2"
-    group_item_label: "ID"
-  }
-  dimension: old_subscription__service_2__name {
-    type: string
-    sql: ${TABLE}.old_subscription.services[SAFE_ORDINAL(2)].name ;;
-    group_label: "Old Subscription Service 2"
-    group_item_label: "Name"
-  }
-  dimension: old_subscription__service_2__tier {
-    type: string
-    sql: ${TABLE}.old_subscription.services[SAFE_ORDINAL(2)].tier ;;
-    group_label: "Old Subscription Service 2"
-    group_item_label: "Tier"
   }
 
   dimension: old_subscription__provider_product_id {

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -34,44 +34,6 @@ view: +logical_subscriptions {
     sql: ARRAY_LENGTH(${TABLE}.services) ;;
   }
 
-  dimension: service_1__id {
-    type: string
-    sql: ${TABLE}.services[SAFE_ORDINAL(1)].id ;;
-    group_label: "Service 1"
-    group_item_label: "ID"
-  }
-  dimension: service_1__name {
-    type: string
-    sql: ${TABLE}.services[SAFE_ORDINAL(1)].name ;;
-    group_label: "Service 1"
-    group_item_label: "Name"
-  }
-  dimension: service_1__tier {
-    type: string
-    sql: ${TABLE}.services[SAFE_ORDINAL(1)].tier ;;
-    group_label: "Service 1"
-    group_item_label: "Tier"
-  }
-
-  dimension: service_2__id {
-    type: string
-    sql: ${TABLE}.services[SAFE_ORDINAL(2)].id ;;
-    group_label: "Service 2"
-    group_item_label: "ID"
-  }
-  dimension: service_2__name {
-    type: string
-    sql: ${TABLE}.services[SAFE_ORDINAL(2)].name ;;
-    group_label: "Service 2"
-    group_item_label: "Name"
-  }
-  dimension: service_2__tier {
-    type: string
-    sql: ${TABLE}.services[SAFE_ORDINAL(2)].tier ;;
-    group_label: "Service 2"
-    group_item_label: "Tier"
-  }
-
   dimension: provider_product_id {
     group_label: "Provider IDs"
     group_item_label: "Product ID"

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -55,44 +55,6 @@ view: +monthly_active_logical_subscriptions {
     group_item_label: "Services Quantity"
   }
 
-  dimension: subscription__service_1__id {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(1)].id ;;
-    group_label: "Subscription Service 1"
-    group_item_label: "ID"
-  }
-  dimension: subscription__service_1__name {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(1)].name ;;
-    group_label: "Subscription Service 1"
-    group_item_label: "Name"
-  }
-  dimension: subscription__service_1__tier {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(1)].tier ;;
-    group_label: "Subscription Service 1"
-    group_item_label: "Tier"
-  }
-
-  dimension: subscription__service_2__id {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(2)].id ;;
-    group_label: "Subscription Service 2"
-    group_item_label: "ID"
-  }
-  dimension: subscription__service_2__name {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(2)].name ;;
-    group_label: "Subscription Service 2"
-    group_item_label: "Name"
-  }
-  dimension: subscription__service_2__tier {
-    type: string
-    sql: ${TABLE}.subscription.services[SAFE_ORDINAL(2)].tier ;;
-    group_label: "Subscription Service 2"
-    group_item_label: "Tier"
-  }
-
   dimension: subscription__provider_product_id {
     group_label: "Subscription Provider IDs"
     group_item_label: "Product ID"


### PR DESCRIPTION
## [DS-3082](https://mozilla-hub.atlassian.net/browse/DS-3082): SubPlat logical subscriptions Looker explores

Unnesting the `services` arrays allows their subfields to be selected and filtered more flexibly.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
