### PR TITLE
Improve Stripe plans view (DENG-1572)

### DIFF
--- a/subscription_platform/views/stripe_plans.view.lkml
+++ b/subscription_platform/views/stripe_plans.view.lkml
@@ -46,6 +46,19 @@ view: +stripe_plans {
       END ;;
   }
 
+  dimension: summary {
+    type: string
+    sql:
+      CONCAT(
+        ${interval_description},
+        IF(
+          ${amount} IS NOT NULL,
+          CONCAT(' ', ${currency}, ' ', FORMAT('%.2f', ${amount})),
+          ''
+        )
+      ) ;;
+  }
+
   dimension: tiers_mode {
     hidden:  yes
   }

--- a/subscription_platform/views/stripe_plans.view.lkml
+++ b/subscription_platform/views/stripe_plans.view.lkml
@@ -10,6 +10,11 @@ view: +stripe_plans {
     hidden:  yes
   }
 
+  dimension: amount {
+    sql: CAST(${TABLE}.amount AS DECIMAL) / 100 ;;
+    value_format_name: decimal_2
+  }
+
   dimension: billing_scheme {
     hidden:  yes
   }

--- a/subscription_platform/views/stripe_plans.view.lkml
+++ b/subscription_platform/views/stripe_plans.view.lkml
@@ -14,6 +14,10 @@ view: +stripe_plans {
     hidden:  yes
   }
 
+  dimension: currency {
+    sql: UPPER(${TABLE}.currency) ;;
+  }
+
   dimension: tiers_mode {
     hidden:  yes
   }

--- a/subscription_platform/views/stripe_plans.view.lkml
+++ b/subscription_platform/views/stripe_plans.view.lkml
@@ -18,6 +18,17 @@ view: +stripe_plans {
     sql: UPPER(${TABLE}.currency) ;;
   }
 
+  dimension: interval_description {
+    type: string
+    sql:
+      CONCAT(
+        ${interval_count},
+        ' ',
+        ${interval},
+        IF(${interval_count} > 1, 's', '')
+      ) ;;
+  }
+
   dimension: tiers_mode {
     hidden:  yes
   }

--- a/subscription_platform/views/stripe_plans.view.lkml
+++ b/subscription_platform/views/stripe_plans.view.lkml
@@ -29,6 +29,18 @@ view: +stripe_plans {
       ) ;;
   }
 
+  dimension: interval_months {
+    type: number
+    sql:
+      CASE
+        ${interval}
+        WHEN 'month'
+          THEN ${interval_count}
+        WHEN 'year'
+          THEN ${interval_count} * 12
+      END ;;
+  }
+
   dimension: tiers_mode {
     hidden:  yes
   }


### PR DESCRIPTION
This uppercases Stripe plan currency codes as requested in [DENG-1572](https://mozilla-hub.atlassian.net/browse/DENG-1572), plus formatting plan amounts and adding convenience dimensions to bring the Stripe plans view into more parity with the plan dimensions available in the logical subscriptions views.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
