### PR TITLE
swaped stale adjust table

### DIFF
--- a/duet/duet.model.lkml
+++ b/duet/duet.model.lkml
@@ -28,7 +28,9 @@ explore: kpi_downloads {
 }
 
 explore: kpi_installs{
-  sql_always_where: ${period_filtered_measures} in ("this", "last");;
+  sql_always_where: ${period_filtered_measures} in ("this", "last") AND
+                    ${app} = "Firefox Android and iOS" AND ${os} in ( "ios", "android")
+                    AND ${network} <> "Untrusted Devices";;
 }
 
 explore: app_store_territory_source_type_report {

--- a/duet/views/kpi_dau.view.lkml
+++ b/duet/views/kpi_dau.view.lkml
@@ -191,7 +191,7 @@ view: kpi_dau {
     type: string
     hidden: no
     sql: CASE WHEN ${app_name} = "Firefox Desktop" THEN "Desktop"
-              WHEN  ${app_name} IN ("Fenix", "Firefox iOS") THEN "Mobile"
+              WHEN  ${app_name} IN ("Fenix", "Firefox iOS", "Focus iOS", "Focus Android", "Klar iOS") THEN "Mobile"
               ELSE "Other" END ;;
   }
 

--- a/duet/views/kpi_installs.view.lkml
+++ b/duet/views/kpi_installs.view.lkml
@@ -1,7 +1,8 @@
-include: "//looker-hub/duet/views/firefox_mobile_installs.view.lkml"
+include: "//looker-hub/duet/views/firefox_mobile_installs_adjust_deliverables.view.lkml"
 view: kpi_installs {
 
-  extends: [firefox_mobile_installs]
+  extends: [firefox_mobile_installs_adjust_deliverables]
+
 
   filter: current_date {
     type: date
@@ -157,15 +158,15 @@ view: kpi_installs {
   measure: installs_goal {
     view_label: "KPI filtered metrics"
     type: sum
-    sql: CASE WHEN ${country} = "CA" THEN ${installs}  * 1.105
-              WHEN ${country} = "DE" THEN ${installs} * 1.103
-              WHEN ${country} = "FR" THEN ${installs} * 1.105
-              WHEN ${country} = "PL" THEN ${installs} * 1.077
-              WHEN ${country} = "IT" THEN ${installs} * 1.111
-              WHEN ${country} = "ES" THEN ${installs} * 1.118
-              WHEN ${country} = "GB" THEN ${installs} * 1.103
-              WHEN ${country} = "US" THEN ${installs} * 1.099
-              ELSE ${installs} * 1.112 END;;
+    sql: CASE WHEN UPPER(${country}) = "CA" THEN ${installs}  * 1.105
+              WHEN UPPER(${country}) = "DE" THEN ${installs} * 1.103
+              WHEN UPPER(${country}) = "FR" THEN ${installs} * 1.105
+              WHEN UPPER(${country}) = "PL" THEN ${installs} * 1.077
+              WHEN UPPER(${country}) = "IT" THEN ${installs} * 1.111
+              WHEN UPPER(${country}) = "ES" THEN ${installs} * 1.118
+              WHEN UPPER(${country}) = "GB" THEN ${installs} * 1.103
+              WHEN UPPER(${country}) = "US" THEN ${installs} * 1.099
+              ELSE UPPER(${country}) * 1.112 END;;
     filters: [period_filtered_measures: "last"]
   }
 
@@ -173,7 +174,7 @@ view: kpi_installs {
     description: "Normalizing country name to the names we want"
     type: string
     hidden: no
-    sql: CASE WHEN ${country} IN ("US","DE", "FR","PL", "IT", "ES", "GB", "CA") THEN ${country}
+    sql: CASE WHEN UPPER(${country}) IN ("US","DE", "FR","PL", "IT", "ES", "GB", "CA") THEN UPPER(${country})
               ELSE "Other" END ;;
   }
 

--- a/firefox_ios/views/app_store_funnel_table.view.lkml
+++ b/firefox_ios/views/app_store_funnel_table.view.lkml
@@ -31,11 +31,6 @@ view: +app_store_funnel_table {
     sql: ${TABLE}.new_profiles ;;
   }
 
-  measure: activations_sum {
-    description: "Early indicator for LTV based on days of app open and searches on the first week"
-    type: sum
-    sql: ${TABLE}.activations ;;
-  }
 
   measure: view_ctr {
     label: "View Click Through Rate"
@@ -49,13 +44,6 @@ view: +app_store_funnel_table {
     type: number
     value_format_name: percent_2
     sql: ${new_profiles}/ NULLIF(${total_downloads},0) ;;
-  }
-
-  measure: activation_rate {
-    label: "Activation Rate"
-    type: number
-    value_format_name: percent_2
-    sql: ${activations}/ NULLIF(${new_profiles},0) ;;
   }
 
   # measure: multi_days_users_conversion {
@@ -251,19 +239,6 @@ view: +app_store_funnel_table {
     filters: [period_filtered_measures: "last"]
   }
 
-  measure: current_period_activations {
-    view_label: "filtered metrics"
-    type: sum
-    sql: ${TABLE}.activations ;;
-    filters: [period_filtered_measures: "this"]
-  }
-
-  measure: previous_period_activations {
-    view_label: "filtered metrics"
-    type: sum
-    sql: ${TABLE}.activations ;;
-    filters: [period_filtered_measures: "last"]
-  }
 
   # measure: current_period_multi_days_users {
   #   view_label: "filtered metrics"
@@ -293,19 +268,7 @@ view: +app_store_funnel_table {
   #   filters: [period_filtered_measures: "last"]
   # }
 
-  measure: current_period_activation_rate {
-    view_label: "filtered metrics"
-    type: sum
-    sql: ${TABLE}.activation_rate ;;
-    filters: [period_filtered_measures: "this"]
-  }
 
-  measure: previous_period_activation_rate {
-    view_label: "filtered metrics"
-    type: sum
-    sql: ${TABLE}.activation_rate ;;
-    filters: [period_filtered_measures: "last"]
-  }
 
   # measure: current_period_multi_days_users_conversion {
   #   view_label: "filtered metrics"


### PR DESCRIPTION
Checklist for reviewer:

I replace the old adjust table with new one and made changes to the views and explore that pointed to the old table

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
