### PR TITLE
Add "Daily Multi-Service Customers" explore (DS-3137)

### DIFF
--- a/subscription_platform/explores/daily_multi_service_customers.explore.lkml
+++ b/subscription_platform/explores/daily_multi_service_customers.explore.lkml
@@ -1,0 +1,50 @@
+include: "../views/daily_multi_service_customers.view.lkml"
+include: "/shared/views/countries.view.lkml"
+
+explore: daily_multi_service_customers {
+  label: "Daily Multi-Service Customers"
+
+  conditionally_filter: {
+    filters: [date_date: "30 days ago for 30 days"]
+    unless: [date_week, date_month, date_quarter, date_year]
+  }
+
+  join: countries {
+    sql_on: ${daily_multi_service_customers.country_code} = ${countries.code} ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+
+  join: service_ids {
+    view_label: "Service IDs"
+    from: daily_multi_service_customers__service_ids
+    sql_table_name: UNNEST(daily_multi_service_customers.service_ids) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: service_names {
+    from: daily_multi_service_customers__service_names
+    sql_table_name: UNNEST(daily_multi_service_customers.service_names) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: product_names {
+    from: daily_multi_service_customers__product_names
+    sql_table_name: UNNEST(daily_multi_service_customers.product_names) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: plan_intervals {
+    from: daily_multi_service_customers__plan_intervals
+    sql_table_name: UNNEST(daily_multi_service_customers.plan_intervals) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+}

--- a/subscription_platform/views/daily_multi_service_customers.view.lkml
+++ b/subscription_platform/views/daily_multi_service_customers.view.lkml
@@ -65,6 +65,11 @@ view: daily_multi_service_customers {
     sql: ARRAY_TO_STRING(${TABLE}.service_names, ' + ') ;;
   }
 
+  dimension: product_names {
+    type: string
+    sql: ARRAY_TO_STRING(${TABLE}.product_names, ' + ') ;;
+  }
+
   dimension: country_code {
     type: string
     sql: ${TABLE}.country_code ;;

--- a/subscription_platform/views/daily_multi_service_customers.view.lkml
+++ b/subscription_platform/views/daily_multi_service_customers.view.lkml
@@ -6,10 +6,10 @@ view: daily_multi_service_customers {
       SELECT
         date,
         subscription.mozilla_account_id,
-        ARRAY_AGG(DISTINCT service.id ORDER BY service.id) AS service_ids,
-        ARRAY_AGG(DISTINCT service.name ORDER BY service.name) AS service_names,
-        ARRAY_AGG(DISTINCT subscription.product_name ORDER BY subscription.product_name) AS product_names,
-        ARRAY_AGG(DISTINCT subscription.plan_interval ORDER BY subscription.plan_interval) AS plan_intervals,
+        ARRAY_AGG(DISTINCT service.id IGNORE NULLS ORDER BY service.id) AS service_ids,
+        ARRAY_AGG(DISTINCT service.name IGNORE NULLS ORDER BY service.name) AS service_names,
+        ARRAY_AGG(DISTINCT subscription.product_name IGNORE NULLS ORDER BY subscription.product_name) AS product_names,
+        ARRAY_AGG(DISTINCT subscription.plan_interval IGNORE NULLS ORDER BY subscription.plan_interval) AS plan_intervals,
         MAX_BY(subscription.country_code, subscription.customer_subscription_number) AS country_code,
         MAX_BY(subscription.country_name, subscription.customer_subscription_number) AS country_name,
       FROM

--- a/subscription_platform/views/daily_multi_service_customers.view.lkml
+++ b/subscription_platform/views/daily_multi_service_customers.view.lkml
@@ -1,0 +1,105 @@
+view: daily_multi_service_customers {
+  label: "Daily Multi-Service Customers"
+
+  derived_table: {
+    sql:
+      SELECT
+        date,
+        subscription.mozilla_account_id,
+        ARRAY_AGG(DISTINCT service.id ORDER BY service.id) AS service_ids,
+        ARRAY_AGG(DISTINCT service.name ORDER BY service.name) AS service_names,
+        ARRAY_AGG(DISTINCT subscription.product_name ORDER BY subscription.product_name) AS product_names,
+        ARRAY_AGG(DISTINCT subscription.plan_interval ORDER BY subscription.plan_interval) AS plan_intervals,
+        MAX_BY(subscription.country_code, subscription.customer_subscription_number) AS country_code,
+        MAX_BY(subscription.country_name, subscription.customer_subscription_number) AS country_name,
+      FROM
+        `mozdata.subscription_platform.daily_active_logical_subscriptions`
+      CROSS JOIN
+        UNNEST(subscription.services) AS service
+      WHERE
+        was_active_at_day_end
+      GROUP BY
+        date,
+        subscription.mozilla_account_id
+      HAVING
+        ARRAY_LENGTH(service_ids) > 1 ;;
+  }
+
+  measure: customer_count {
+    type: count_distinct
+    sql: ${TABLE}.mozilla_account_id ;;
+  }
+
+  dimension_group: date {
+    type: time
+    sql: ${TABLE}.date ;;
+    datatype: date
+    convert_tz: no
+    timeframes: [
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+  }
+
+  dimension: mozilla_account_id {
+    type: string
+    sql: ${TABLE}.mozilla_account_id ;;
+  }
+
+  dimension: services_quantity {
+    type: number
+    sql: ARRAY_LENGTH(${TABLE}.service_ids) ;;
+  }
+
+  dimension: service_ids {
+    label: "Service IDs"
+    type: string
+    sql: ARRAY_TO_STRING(${TABLE}.service_ids, ' + ') ;;
+  }
+
+  dimension: service_names {
+    type: string
+    sql: ARRAY_TO_STRING(${TABLE}.service_names, ' + ') ;;
+  }
+
+  dimension: country_code {
+    type: string
+    sql: ${TABLE}.country_code ;;
+  }
+
+  dimension: country_name {
+    type: string
+    sql: ${TABLE}.country_name ;;
+  }
+}
+
+view: daily_multi_service_customers__service_ids {
+  dimension: service_id {
+    type: string
+    sql: ${TABLE} ;;
+  }
+}
+
+view: daily_multi_service_customers__service_names {
+  dimension: service_name {
+    type: string
+    sql: ${TABLE} ;;
+  }
+}
+
+view: daily_multi_service_customers__product_names {
+  dimension: product_name {
+    type: string
+    sql: ${TABLE} ;;
+  }
+}
+
+view: daily_multi_service_customers__plan_intervals {
+  dimension: plan_interval {
+    type: string
+    sql: ${TABLE} ;;
+  }
+}


### PR DESCRIPTION
## [DS-3137](https://mozilla-hub.atlassian.net/browse/DS-3137): Create multiproduct customer view for SubPlat dashboard

This is a stop-gap measure using a derived table view to unblock development of SubPlat's new metrics dashboards.  Ultimately we'll probably want to have some sort of customers ETL doing this aggregation.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
