### PR TITLE
Urlbar events: trending & some dims

### DIFF
--- a/firefox_desktop/views/urlbar_events.view.lkml
+++ b/firefox_desktop/views/urlbar_events.view.lkml
@@ -2,7 +2,8 @@ include: "//looker-hub/firefox_desktop/views/*"
 
 view: +urlbar_events {
 dimension: annoyance_signal_type {
-  hidden: yes
+  group_label: "Urlbar-specific filters"
+  description: "The type of annoyance: help, inaccurate_location, not_interested, not_relevant, show_less_frequently"
 }
 
 dimension: engaged_result_type {
@@ -130,7 +131,8 @@ dimension: sample_id {
 }
 
 dimension: session_action_type {
-  hidden:  yes
+  group_label: "Urlbar-specific filters"
+  description: "The type of urlbar event: engagement, abandonment or annoyance."
 }
 
 dimension_group: submission {
@@ -437,6 +439,32 @@ measure: urlbar_annoyances {
   measure: search_engine_annoyances {
     group_label: "Search Engine"
     sql: COUNTIF(product_engaged_result_type = "search_engine" and ${session_action_type} = "annoyance");;
+    type: number
+  }
+
+  measure: trending_clicks {
+    group_label: "Trending Suggestion"
+    sql: COUNTIF(product_engaged_result_type = "trending_suggestion" and ${is_terminal} and ${session_action_type} = "engaged");;
+    type: number
+  }
+
+  measure: trending_impressions {
+    group_label: "Trending Suggestion"
+    description: "The number of times a user exits the urlbar dropdown menu while a trending suggestion result was visible"
+    sql: COUNTIF(${num_trending_suggestion_impressions} > 0 and ${is_terminal});;
+    type: number
+  }
+
+  measure: trending_CTR {
+    group_label: "Trending Suggestion"
+    description: "Clicks / Impressions"
+    sql: safe_divide(${trending_clicks}, ${trending_impressions});;
+    type: number
+  }
+
+  measure: trending_annoyances {
+    group_label: "Trending Suggestion"
+    sql: COUNTIF(product_engaged_result_type = "trending_suggestion" and ${session_action_type} = "annoyance");;
     type: number
   }
 


### PR DESCRIPTION
Changes:
1. Add metrics for the trending_suggestions product result type (only need to change looker explore)
2. Expose annoyance type, session action type as dimensions. Annoyance types are only used in the pie charts on the[ main dashboard](https://mozilla.cloud.looker.com/dashboards/1328). Both are used in multiple places in the[ second dashboard](https://mozilla.cloud.looker.com/dashboards/1376).  (only need to change looker explore)


Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
