### PR TITLE
Creating a sql derive table on the funnel retention table 

### DIFF
--- a/duet/dashboards/kpi_installs_tracker.dashboard.lookml
+++ b/duet/dashboards/kpi_installs_tracker.dashboard.lookml
@@ -43,7 +43,7 @@
     filters:
       kpi_installs.compare_to: Year
       kpi_installs.network: ''
-    sorts: [kpi_installs.day_month]
+    sorts: [kpi_installs.day_month desc]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -65,7 +65,7 @@
     show_x_axis_label: true
     show_x_axis_ticks: true
     y_axis_scale_mode: linear
-    x_axis_reversed: false
+    x_axis_reversed: true
     y_axis_reversed: false
     plot_size_by_field: false
     trellis: ''
@@ -79,6 +79,9 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
+    y_axes: []
+    x_axis_zoom: true
+    y_axis_zoom: true
     show_row_numbers: true
     truncate_column_names: false
     hide_totals: false
@@ -89,7 +92,6 @@
     conditional_formatting_include_nulls: false
     defaults_version: 1
     hidden_fields: [kpi_installs.installs_goal]
-    y_axes: []
     listen:
       Adgroup: kpi_installs.adgroup
       Campaign: kpi_installs.campaign
@@ -111,7 +113,7 @@
     filters:
       kpi_installs.compare_to: Year
       kpi_installs.network: ''
-    sorts: [kpi_installs.month]
+    sorts: [kpi_installs.month desc]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -133,7 +135,7 @@
     show_x_axis_label: true
     show_x_axis_ticks: true
     y_axis_scale_mode: linear
-    x_axis_reversed: false
+    x_axis_reversed: true
     y_axis_reversed: false
     plot_size_by_field: false
     trellis: ''
@@ -147,6 +149,9 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
+    y_axes: []
+    x_axis_zoom: true
+    y_axis_zoom: true
     ordering: none
     show_null_labels: false
     show_totals_labels: false
@@ -154,7 +159,6 @@
     totals_color: "#808080"
     defaults_version: 1
     hidden_fields: [kpi_installs.installs_goal]
-    y_axes: []
     listen:
       Adgroup: kpi_installs.adgroup
       Campaign: kpi_installs.campaign
@@ -198,7 +202,7 @@
     show_x_axis_label: true
     show_x_axis_ticks: true
     y_axis_scale_mode: linear
-    x_axis_reversed: false
+    x_axis_reversed: true
     y_axis_reversed: false
     plot_size_by_field: false
     trellis: ''
@@ -212,6 +216,9 @@
     y_axis_combined: true
     show_null_points: true
     interpolation: linear
+    y_axes: []
+    x_axis_zoom: true
+    y_axis_zoom: true
     ordering: none
     show_null_labels: false
     show_totals_labels: false
@@ -219,7 +226,6 @@
     totals_color: "#808080"
     defaults_version: 1
     hidden_fields: [kpi_installs.installs_goal]
-    y_axes: []
     listen:
       Adgroup: kpi_installs.adgroup
       Campaign: kpi_installs.campaign

--- a/firefox_ios/views/ios_funnel_retention.view.lkml
+++ b/firefox_ios/views/ios_funnel_retention.view.lkml
@@ -1,0 +1,228 @@
+view: ios_funnel_retention {
+
+  derived_table: {
+    sql:
+      SELECT first_seen_date,
+             first_reported_country,
+             adjust_ad_group,
+            adjust_campaign,
+            adjust_creative,
+            adjust_network,
+            adjust_network,
+            first_reported_isp,
+            COUNT(1) as new_profiles,
+            COUNTIF(repeat_first_month_user) as repeat_user,
+            COUNTIF(retained_week_4) retained_week_4
+      FROM
+        `moz-fx-data-shared-prod.firefox_ios.funnel_retention`
+        group by 1, 2, 3, 4, 5, 6, 7, 8
+      ;;
+  }
+
+  dimension: country {
+    type: string
+    sql: ${TABLE}.first_reported_country ;;
+  }
+
+  dimension_group: date {
+    type: time
+    datatype: date
+    timeframes: [date, week, month, year]
+    sql: ${TABLE}.first_seen_date ;;
+    convert_tz: no
+  }
+
+  dimension: adjust_ad_group {
+    type: string
+    sql: ${TABLE}.adjust_ad_group ;;
+  }
+
+  dimension: adjust_campaign {
+    type: string
+    sql: ${TABLE}.adjust_campaign ;;
+  }
+
+  dimension: adjust_creative {
+    type: string
+    sql: ${TABLE}.adjust_creative ;;
+  }
+
+  dimension: adjust_network {
+    type: string
+    sql: ${TABLE}.adjust_network ;;
+  }
+
+  dimension: first_reported_isp {
+    type: string
+    sql: ${TABLE}.first_reported_isp ;;
+  }
+
+  measure: new_profiles {
+    description: "New Profile counts on a given first seen date"
+    type: sum
+    sql: ${TABLE}.new_profiles ;;
+  }
+
+  measure: repeat_user {
+    description: "Number of new profiles that visted more than once in their first 28-day window"
+    type: sum
+    sql: ${TABLE}.repeat_user ;;
+  }
+
+  measure: retained_week_4 {
+    description: "Number of new profiles that were retained in week 4 after their first seen date"
+    type: sum
+    sql: ${TABLE}.retained_week_4 ;;
+  }
+
+  filter: current_date {
+    type: date
+    view_label: "Funnel date filter"
+    label: "1. Current Date"
+    description: "Select the last date of the period you are interested in"
+    convert_tz: no
+  }
+
+
+  dimension: day_month {
+    description: "this dimension will help us trend period over period analysis for YoY, MoM and QoQ at daily granularity"
+    type:  string
+    hidden: no
+    view_label: "Funnel date axis"
+    sql: FORMAT_DATE("%m-%d", ${TABLE}.first_seen_date);;
+  }
+
+  dimension: month {
+    description: "this dimension will help us trend period over period analysis for YoY, MoM and QoQ at monthly granularity"
+    type:  string
+    hidden: no
+    view_label: "Funnel date axis"
+    sql: FORMAT_DATE("%m-%B", ${TABLE}.first_seen_date);;
+  }
+
+  dimension: quarter_abr {
+    description: "this dimension will help us trend period over period analysis for QR"
+    type:  string
+    hidden: no
+    view_label: "Funnel date axis"
+    sql: CASE WHEN FORMAT_DATE("%m",  DATE_TRUNC(${TABLE}.first_seen_date, QUARTER)) = "01" then "Q1"
+              WHEN FORMAT_DATE("%m",  DATE_TRUNC(${TABLE}.first_seen_date, QUARTER)) = "04" then "Q2"
+              WHEN FORMAT_DATE("%m",  DATE_TRUNC(${TABLE}.first_seen_date, QUARTER)) = "07" then "Q3"
+              ELSE "Q4" end;;
+  }
+
+  dimension: filter_end_date {
+    type: date
+    hidden: yes
+    description: "Select the last date of the period you are interested in"
+    sql: {% date_end current_date%};;
+  }
+
+  parameter: compare_to {
+    view_label: "Funnel date filter"
+    description: "Select the templated previous period you would like to compare to. Must be used with Current Date filter"
+    label: "2. Compare To:"
+    type: unquoted
+    # allowed_value: {
+    #   label: "Previous Period"
+    #   value: "Period"
+    # }
+    allowed_value: {
+      label: "Previous Week"
+      value: "Week"
+    }
+    allowed_value: {
+      label: "Previous Month"
+      value: "Month"
+    }
+    allowed_value: {
+      label: "Previous Quarter"
+      value: "Quarter"
+    }
+    allowed_value: {
+      label: "Previous Year"
+      value: "Year"
+    }
+    default_value: "Year"
+  }
+
+  dimension: first_date_in_period {
+    description: "For a well defined period (YoY, QoQ, MoM, WoW), we use date trunc to get the period start date, for arbitrary period modify this dimension to use date sub and number of days in period"
+    type: date
+    hidden: yes
+    sql: DATE_TRUNC(${filter_end_date}, {% parameter compare_to %});;
+  }
+
+  dimension: period_2_start {
+    hidden:  yes
+    description: "Calculates the start of the previous period"
+    type: date
+    sql:
+        DATE_SUB(${first_date_in_period}, INTERVAL 1 {% parameter compare_to %});;
+    convert_tz: no
+  }
+
+  dimension: period_2_end {
+    hidden:  yes
+    description: "Calculates the end of the previous period"
+    type: date
+    sql:
+        DATE_SUB(${filter_end_date}, INTERVAL 1 {% parameter compare_to %});;
+    convert_tz: no
+  }
+
+
+  dimension: period_filtered_measures {
+    hidden: yes
+    description: "We just use this to create the measures for the respective periods (this = current period, last = previous period)"
+    type: string
+    sql:
+        {% if current_date._is_filtered %}
+            CASE
+            WHEN DATE(${TABLE}.first_seen_date) BETWEEN DATE(${first_date_in_period}) AND DATE(${filter_end_date}) THEN 'this'
+            WHEN DATE(${TABLE}.first_seen_date) between ${period_2_start} and ${period_2_end} THEN 'last' END
+        {% else %} NULL {% endif %} ;;
+  }
+
+  measure: current_period_repeat_user {
+    view_label: "filtered metrics"
+    type: sum
+    sql: ${TABLE}.repeat_user ;;
+    filters: [period_filtered_measures: "this"]
+  }
+
+  measure: previous_period_repeat_user {
+    view_label: "filtered metrics"
+    type: sum
+    sql: ${TABLE}.repeat_user ;;
+    filters: [period_filtered_measures: "last"]
+  }
+
+  measure: current_period_new_profiles {
+    view_label: "filtered metrics"
+    type: sum
+    sql: ${TABLE}.new_profiles ;;
+    filters: [period_filtered_measures: "this"]
+  }
+
+  measure: previous_period_new_profiles {
+    view_label: "filtered metrics"
+    type: sum
+    sql: ${TABLE}.new_profiles ;;
+    filters: [period_filtered_measures: "last"]
+  }
+
+  measure: current_period_retained_week_4 {
+    view_label: "filtered metrics"
+    type: sum
+    sql: ${TABLE}.retained_week_4 ;;
+    filters: [period_filtered_measures: "this"]
+  }
+
+  measure: previous_period_retained_week_4 {
+    view_label: "filtered metrics"
+    type: sum
+    sql: ${TABLE}.retained_week_4 ;;
+    filters: [period_filtered_measures: "last"]
+  }
+}


### PR DESCRIPTION
I am committing this view which is based on a sql derive table to complete the funnel. The sql derive table will be replaced by the aggregated final table which will not be at client_id level

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
