### PR TITLE
Override looker-hub View with spoke-default View

### DIFF
--- a/firefox_desktop/explores/urlbar_events_temp_v2.explore.lkml
+++ b/firefox_desktop/explores/urlbar_events_temp_v2.explore.lkml
@@ -1,0 +1,11 @@
+include: "//looker-hub/firefox_desktop/views/*"
+include: "/firefox_desktop/views/*"
+
+explore: urlbar_events_temp_v2 {
+  view_name: urlbar_events_temp_v2
+
+  always_filter: {
+    filters: [urlbar_events_temp_v2.submission_date: "28 days"
+    ]
+  }
+}

--- a/firefox_desktop/views/urlbar_events_temp_v2.view.lkml
+++ b/firefox_desktop/views/urlbar_events_temp_v2.view.lkml
@@ -1,0 +1,189 @@
+include: "//looker-hub/firefox_desktop/views/*"
+
+view: +urlbar_events_table_temp_v2 {
+  dimension: annoyance_signal_type {
+    group_label: "Urlbar-specific filters"
+    description: "The type of annoyance: help, inaccurate_location, not_interested, not_relevant, show_less_frequently"
+  }
+
+  dimension: engaged_result_type {
+    hidden: yes
+  }
+
+  dimension: engagement_type {
+    hidden: yes
+  }
+
+  dimension: event_action {
+    group_label: "Urlbar-specific filters"
+    description: "The type of urlbar event: engagement, abandonment or annoyance."
+  }
+
+  dimension: event_id {
+    hidden: yes
+  }
+
+  dimension: event_name {
+    hidden:  yes
+  }
+
+  dimension: event_timestamp {
+    hidden:  yes
+  }
+
+  dimension: experiments {
+    hidden:  yes
+  }
+
+  dimension: glean_client_id {
+    hidden:  yes
+  }
+
+  dimension: interaction {
+    hidden:  yes
+  }
+
+  dimension: is_terminal {
+    hidden:  yes
+  }
+
+  dimension: legacy_telemetry_client_id {
+    hidden:  yes
+  }
+
+  dimension: normalized_channel {
+    sql: ${TABLE}.normalized_channel ;;
+    type: string
+  }
+
+  dimension: normalized_country_code {
+    sql: ${TABLE}.normalized_country_code ;;
+    type: string
+  }
+
+  dimension: num_chars_typed {
+    hidden:  yes
+  }
+
+  measure: average_characters_typed {
+    type: number
+    sql: AVG(${TABLE}.num_chars_typed) ;;
+  }
+
+  dimension: num_total_results {
+    hidden:  yes
+  }
+
+  dimension: pref_data_collection {
+    sql: ${TABLE}.pref_data_collection ;;
+    type: yesno
+  }
+
+  dimension: pref_fx_suggestions {
+    sql: ${TABLE}.pref_fx_suggestions ;;
+    type: yesno
+  }
+
+  dimension: pref_sponsored_suggestions {
+    sql: ${TABLE}.pref_sponsored_suggestions ;;
+    type: yesno
+  }
+
+  dimension: product_engaged_result_type {
+    hidden:  yes
+  }
+
+  dimension: product_selected_result {
+    hidden:  yes
+  }
+
+  dimension: sample_id {
+    group_label: "Filters to speed up Looker"
+    description: "Filter on this Dimension to speed up Looker while prototyping a dashboard. For example, filtering `sample_id < 10` will select a random 10% sample of the data, instead of all the data. DO NOT use this filter in a production dashboard for metrics with rare events (e.g., when click counts on a result type are low)."
+  }
+
+  dimension: selected_position {
+    hidden:  yes
+  }
+
+  dimension: selected_result {
+    hidden:  yes
+  }
+
+  dimension: seq {
+    hidden:  yes
+  }
+
+  dimension_group: submission {
+    sql: ${TABLE}.submission_date ;;
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+
+  measure: event_count {
+    hidden: yes
+  }
+
+  measure: urlbar_clicks {
+    group_label: "Urlbar Metrics"
+    description: "Count of clicks on any result shown in the urlbar dropdown menu"
+    sql: COUNTIF(${is_terminal} and ${event_action} = "engaged");;
+    type: number
+  }
+
+  measure: urlbar_impressions {
+    group_label: "Urlbar Metrics"
+    description: "The number of times a user exits the urlbar dropdown menu, either by abandoning the urlbar, engaging with a urlbar result, or selecting an annoyance signal that closes the urlbar dropdown menu"
+    sql: COUNTIF(${is_terminal});;
+    type: number
+  }
+
+  measure: urlbar_CTR {
+    group_label: "Urlbar Metrics"
+    description: "Clicks / Impressions"
+    sql: safe_divide(${urlbar_clicks}, ${urlbar_impressions});;
+    type: number
+  }
+
+  measure: urlbar_annoyances {
+    group_label: "Urlbar Metrics"
+    description: "Count of clicks on annoyance signals across all results shown in the urlbar dropdown menu"
+    sql: COUNTIF(${event_action} = "annoyance");;
+    type: number
+  }
+
+  measure: addon_clicks {
+    group_label: "Addon"
+    sql: COUNTIF(${product_selected_result} = "add_on" and ${is_terminal} and ${event_action} = "engaged");;
+    type: number
+  }
+
+  measure: addon_impressions {
+    group_label: "Addon"
+    description: "The number of times a user exits the urlbar dropdown menu while an addon result was visible"
+    sql: COUNTIF(${is_terminal} and ARRAY_LENGTH(ARRAY( SELECT 1 FROM UNNEST(${results}) AS e WHERE e.product_result_type = "add_on")));;
+    type: number
+  }
+
+  measure: addon_CTR {
+    group_label: "Addon"
+    description: "Clicks / Impressions"
+    sql: safe_divide(${addon_clicks}, ${addon_impressions});;
+    type: number
+  }
+
+  measure: addon_annoyances {
+    group_label: "Addon"
+    sql: COUNTIF(${product_engaged_result_type} = "add_on" and ${event_action} = "annoyance");;
+    type: number
+  }
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
