### PR TITLE
fix: small typos

### DIFF
--- a/firefox_desktop/views/urlbar_events.view.lkml
+++ b/firefox_desktop/views/urlbar_events.view.lkml
@@ -20,6 +20,7 @@ view: +urlbar_events {
   }
 
   dimension: session_action_type {
+    sql: ${TABLE}.event_action ;;
     group_label: "Urlbar-specific filters"
     description: "Don't use this field. It's the same as `Event Action`. It is included only for backwards compatibility on some older dashboards."
   }
@@ -37,6 +38,11 @@ view: +urlbar_events {
   }
 
   dimension: experiments {
+    hidden:  yes
+  }
+
+  dimension: first_result_type {
+    # looker-hub erroneously generates this Dimension that should not exist.
     hidden:  yes
   }
 
@@ -122,7 +128,7 @@ view: +urlbar_events {
   }
 
   dimension: product_first_result_type {
-    sql: ARRAY(SELECT r.product_result_type FROM UNNEST(${results}) AS r WHERE r.position = 1)[SAFE_OFFSET(0)] ;;
+    sql: ARRAY(SELECT r.product_result_type FROM UNNEST(results) AS r WHERE r.position = 1)[SAFE_OFFSET(0)] ;;
     type: string
   }
 
@@ -160,6 +166,11 @@ view: +urlbar_events {
     ]
     convert_tz: no
     datatype: date
+  }
+
+  dimension: num_add_on_impressions {
+    # looker-hub erroneously generates this Dimension that should not exist.
+    hidden:  yes
   }
 
   dimension: num_autofill_impressions {


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
