### PR TITLE
Add desktop acquisition funnel explore to spoke default

### DIFF
--- a/firefox_desktop/firefox_desktop.model.lkml
+++ b/firefox_desktop/firefox_desktop.model.lkml
@@ -95,7 +95,15 @@ explore: acquisition_funnel {
   view_name:  desktop_acquisition_funnel_table
   label: " Desktop Acquisition Funnel"
   description: "Desktop Acquisition Funnel Metrics"
+
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${desktop_acquisition_funnel_table.country_code} = ${countries.code} ;;
+  }
 }
+
+
 
 view: +metrics {
   dimension: client_info__build_date_datetime {

--- a/firefox_desktop/firefox_desktop.model.lkml
+++ b/firefox_desktop/firefox_desktop.model.lkml
@@ -91,6 +91,12 @@ explore: +metrics {
   }
 }
 
+explore: acquisition_funnel {
+  view_name:  desktop_acquisition_funnel_table
+  label: " Desktop Acquisition Funnel"
+  description: "Desktop Acquisition Funnel Metrics"
+}
+
 view: +metrics {
   dimension: client_info__build_date_datetime {
     label: "Build Date (Datetime)"

--- a/firefox_desktop/views/acquisition_funnel.view.lkml
+++ b/firefox_desktop/views/acquisition_funnel.view.lkml
@@ -1,0 +1,253 @@
+include: "//looker-hub/firefox_desktop/views/*"
+
+view: +desktop_acquisition_funnel_table {
+
+  # Hide metric columns showing as dimensions
+  dimension: cohort_dimension {
+    hidden: yes
+    sql: ${TABLE}.cohort ;;
+  }
+
+  dimension: activated_dimension {
+    hidden: yes
+    sql: ${TABLE}.activated ;;
+  }
+
+  dimension: returned_second_day_dimension {
+    hidden: yes
+    sql: ${TABLE}.returned_second_day ;;
+  }
+
+  dimension: qualified_second_day_dimension {
+    hidden: yes
+    sql: ${TABLE}.qualified_second_day ;;
+  }
+
+
+  dimension: retained_week4_dimension {
+    hidden: yes
+    sql: ${TABLE}.retained_week4 ;;
+  }
+
+  dimension: qualified_week_4_dimension {
+    hidden: yes
+    sql: ${TABLE}.qualified_week4 ;;
+  }
+
+  # Define measures
+  measure: cohort_measure {
+    label: "cohort"
+    type:  sum
+    sql: (${TABLE}.cohort) ;;
+  }
+
+  measure: activated_measure {
+    label: "clients activated"
+    type: sum
+    sql:  ${TABLE}.activated ;;
+  }
+
+  measure: returned_second_day_measure {
+    label: "clients repeat first month"
+    type: sum
+    sql:  ${TABLE}.returned_second_day ;;
+  }
+
+  measure: qualified_second_day_measure {
+    label: "clients repeat first month (DAU qualified)"
+    type: sum
+    sql:  ${TABLE}.qualified_second_day ;;
+  }
+
+  measure: retained_week_4_measure {
+    label: "clients retained in week 4"
+    type: sum
+    sql:  ${TABLE}.retained_week4 ;;
+  }
+
+  measure: qualified_week_4_measure {
+    label: "clients retained in week 4 (DAU qualified)"
+    type: sum
+    sql:  ${TABLE}.retained_week4 ;;
+  }
+
+  measure: activation_rate_measure{
+    label: "activation rate"
+    type: number
+    sql: SAFE_DIVIDE(${activated_measure}, ${cohort_measure}) ;;
+    value_format: "0.00%"
+  }
+
+  measure: repeat_first_month_user_rate_measure{
+    label: "repeat first month user rate"
+    type: number
+    sql: SAFE_DIVIDE(${returned_second_day_measure}, ${cohort_measure}) ;;
+    value_format: "0.00%"
+  }
+
+  measure: qualified_repeat_first_month_user_rate_measure{
+    label: "repeat first month user rate (DAU qualified)"
+    type: number
+    sql: SAFE_DIVIDE(${qualified_second_day_measure}, ${cohort_measure}) ;;
+    value_format: "0.00%"
+  }
+
+  measure: retention_week_4_measure{
+    label: "retention week 4"
+    type: number
+    sql: SAFE_DIVIDE(${retained_week_4_measure}, ${cohort_measure}) ;;
+    value_format: "0.00%"
+  }
+
+  measure: qualified_retention_week_4_measure{
+    label: "retention week 4 (DAU qualified)"
+    type: number
+    sql: SAFE_DIVIDE(${qualified_week_4_measure}, ${cohort_measure}) ;;
+    value_format: "0.00%"
+  }
+
+# Dates
+
+  parameter: choose_breakdown {
+    label: "Choose Grouping (Rows)"
+    view_label: "Date/Period Selection"
+    type: unquoted
+    default_value: "Month"
+    allowed_value: {label: "Month Number" value:"Month"}
+    allowed_value: {label: "Month and Day" value: "Month_Day"}
+    allowed_value: {label: "Week of Year" value: "WOY"}
+    allowed_value: {label: "Day of Year" value: "DOY"}
+    allowed_value: {label: "Day of Month" value: "DOM"}
+    allowed_value: {label: "Day of Week" value: "DOW"}
+    allowed_value: {value: "Date"}
+  }
+
+  parameter: choose_comparison {
+    label: "Choose Comparison (Pivot)"
+    view_label: "Date/Period Selection"
+    type: unquoted
+    default_value: "Year"
+    allowed_value: {value: "Year" }
+    allowed_value: {value: "Month"}
+    allowed_value: {value: "Week"}
+  }
+
+  dimension_group: first_seen {
+    type: time
+    view_label: "Date/Period Selection"
+    timeframes: [
+      raw,
+      date,
+      day_of_month,
+      day_of_year,
+      week,
+      week_of_year,
+      month,
+      month_name,
+      month_num,
+      quarter,
+      year
+    ]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.first_seen_date ;;
+  }
+
+  dimension: day_month_abbreviation {
+    type:  date
+    hidden: yes
+    view_label: "Date/Period Selection"
+    convert_tz: no
+    datatype:  date
+    sql: FORMAT_DATE("%b %d", ${TABLE}.first_seen_date);;
+  }
+
+  dimension: day_month_number {
+    type:  date
+    hidden: yes
+    view_label: "Date/Period Selection"
+    datatype:  date
+    sql: FORMAT_DATE("%m-%d", ${TABLE}.first_seen_date);;
+  }
+
+  dimension: period_over_period_row  {
+    view_label: "Date/Period Selection"
+    label_from_parameter: choose_breakdown
+    type: string
+
+    order_by_field: sort_by1
+    sql:
+          {% if choose_breakdown._parameter_value == 'Month' %} ${first_seen_month_num}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${day_month_abbreviation}
+          {% elsif choose_breakdown._parameter_value == 'WOY' %} ${first_seen_week_of_year}
+          {% elsif choose_breakdown._parameter_value == 'DOY' %} ${first_seen_day_of_year}
+          {% elsif choose_breakdown._parameter_value == 'DOM' %} ${first_seen_day_of_month}
+          {% elsif choose_breakdown._parameter_value == 'Date' %} ${first_seen_date}
+          {% else %}NULL{% endif %} ;;
+  }
+
+  dimension: period_over_period_pivot {
+    view_label: "Date/Period Selection"
+    label_from_parameter: choose_comparison
+    type: string
+
+    order_by_field: sort_by2
+    sql:
+          {% if choose_comparison._parameter_value == 'Year' %} ${first_seen_year}
+          {% elsif choose_comparison._parameter_value == 'Month' %} ${first_seen_month}
+          {% elsif choose_breakdown._parameter_value == 'WOY' %} ${first_seen_week_of_year}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${day_month_abbreviation}
+          {% else %}NULL{% endif %} ;;
+    }
+
+# These dimensions are just to make sure the dimensions sort correctly
+  dimension: sort_by1 {
+    hidden: yes
+    type: number
+    sql:
+          {% if choose_breakdown._parameter_value == 'Month' %} ${first_seen_month_num}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${first_seen_day_of_year}
+          {% elsif choose_breakdown._parameter_value == 'WOY' %} ${first_seen_week_of_year}
+          {% elsif choose_breakdown._parameter_value == 'DOY' %} ${first_seen_day_of_year}
+          {% elsif choose_breakdown._parameter_value == 'DOM' %} ${first_seen_day_of_month}
+          {% elsif choose_breakdown._parameter_value == 'Date' %} ${first_seen_date}
+          {% else %}NULL{% endif %} ;;
+  }
+
+  dimension: sort_by2 {
+    hidden: yes
+    type: string
+    sql:
+          {% if choose_comparison._parameter_value == 'Year' %} ${first_seen_year}
+          {% elsif choose_comparison._parameter_value == 'Month' %} ${first_seen_month_num}
+          {% elsif choose_breakdown._parameter_value == 'WOY' %} ${first_seen_week_of_year}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${first_seen_day_of_year}
+          {% elsif choose_comparison._parameter_value == 'Week' %} ${first_seen_week}
+          {% else %}NULL{% endif %} ;;
+
+  }
+
+  dimension: mtd_only {
+    group_label: "To-Date Filters"
+    label: "MTD"
+    view_label: "Date/Period Selection"
+    type: yesno
+    sql:  (EXTRACT(DAY FROM ${first_seen_date}) < EXTRACT(DAY FROM CURRENT_DATE()));;
+  }
+
+  dimension: wtd_only {
+    group_label: "To-Date Filters"
+    label: "WTD"
+    view_label: "Date/Period Selection"
+    type: yesno
+    sql:  ${first_seen_week_of_year} < (EXTRACT(WEEK FROM CURRENT_DATE()));;
+  }
+
+  dimension: ytd_only {
+    group_label: "To-Date Filters"
+    label: "YTD"
+    view_label: "Date/Period Selection"
+    type: yesno
+    sql:  (EXTRACT(DAYOFYEAR FROM ${first_seen_date}) < EXTRACT(DAYOFYEAR FROM CURRENT_DATE()));;
+  }
+}

--- a/firefox_desktop/views/acquisition_funnel.view.lkml
+++ b/firefox_desktop/views/acquisition_funnel.view.lkml
@@ -3,72 +3,72 @@ include: "//looker-hub/firefox_desktop/views/*"
 view: +desktop_acquisition_funnel_table {
 
   # Hide metric columns showing as dimensions
-  dimension: cohort_dimension {
+  dimension: cohort {
     hidden: yes
     sql: ${TABLE}.cohort ;;
   }
 
-  dimension: activated_dimension {
+  dimension: activated {
     hidden: yes
     sql: ${TABLE}.activated ;;
   }
 
-  dimension: returned_second_day_dimension {
+  dimension: returned_second_day {
     hidden: yes
     sql: ${TABLE}.returned_second_day ;;
   }
 
-  dimension: qualified_second_day_dimension {
+  dimension: qualified_second_day {
     hidden: yes
     sql: ${TABLE}.qualified_second_day ;;
   }
 
 
-  dimension: retained_week4_dimension {
+  dimension: retained_week4 {
     hidden: yes
     sql: ${TABLE}.retained_week4 ;;
   }
 
-  dimension: qualified_week_4_dimension {
+  dimension: qualified_week_4 {
     hidden: yes
     sql: ${TABLE}.qualified_week4 ;;
   }
 
   # Define measures
   measure: cohort_measure {
-    label: "cohort"
+    label: "New Profiles (cohort)"
     type:  sum
     sql: (${TABLE}.cohort) ;;
   }
 
   measure: activated_measure {
-    label: "clients activated"
+    label: "clients - activated"
     type: sum
     sql:  ${TABLE}.activated ;;
   }
 
   measure: returned_second_day_measure {
-    label: "clients repeat first month"
+    label: "clients - repeat first month"
     type: sum
     sql:  ${TABLE}.returned_second_day ;;
   }
 
   measure: qualified_second_day_measure {
-    label: "clients repeat first month (DAU qualified)"
+    label: "clients - repeat first month (DAU qualified)"
     type: sum
     sql:  ${TABLE}.qualified_second_day ;;
   }
 
   measure: retained_week_4_measure {
-    label: "clients retained in week 4"
+    label: "clients - retained in week 4"
     type: sum
     sql:  ${TABLE}.retained_week4 ;;
   }
 
   measure: qualified_week_4_measure {
-    label: "clients retained in week 4 (DAU qualified)"
+    label: "clients - retained in week 4 (DAU qualified)"
     type: sum
-    sql:  ${TABLE}.retained_week4 ;;
+    sql:  ${TABLE}.qualified_week4 ;;
   }
 
   measure: activation_rate_measure{
@@ -106,7 +106,58 @@ view: +desktop_acquisition_funnel_table {
     value_format: "0.00%"
   }
 
-# Dates
+# Group Dimensions
+  dimension: attribution_campaign {
+    label: "Campaign"
+    type:  string
+    group_label: "Attribution"
+    sql: ${TABLE}.attribution_campaign ;;
+  }
+
+  dimension: attribution_content {
+    label: "Content"
+    type:  string
+    group_label: "Attribution"
+    sql: ${TABLE}.attribution_content ;;
+  }
+
+  dimension: attribution_dlsource {
+    label: "Download Source"
+    type:  string
+    group_label: "Attribution"
+    sql: ${TABLE}.attribution_dlsource ;;
+  }
+
+  dimension: attribution_experiment {
+    label: "Experiment"
+    type:  string
+    group_label: "Attribution"
+    sql: ${TABLE}.attribution_experiment ;;
+  }
+
+  dimension: attribution_medium {
+    label: "Medium"
+    type:  string
+    group_label: "Attribution"
+    sql: ${TABLE}.attribution_medium ;;
+  }
+
+  dimension: attribution_source {
+    label: "Source"
+    type:  string
+    group_label: "Attribution"
+    sql: ${TABLE}.attribution_source ;;
+  }
+
+  dimension: attribution_ua {
+    label: "User Agent"
+    type:  string
+    group_label: "Attribution"
+    sql: ${TABLE}.attribution_ua ;;
+  }
+
+
+# Dates Setup
 
   parameter: choose_breakdown {
     label: "Choose Grouping (Rows)"

--- a/monitoring/monitoring.model.lkml
+++ b/monitoring/monitoring.model.lkml
@@ -118,7 +118,3 @@ explore: missing_document_namespaces_notes {
 explore: event_monitoring_live {
   hidden: yes
 }
-
-explore: event_error_monitoring_aggregates {
-  hidden: yes
-}

--- a/review_checker/review_checker.model.lkml
+++ b/review_checker/review_checker.model.lkml
@@ -1,9 +1,9 @@
 connection: "telemetry"
 label: "Review Checker"
 # Include files from looker-hub or spoke-default below. For example:
-  include: "//looker-hub/review_checker/explores/*"
+#  include: "//looker-hub/review_checker/explores/*"
 # include: "//looker-hub/review_checker/dashboards/*"
-  include: "//looker-hub/review_checker/views/*"
+#  include: "//looker-hub/review_checker/views/*"
 # include: "views/*"
 # include: "explores/*"
 # include: "dashboards/*"


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
