### PR TITLE
filter google_ads

### DIFF
--- a/duet/views/ctd_uac.view.lkml
+++ b/duet/views/ctd_uac.view.lkml
@@ -10,9 +10,11 @@ view: ctd_uac {
   FROM
     mozdata.google_ads.daily_ad_group_stats
   WHERE
-    campaign_name = "Mozilla_FF_UAC_EU_DE_DE_AllGroups_Event7"
-  AND date  >= '2023-06-01'
-    group by 1, 2, 3, 4 order by 1
+    account_name = "Mozilla Firefox UAC"
+    AND campaign_name = "Mozilla_FF_UAC_EU_DE_DE_AllGroups_Event7"
+    AND date  >= '2023-06-01'
+  GROUP BY 1, 2, 3, 4 
+  ORDER BY 1
 )
 , telemetry as (
   SELECT
@@ -26,11 +28,12 @@ view: ctd_uac {
      AND adjust_network = 'Google Ads ACI'
      AND adjust_campaign like "%Mozilla_FF_UAC_EU_DE_DE_AllGroups_Event7%"
         --AND adjust_adgroup <> "DE Ad Group (150957842358)"
-  GROUP BY 1, 2 order by 1
+  GROUP BY 1, 2 
+  ORDER BY 1
 )
-select uac.*, telemetry.activations, telemetry.clients
-from on_platform uac
-left JOIN telemetry
+SELECT uac.*, telemetry.activations, telemetry.clients
+FROM on_platform uac
+LEFT JOIN telemetry
 USING(date, ad_group_id)
 ;;
 }

--- a/duet/views/google_uac_android_activation.view.lkml
+++ b/duet/views/google_uac_android_activation.view.lkml
@@ -12,7 +12,8 @@ view: google_uac_android_activation {
          FROM
            mozdata.google_ads.daily_ad_group_stats
          WHERE
-            campaign_name NOT LIKE '%iOS%'
+            account_name = "Mozilla Firefox UAC"
+            AND campaign_name NOT LIKE '%iOS%'
             AND date >= '2022-12-01'
         ), activation AS (
          SELECT


### PR DESCRIPTION
Following https://github.com/mozilla/bigquery-etl/pull/4525/files
do not merge before that one is landed

with switching to a new connector all google ads accounts are now in that table so limiting the existing looker views to still work 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
