### PR TITLE
Update SERP impressions explore

### DIFF
--- a/firefox_desktop/explores/serp_impression.explore.lkml
+++ b/firefox_desktop/explores/serp_impression.explore.lkml
@@ -3,6 +3,17 @@ include: "/firefox_desktop/views/*"
 
 explore: serp_impression {
   view_name: serp_impression
+  label: "SERP Impressions"
+
+  # Main join key is impression ID.
+  # Also join on submission_date/normalized_channel/sample_id to propagate partitioning/clustering
+  join: serp_components {
+    sql_on: ${serp_impression.impression_id} = ${serp_components.impression_id}
+      and ${serp_impression.submission_date} = ${serp_components.submission_date}
+      and ${serp_impression.normalized_channel} = ${serp_components.normalized_channel}
+      and ${serp_impression.sample_id} = ${serp_components.sample_id} ;;
+    relationship: one_to_many
+  }
 
   always_filter: {
     filters: [serp_impression.submission_date:"28 days"

--- a/firefox_desktop/views/serp_impression.view.lkml
+++ b/firefox_desktop/views/serp_impression.view.lkml
@@ -1,85 +1,118 @@
 include: "//looker-hub/firefox_desktop/views/serp_events_table.view.lkml"
 
 view: serp_impression {
-  extends: [serp_events_table]
-
+  label: "SERP Impressions"
+  derived_table: {
+    # Aggregate at the impression ID level to get per-impression dimensions
+    sql:
+      SELECT
+        impression_id,
+        submission_date,
+        normalized_channel,
+        normalized_country_code,
+        sample_id,
+        is_shopping_page,
+        search_engine,
+        sap_source,
+        is_tagged,
+        is_engaged,
+        abandon_reason,
+        LOGICAL_OR(is_core_ad_component
+          AND num_ads_loaded_reported > 0) AS has_ads_loaded,
+        LOGICAL_OR(is_core_ad_component
+          AND num_ads_showing > 0) AS has_ads_visible,
+        LOGICAL_OR(is_core_ad_component AND num_ads_showing > 0
+          AND num_clicks > 0) AS has_ad_click,
+        LOGICAL_OR(num_clicks > 0) AS has_any_click,
+        LOGICAL_OR(is_core_ad_component
+          AND ad_blocker_inferred) AS ad_blocker_inferred,
+        SUM(num_clicks) AS num_clicks,
+        SUM(num_expands) AS num_expands,
+        SUM(num_submits) AS num_submits,
+        SUM(IF(is_core_ad_component, num_ads_loaded_reported, 0)) AS num_ads_loaded,
+        SUM(IF(is_core_ad_component, num_ads_showing, 0)) AS num_ads_showing,
+        SUM(IF(is_core_ad_component, num_ads_notshowing, 0)) AS num_ads_notshowing,
+        SUM(IF(is_core_ad_component and num_ads_showing > 0, num_clicks, 0)) AS num_ad_clicks,
+      FROM (
+        SELECT
+          *,
+          COALESCE(
+            component IN (
+              'ad_carousel',
+              'ad_image_row',
+              'ad_link',
+              'ad_sidebar',
+              'ad_sitelink'
+            ),
+            FALSE
+          ) AS is_core_ad_component
+        FROM
+          ${serp_events_table.SQL_TABLE_NAME} AS serp_events_table
+      )
+      GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+      ;;
+  }
   dimension: abandon_reason {
+    group_label: "SERP Features"
     type: string
-    description: "Reason for abandonment (Null if is_engaged = Yes)"
+    label: "Abandonment reason"
+    description: "Reason for SERP abandonment (Null if is_engaged = Yes)"
     sql: ${TABLE}.abandon_reason ;;
   }
   dimension: ad_blocker_inferred {
+    group_label: "Ad Features"
     type: yesno
-    description: "If ad blocker was being used (Yes/No)"
+    label: "Ad Blocker in Use"
+    description: "If ad blocker was being used on SERP"
     sql: ${TABLE}.ad_blocker_inferred ;;
   }
-  dimension: browser_version_info__is_major_release {
-    hidden: yes
-  }
-  dimension: browser_version_info__major_version {
-    hidden: yes
-  }
-  dimension: browser_version_info__minor_version {
-    hidden: yes
-  }
-  dimension: browser_version_info__patch_revision {
-    hidden: yes
-  }
-  dimension: browser_version_info__version {
-    hidden: yes
-  }
-  dimension: component {
-    type: string
-    description: "SERP display component"
-    sql: ${TABLE}.component ;;
-  }
-  dimension: event_timestamp {
-    hidden: yes
-  }
-  dimension: experiments {
-    hidden: yes
-    sql: ${TABLE}.experiments ;;
-  }
-  dimension: glean_client_id {
-    hidden: yes
-    sql: ${TABLE}.glean_client_id ;;
-  }
   dimension: has_ads_loaded {
+    group_label: "Ad Features"
     type: yesno
-    description: "If ads were loaded (Yes/No)"
+    description: "If SERP had ads loaded (may or may not be visible)"
     sql: ${TABLE}.has_ads_loaded ;;
   }
-
   dimension: has_ads_visible {
+    group_label: "Ad Features"
     type: yesno
-    description: "If ads were visible (Yes/No)"
-    sql: ${TABLE}.num_ads_showing > 0;;
+    description: "If SERP had visible ads"
+    sql: ${TABLE}.has_ads_visible ;;
+  }
+  dimension: has_ad_click {
+    group_label: "Ad Features"
+    type: yesno
+    description: "If SERP had at least 1 click on a visible ad"
+    sql: ${TABLE}.has_ad_click ;;
+  }
+  dimension: has_any_click {
+    group_label: "SERP Features"
+    type: yesno
+    description: "If SERP had at least 1 click on any component (ad/non-ad)"
+    sql: ${TABLE}.has_any_click ;;
   }
   dimension: impression_id {
+    type:  string
+    primary_key: yes
     hidden: yes
-  }
-  dimension: is_ad_component {
-    type: yesno
-    description: "If component is an ad component (Yes/No)"
-    sql: ${TABLE}.is_ad_component ;;
+    sql: ${TABLE}.impression_id ;;
   }
   dimension: is_engaged {
+    group_label: "SERP Features"
     type: yesno
-    description: "At least 1 engagement event present for the impression ID (Yes/No)"
+    description: "At least 1 engagement (click/expand/submit) on SERP (including ads/non-ads)"
     sql: ${TABLE}.is_engaged ;;
   }
   dimension: is_shopping_page {
+    group_label: "SERP Features"
     type: yesno
-    description: "If SERP Impression is known to be a shopping page (Yes/No)"
+    description: "If SERP is known to be a shopping page"
     sql: ${TABLE}.is_shopping_page ;;
   }
   dimension: is_tagged {
+    group_label: "SERP Features"
     type: yesno
-    description: "If SERP Impression is tagged (Yes/No)"
+    description: "If SERP comes from a tagged search"
     sql: ${TABLE}.is_tagged ;;
-  }
-  dimension: legacy_telemetry_client_id {
-    hidden: yes
   }
   dimension: normalized_channel {
     type: string
@@ -89,48 +122,19 @@ view: serp_impression {
     type: string
     sql: ${TABLE}.normalized_country_code ;;
   }
-  dimension: num_ads_hidden_reported {
-    hidden: yes
-  }
-  dimension: num_ads_loaded_reported {
-    hidden: yes
-  }
-  dimension: num_ads_notshowing {
-    hidden: yes
-  }
-  dimension: num_ads_showing {
-    hidden: yes
-  }
-  dimension: num_ads_visible_reported {
-    hidden: yes
-  }
-  dimension: num_clicks {
-    hidden: yes
-  }
-  dimension: num_expands {
-    hidden: yes
-  }
-  dimension: num_submits {
-    hidden: yes
-  }
-  dimension: os {
-    hidden: yes
-  }
-  dimension: ping_seq {
-    hidden: yes
-  }
-  dimension: sample_id {
-    group_label: "Filters to speed up Looker"
-    description: "Filter on this Dimension to speed up Looker while prototyping a dashboard. For example, filtering `sample_id < 10` will select a random 10% sample of the data, instead of all the data. DO NOT use this filter in a production dashboard for metrics with rare events (e.g., when click counts on a result type are low)."
+  filter: sample_id {
+    description: "Filter on sample ID to speed up Looker while prototyping a dashboard. For example, filtering `sample_id < 10` will select a random 10% sample of the data, instead of all the data. DO NOT use this filter in a production dashboard for metrics with rare events (e.g., when click counts on a result type are low)."
     type: number
     sql: ${TABLE}.sample_id ;;
   }
   dimension: sap_source {
+    group_label: "SERP Features"
     description: "How the user arrived at the SERP"
     type: string
     sql: ${TABLE}.sap_source ;;
   }
   dimension: search_engine {
+    group_label: "SERP Features"
     description: "Search engine"
     type: string
     sql: ${TABLE}.search_engine ;;
@@ -142,155 +146,310 @@ view: serp_impression {
     datatype: date
     sql: ${TABLE}.submission_date ;;
   }
+
   measure: serp_impressions_count {
     group_label: "SERP Impression Metrics"
-    description: "The number of distinct SERP Impressions"
-    type: count_distinct
-    sql: ${impression_id};;
+    label: "Num SERP Impressions"
+    description: "Number of SERP impressions"
+    type: count
   }
-
-
-
-
-
   measure: ad_impressions_count {
     group_label: "Ad Impression Metrics"
-    description: "The number of distinct SERP impressions with visible ads"
-    type: number
-    sql: COUNT(DISTINCT IF(${has_ads_visible}, ${impression_id}, NULL));;
-
+    label: "Num SERP with Ad Impressions"
+    description: "Number of SERP impressions with visible ads"
+    type: count
+    filters: [has_ads_visible: "yes"]
   }
-
+  measure: ad_impression_rate {
+    group_label: "Ad Impression Metrics"
+    label: "SERP Ad Impression Rate"
+    description: "Proportion of SERP impressions with visible ads"
+    type: number
+    sql: safe_divide(${ad_impressions_count}, ${serp_impressions_count}) ;;
+  }
+  measure: clicked_ad_impressions_count {
+    group_label: "Engagement Metrics"
+    label: "Num SERP with Ad Click"
+    description: "Number of SERP impressions with at least 1 ad click"
+    type: count
+    filters: [has_ad_click: "yes"]
+  }
   measure: ads_loaded{
     group_label: "Ad Impression Metrics"
+    label: "Num Ads Loaded"
     description: "Total number of ads loaded"
     type: sum
-    sql: ${TABLE}.num_ads_loaded_reported;;
-
+    sql: ${TABLE}.num_ads_loaded;;
   }
-
   measure: ads_visible{
     group_label: "Ad Impression Metrics"
+    label: "Num Ads Visible"
     description: "Total number of ads visible"
     type: sum
     sql: ${TABLE}.num_ads_showing;;
-
   }
-
   measure: ads_not_showing{
     group_label: "Ad Impression Metrics"
-    description: "Total number of ads loaded and not showing on SERP"
+    label: "Num Ads Not Showing"
+    description: "Total number of ads loaded and not showing"
     type: sum
     sql: ${TABLE}.num_ads_notshowing;;
-
   }
-
   measure: ads_loaded_per_impression_id {
     group_label: "Ad Impression Metrics"
-    description: "number of ads loaded / serp_impressions_count"
+    label: "Ads Loaded Per SERP"
+    description: "Number of ads loaded / number of SERP impressions"
     type: number
-    sql: safe_divide(${ads_loaded},${serp_impressions_count} );;
-
+    sql: safe_divide(${ads_loaded},${serp_impressions_count});;
   }
-
   measure: ads_visible_per_impression_id {
     group_label: "Ad Impression Metrics"
-    description: "number of ads visible / serp_impressions_count"
+    label: "Ads Visible Per SERP"
+    description: "Number of ads visible / number of SERP impressions"
     type: number
-    sql: safe_divide(${ads_visible},${serp_impressions_count} );;
-
+    sql: safe_divide(${ads_visible},${serp_impressions_count});;
   }
-
   measure: ads_not_showing_per_impression_id {
     group_label: "Ad Impression Metrics"
-    description: "number of ads not showing / serp_impressions_count"
+    label: "Ads Not Showing Per SERP"
+    description: "Number of ads not showing / number of SERP impressions"
     type: number
     sql: safe_divide(${ads_not_showing},${serp_impressions_count});;
-
   }
-
   measure: visible_proportion{
     group_label: "Ad Impression Metrics"
-    description: "number of ads visible / number of ads loaded"
+    label: "Proportion Loaded Ads Visible"
+    description: "Number of ads visible / number of ads loaded"
     type: number
     sql: safe_divide(${ads_visible},${ads_loaded});;
-
   }
-
+  measure: shopping_page_impressions_count {
+    group_label: "Shopping page Metrics"
+    label: "Num Shopping Page Impressions"
+    description: "Number of shopping page impressions"
+    type: count
+    filters: [is_shopping_page: "yes"]
+  }
   measure: is_shopping_page_proportion{
-    group_label: "Ad Impression Metrics"
-    description: "shopping page ratio (yes/no) for impressions with visible ads"
+    group_label: "Shopping page Metrics"
+    label: "Proportion Shopping Page Impressions"
+    description: "Shopping page ratio (yes/no) for impressions with visible ads"
     type: number
     sql: safe_divide(${is_shopping_page_ad_impression_count}, ${ad_impressions_count});;
   }
-
   measure: is_shopping_page_ad_impression_count {
-    group_label: "Ad Impression Metrics"
-    description: "The number of distinct impressions for shopping page with visible ads"
-    type: number
-    sql: COUNT(DISTINCT IF(${is_shopping_page} and ${has_ads_visible}, ${impression_id}, NULL));;
-
+    group_label: "Shopping page Metrics"
+    label: "Num Shopping Page with Ad Impressions"
+    description: "Number of shopping page impressions with visible ads"
+    type: count
+    filters: [is_shopping_page: "yes", has_ads_visible: "yes"]
   }
-
+  measure: shopping_page_with_ad_click_count {
+    group_label: "Shopping page Metrics"
+    label: "Num Shopping Page with Ad Click"
+    description: "Number of shopping page impressions with at least 1 ad click"
+    type: count
+    filters: [is_shopping_page: "yes", has_ad_click: "yes"]
+  }
   measure: clicks{
     group_label: "Engagement Metrics"
-    description: "Total number of ads/non-ads links clicked"
+    label: "Num Clicks"
+    description: "Total number of ad links/non-ad links/UI features clicked"
     type: sum
     sql: ${TABLE}.num_clicks;;
-
   }
-
   measure: ad_clicks{
     group_label: "Engagement Metrics"
-    description: "Total number of ads clicks for impressions with visible ads"
-    type: number
-    sql: SUM( IF( ${has_ads_visible} , ${TABLE}.num_clicks, 0));;
-
+    label: "Num Ad Clicks"
+    description: "Total number of clicks on visible ads"
+    type: sum
+    sql: ${TABLE}.num_ad_clicks;;
   }
-
   measure: expansion{
     group_label: "Engagement Metrics"
-    description: "Total number of clicks on the expansion button (applies to ad_carousel, ad_sidebar, refined_search_buttons) "
+    label: "Num Expands"
+    description: "Total number of clicks on the expansion button (applies to ad_carousel, ad_sidebar, refined_search_buttons)"
     type: sum
     sql: ${TABLE}.num_expands;;
-
   }
-
   measure: submits{
     group_label: "Engagement Metrics"
-    description: "Total number of in content search box submits"
+    label: "Num Submits"
+    description: "Total number of in-content search box submits"
     type: sum
     sql: ${TABLE}.num_submits;;
-
   }
-
-
   measure: Ads_CTR{
     group_label: "Engagement Metrics"
-    description: "number of impressions with at least 1 ad clicks / number of impressions with visible ads"
+    label: "SERP Ad CTR"
+    description: "Number of SERP impressions with at least 1 ad click / number of SERP impressions with visible ads"
     type: number
-    sql: safe_divide(COUNT(DISTINCT IF (${num_clicks} > 0 and ${num_ads_showing} > 0 , ${impression_id}, NULL)), ${ad_impressions_count});;
-
-
+    sql: safe_divide(${clicked_ad_impressions_count}, ${ad_impressions_count}) ;;
   }
-
   measure: ad_clicks_per_impression_id {
     group_label: "Engagement Metrics"
+    label: "Ads Clicked Per SERP"
     description: "Total number of ads clicked / number of impressions with visible ads"
     type: number
     sql: safe_divide(${ad_clicks},${ad_impressions_count});;
-
   }
-
-
- measure: abandonment_impressions_count {
-  group_label: "Abandonment Metrics"
-  description: "The number of abandoned impressions"
-  type: number
-  sql: COUNT(DISTINCT IF (${is_engaged} = FALSE, ${impression_id}, NULL));;
-
+  measure: abandonment_impressions_count {
+    group_label: "Abandonment Metrics"
+    label: "Num Abandoned SERP"
+    description: "Number of abandoned SERP impressions"
+    type: count
+    filters: [is_engaged: "no"]
+  }
 }
 
+view: serp_components {
+  sql_table_name: `mozdata.firefox_desktop.serp_events` ;;
+  label: "SERP Components"
 
+  # Include these explicitly so they are available for joining in the explore
+  dimension: impression_id {
+    hidden: yes
+    type:  string
+    sql: ${TABLE}.impression_id ;;
+  }
+  dimension_group: submission {
+    hidden: yes
+    type: time
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.submission_date ;;
+  }
+  dimension: normalized_channel {
+    hidden: yes
+    type: string
+    sql: ${TABLE}.normalized_channel ;;
+  }
+  dimension: sample_id {
+    hidden: yes
+    type: number
+    sql: ${TABLE}.sample_id ;;
+  }
+  dimension: component {
+    label: "Display Component"
+    description: "SERP display component"
+    type: string
+    sql: ${TABLE}.component ;;
+  }
+  dimension: is_ad_component {
+    # Override table's is_ad_component to restrict the definition to monetizable ad components
+    type: yesno
+    description: "If component is an ad component"
+    sql: ${component} in ('ad_carousel', 'ad_image_row', 'ad_link', 'ad_sidebar', 'ad_sitelink') ;;
+  }
+  dimension: has_ads_visible {
+    type: yesno
+    description: "If component had ads visible (always False for non-ad components)"
+    sql: ${is_ad_component} and ${TABLE}.num_ads_showing > 0;;
+  }
+  dimension: has_ad_clicked {
+    type: yesno
+    description: "If component had at least 1 visible ad clicked"
+    sql: ${is_ad_component} and ${TABLE}.num_ads_showing > 0 and ${TABLE}.num_clicks > 0;;
+  }
+  dimension: is_engaged {
+    type: yesno
+    description: "If at least 1 engagement (click/expand/submit) was recorded for the component"
+    sql: ${TABLE}.num_clicks > 0 or ${TABLE}.num_expands > 0 or ${TABLE}.num_submits > 0 ;;
+  }
 
+  measure: serp_impressions_count {
+    group_label: "SERP Impression Metrics"
+    label: "Num SERP Impressions"
+    description: "Number of SERP Impressions with component"
+    type: count_distinct
+    sql: ${impression_id};;
+  }
+  measure: ad_impressions_count {
+    group_label: "Ad Impression Metrics"
+    label: "Num SERP with Ad Impressions"
+    description: "Number of SERP impressions with visible ads in component"
+    type: count_distinct
+    sql: ${impression_id};;
+    filters: [has_ads_visible: "yes"]
+  }
+  measure: clicked_ad_impressions_count {
+    group_label: "Engagement Metrics"
+    label: "Num SERP with Ad Click"
+    description: "Number of SERP impressions with at least 1 ad click in component"
+    type: count_distinct
+    sql: ${impression_id};;
+    filters: [has_ad_clicked: "yes"]
+  }
+  measure: ad_impression_rate {
+    group_label: "Ad Impression Metrics"
+    label: "SERP Ad Impression Rate"
+    description: "Proportion of SERP impressions with visible ads in component"
+    type: number
+    sql: safe_divide(${ad_impressions_count}, ${serp_impressions_count}) ;;
+  }
+  measure: ad_ctr{
+    group_label: "Engagement Metrics"
+    label: "SERP Ad CTR"
+    description: "Number of SERP impressions with at least 1 ad click / number of SERP impressions with visible ads"
+    type: number
+    sql: safe_divide(${clicked_ad_impressions_count}, ${ad_impressions_count}) ;;
+  }
+  measure: ads_loaded{
+    group_label: "Ad Impression Metrics"
+    label: "Num Ads Loaded"
+    description: "Total number of ads loaded in component"
+    type: sum
+    sql: ${TABLE}.num_ads_loaded_reported;;
+  }
+  measure: ads_visible{
+    group_label: "Ad Impression Metrics"
+    label: "Num Ads Visible"
+    description: "Total number of ads visible in component"
+    type: sum
+    sql: ${TABLE}.num_ads_showing;;
+  }
+  measure: ads_not_showing{
+    group_label: "Ad Impression Metrics"
+    label: "Num Ads Not Showing"
+    description: "Total number of ads loaded and not showing in component"
+    type: sum
+    sql: ${TABLE}.num_ads_notshowing;;
+  }
+  measure: visible_proportion{
+    group_label: "Ad Impression Metrics"
+    label: "Proportion Loaded Ads Visible"
+    description: "Number of ads visible / number of ads loaded in component"
+    type: number
+    sql: safe_divide(${ads_visible},${ads_loaded});;
+  }
+  measure: clicks{
+    group_label: "Engagement Metrics"
+    label: "Num Clicks"
+    description: "Total number of ad links/non-ad links/UI features clicked in component"
+    type: sum
+    sql: ${TABLE}.num_clicks;;
+  }
+  measure: ad_clicks{
+    group_label: "Engagement Metrics"
+    label: "Num Ad Clicks"
+    description: "Total number of clicks on visible ads in component"
+    type: sum
+    sql: ${TABLE}.num_clicks;;
+    filters: [has_ads_visible: "yes"]
+  }
+  measure: expands{
+    group_label: "Engagement Metrics"
+    label: "Num Expands"
+    description: "Total number of clicks on the expansion button (applies to ad_carousel, ad_sidebar, refined_search_buttons)"
+    type: sum
+    sql: ${TABLE}.num_expands;;
+  }
+  measure: submits{
+    group_label: "Engagement Metrics"
+    label: "Num Submits"
+    description: "Total number of in-content search box submits"
+    type: sum
+    sql: ${TABLE}.num_submits;;
+  }
 }

--- a/firefox_desktop/views/serp_impression.view.lkml
+++ b/firefox_desktop/views/serp_impression.view.lkml
@@ -122,7 +122,8 @@ view: serp_impression {
     type: string
     sql: ${TABLE}.normalized_country_code ;;
   }
-  filter: sample_id {
+  dimension: sample_id {
+    group_label: "Filters to speed up Looker"
     description: "Filter on sample ID to speed up Looker while prototyping a dashboard. For example, filtering `sample_id < 10` will select a random 10% sample of the data, instead of all the data. DO NOT use this filter in a production dashboard for metrics with rare events (e.g., when click counts on a result type are low)."
     type: number
     sql: ${TABLE}.sample_id ;;


### PR DESCRIPTION
- Redefine "ad" to only include monetizable display components
- Split explore into separate views for SERP-level and component-level analysis
- Add missing dimensions at SERP and component level

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
