### PR TITLE
ctd downstream impact attribution

### DIFF
--- a/duet/duet.model.lkml
+++ b/duet/duet.model.lkml
@@ -22,6 +22,10 @@ explore: releases {
   }
 }
 
+explore: ctd_cohort_analysis_mobile {}
+
+explore: ctd_cohort_analysis_desktop {}
+
 explore: kpi_dau {
   sql_always_where: ${submission_date} >= "2022-01-01" AND ${period_filtered_measures} in ("this", "last");;
 }

--- a/duet/views/ctd_cohort_analysis_desktop.view.lkml
+++ b/duet/views/ctd_cohort_analysis_desktop.view.lkml
@@ -1,0 +1,75 @@
+view: ctd_cohort_analysis_desktop {
+
+
+  derived_table: {
+    sql:
+    SELECT
+        first_seen_date,
+      CASE
+          WHEN attribution_campaign = "ctd-de" THEN "ctd-de"
+          WHEN (attribution_source IS NOT NULL) AND (attribution_campaign != "ctd-de") THEN "other_attributed" --the second bit isnt strictly necessary.
+          ELSE "unattributed"
+        END AS benchmark_filter,attribution_source, attribution_medium, attribution_content,
+        SAFE_DIVIDE(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 7) AS period,
+        SUM(num_clients_in_cohort) AS num_in_cohort,
+        SUM(num_clients_active_atleastonce_in_last_7_days) AS num_clients_active_atleastonce_in_last_7_days
+    FROM `moz-fx-data-shared-prod.telemetry_derived.desktop_cohort_daily_retention_v1`
+    WHERE MOD(DATE_DIFF(submission_date, first_seen_date, DAY) + 1, 7) = 0
+    AND submission_date >= DATE(2023, 1, 1)
+    AND first_seen_date >= DATE(2023, 1, 1)
+    AND country = 'DE'
+    AND normalized_os LIKE 'Windows%'
+    AND normalized_channel = 'release'
+    GROUP BY 1,2,3, 4, 5, 6
+        ;;
+  }
+
+  dimension: attribution_source {
+    type: string
+    sql: ${TABLE}.attribution_source ;;
+  }
+
+  dimension: attribution_medium {
+    type: string
+    sql: ${TABLE}.attribution_medium ;;
+  }
+  dimension: attribution_content {
+    type: string
+    sql: ${TABLE}.attribution_content ;;
+  }
+
+  dimension: benchmark_filter {
+    description: "Groupings to compare ctd to other benchmark cohort"
+    type: string
+    sql:${TABLE}.benchmark_filter
+      ;;
+  }
+
+  dimension_group: cohort_date {
+    type: time
+    datatype: date
+    timeframes: [date]
+    sql: ${TABLE}.first_seen_date ;;
+    convert_tz: no
+  }
+
+  dimension: weeks_since_seen {
+    description: "Groupings to compare ctd to other benchmark cohort"
+    type: number
+    sql:${TABLE}.period
+      ;;
+  }
+
+  measure: num_in_cohort {
+    description: "total number of clients in cohort"
+    type: sum
+    sql: ${TABLE}.num_in_cohort ;;
+  }
+
+  measure: num_clients_active_atleastonce_in_last_7_days {
+    description: "number of clients that visited atleast once in a given week"
+    type: sum
+    sql: ${TABLE}.num_clients_active_atleastonce_in_last_7_days ;;
+  }
+
+}

--- a/duet/views/ctd_cohort_analysis_mobile.view.lkml
+++ b/duet/views/ctd_cohort_analysis_mobile.view.lkml
@@ -1,0 +1,58 @@
+view: ctd_cohort_analysis_mobile {
+
+  #base table https://console.cloud.google.com/bigquery?sq=470293616514:eee95f9ddd584b54bc3e7e4d068f135a
+
+    derived_table: {
+      sql:
+    SELECT
+        cohort_date,
+        benchmark_filter,ad_group_name,
+        SAFE_DIVIDE(DATE_DIFF(activity_date, cohort_date, DAY) + 1, 7) AS period,
+        SUM(num_in_cohort) AS num_in_cohort,
+        SUM(num_clients_active_atleastonce_in_last_7_days) AS num_clients_active_atleastonce_in_last_7_days
+    FROM `mozdata.analysis.cohort_ctd`
+    GROUP BY 1,2,3, 4
+        ;;
+    }
+
+    dimension: ad_group_name {
+      type: string
+      sql: ${TABLE}.ad_group_name ;;
+    }
+
+
+    dimension: benchmark_filter {
+      description: "Groupings to compare ctd to other benchmark cohort"
+      type: string
+      sql:${TABLE}.benchmark_filter
+        ;;
+    }
+
+  dimension_group: cohort_date {
+    type: time
+    datatype: date
+    timeframes: [date]
+    sql: ${TABLE}.cohort_date ;;
+    convert_tz: no
+  }
+
+  dimension: weeks_since_seen {
+    description: "Groupings to compare ctd to other benchmark cohort"
+    type: number
+    sql:${TABLE}.period
+      ;;
+  }
+
+    measure: num_in_cohort {
+      description: "total number of clients in cohort"
+      type: sum
+      sql: ${TABLE}.num_in_cohort ;;
+    }
+
+    measure: num_clients_active_atleastonce_in_last_7_days {
+      description: "number of clients that visited atleast once in a given week"
+      type: sum
+      sql: ${TABLE}.num_clients_active_atleastonce_in_last_7_days ;;
+    }
+
+  }


### PR DESCRIPTION
This PR is to quick put data in looker so stakeholders can use the explore to visualize the data. The views uses derived sql, this is because this is simply for ad-hoc analysis and views will be deleted after delivery of report

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
