### PR TITLE
Add dimensions/measures for logical subscriptions churn and retention by month (DS-3082)

### DIFF
--- a/subscription_platform/explores/logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/logical_subscriptions.explore.lkml
@@ -3,15 +3,24 @@ include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
 
 explore: logical_subscriptions {
-
   join: countries {
     sql_on: ${logical_subscriptions.country_code} = ${countries.code} ;;
     type: left_outer
     relationship: many_to_one
   }
 
+  join: retention_by_month {
+    from: logical_subscriptions__retention_by_month
+    # The `sql` parameter was deprecated in Looker 3.12, so this should use `sql_table_name`,
+    # but Looker currently has a problem resolving dimension references in `sql_table_name`.
+    sql: LEFT JOIN UNNEST(${logical_subscriptions.month_numbers}) AS retention_by_month ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
   join: subscription_services {
     from: logical_subscriptions__services
+    # This should use a dimension reference, but Looker currently has a problem resolving dimension references in `sql_table_name`.
     sql_table_name: UNNEST(logical_subscriptions.services) ;;
     sql_on: TRUE ;;
     type: left_outer
@@ -23,5 +32,4 @@ explore: logical_subscriptions {
     type: left_outer
     relationship: many_to_one
   }
-
 }

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -1,7 +1,6 @@
 include: "//looker-hub/subscription_platform/views/logical_subscriptions.view.lkml"
 
 view: +logical_subscriptions {
-
   dimension: id {
     primary_key: yes
   }
@@ -60,6 +59,32 @@ view: +logical_subscriptions {
     intervals: [day, week, month, quarter, year]
   }
 
+  dimension_group: since_subscription_started {
+    type: duration
+    sql_start: ${TABLE}.started_at ;;
+    sql_end: TIMESTAMP(CURRENT_DATE()) ;;
+    intervals: [day, week, month, quarter, year]
+  }
+
+  dimension: month_numbers {
+    sql: GENERATE_ARRAY(1, ${months_since_subscription_started} + 1) ;;
+    hidden: yes
+  }
+
+  dimension: months_since_start_month_ended {
+    type: duration_month
+    sql_start:
+      TIMESTAMP_SUB(
+        TIMESTAMP_ADD(
+          TIMESTAMP(LAST_DAY(DATE(${TABLE}.started_at), MONTH)),
+          INTERVAL 1 DAY
+        ),
+        INTERVAL 1 MICROSECOND
+      ) ;;
+    sql_end: TIMESTAMP(CURRENT_DATE()) ;;
+    hidden: yes
+  }
+
   dimension: first_touch_attribution__utm_campaign {
     group_item_label: "UTM Campaign"
   }
@@ -110,5 +135,49 @@ view: +logical_subscriptions {
         ${TABLE}.provider_subscription_id
       ) ;;
   }
+}
 
+view: logical_subscriptions__retention_by_month {
+  dimension: subscription_month_number {
+    type: number
+    sql: ${TABLE} ;;
+  }
+
+  dimension: is_start_month_cohort_complete {
+    type: yesno
+    sql: ${subscription_month_number} <= ${logical_subscriptions.months_since_start_month_ended} ;;
+  }
+
+  measure: churned_subscription_count {
+    type: count_distinct
+    sql:
+      CASE
+        WHEN NOT ${logical_subscriptions.is_active}
+          AND ${subscription_month_number} = ${logical_subscriptions.months_active} + 1
+          THEN ${logical_subscriptions.id}
+        ELSE NULL
+      END ;;
+  }
+
+  measure: retained_subscription_count {
+    type: count_distinct
+    sql:
+      CASE
+        WHEN ${logical_subscriptions.is_active}
+          OR ${subscription_month_number} <= ${logical_subscriptions.months_active}
+          THEN ${logical_subscriptions.id}
+        ELSE NULL
+      END ;;
+  }
+
+  measure: previously_retained_subscription_count {
+    type: count_distinct
+    sql:
+      CASE
+        WHEN ${logical_subscriptions.is_active}
+          OR ${subscription_month_number} <= ${logical_subscriptions.months_active} + 1
+          THEN ${logical_subscriptions.id}
+        ELSE NULL
+      END ;;
+  }
 }


### PR DESCRIPTION
## [DS-3082](https://mozilla-hub.atlassian.net/browse/DS-3082): SubPlat logical subscriptions Looker explores

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
