### PR TITLE
Add Stripe subscriptions explore (DS-3079)

### DIFF
--- a/subscription_platform/explores/stripe_subscriptions.explore.lkml
+++ b/subscription_platform/explores/stripe_subscriptions.explore.lkml
@@ -1,0 +1,23 @@
+include: "../views/stripe_subscriptions.view.lkml"
+
+explore: stripe_subscriptions {
+  view_label: "Subscriptions"
+
+  join: default_tax_rates {
+    from: stripe_subscriptions__default_tax_rates
+    # This should use a dimension reference, but Looker currently has a problem resolving dimension references in `sql_table_name`.
+    sql_table_name: UNNEST(stripe_subscriptions.default_tax_rates) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: subscription_items {
+    from: stripe_subscriptions__items
+    # This should use a dimension reference, but Looker currently has a problem resolving dimension references in `sql_table_name`.
+    sql_table_name: UNNEST(stripe_subscriptions.items) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+}

--- a/subscription_platform/views/stripe_subscriptions.view.lkml
+++ b/subscription_platform/views/stripe_subscriptions.view.lkml
@@ -1,0 +1,11 @@
+include: "//looker-hub/subscription_platform/views/stripe_subscriptions.view.lkml"
+
+view: +stripe_subscriptions {
+  dimension: id {
+    primary_key: yes
+  }
+
+  measure: count {
+    type: count
+  }
+}

--- a/subscription_platform/views/stripe_subscriptions.view.lkml
+++ b/subscription_platform/views/stripe_subscriptions.view.lkml
@@ -9,3 +9,13 @@ view: +stripe_subscriptions {
     type: count
   }
 }
+
+view: +stripe_subscriptions__items {
+  dimension: id {
+    primary_key: yes
+  }
+
+  measure: count {
+    type: count
+  }
+}

--- a/subscription_platform/views/stripe_subscriptions.view.lkml
+++ b/subscription_platform/views/stripe_subscriptions.view.lkml
@@ -5,8 +5,47 @@ view: +stripe_subscriptions {
     primary_key: yes
   }
 
+  dimension: customer__address__country {
+    map_layer_name: countries
+  }
+
+  dimension: customer__metadata__userid_sha256 {
+    hidden: yes
+  }
+
+  dimension: customer__shipping__address__country {
+    map_layer_name: countries
+  }
+
+  dimension: default_tax_rates_quantity {
+    type: number
+    sql: ARRAY_LENGTH(${TABLE}.default_tax_rates) ;;
+  }
+
+  dimension: items_quantity {
+    type: number
+    sql: ARRAY_LENGTH(${TABLE}.items) ;;
+  }
+
+  dimension_group: active {
+    type: duration
+    sql_start: ${TABLE}.start_date ;;
+    sql_end: COALESCE(${TABLE}.ended_at, TIMESTAMP(CURRENT_DATE())) ;;
+    intervals: [day, week, month, quarter, year]
+  }
+
   measure: count {
     type: count
+  }
+
+  measure: customer_count {
+    type: count_distinct
+    sql:
+      COALESCE(
+        ${TABLE}.customer.metadata.userid_sha256,
+        ${TABLE}.customer.id,
+        ${TABLE}.id
+      ) ;;
   }
 }
 


### PR DESCRIPTION
## [DS-3079](https://mozilla-hub.atlassian.net/browse/DS-3079): Stripe subscriptions Looker explores

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
