### PR TITLE
1866834 - Adding new view to spoke-default for use-counters data

### DIFF
--- a/combined_browser_metrics/views/fenix_and_firefox_desktop_use_counters.view.lkml
+++ b/combined_browser_metrics/views/fenix_and_firefox_desktop_use_counters.view.lkml
@@ -1,6 +1,6 @@
 include: "//looker-hub/combined_browser_metrics/views/fenix_and_firefox_use_counters.view.lkml"
 
-view: fenix_and_firefox_use_counters {
+view: fenix_and_firefox_desktop_use_counters {
 
   dimension: submission_date {
     description: "The date when the ingestion edge server accepted this message"

--- a/combined_browser_metrics/views/fenix_and_firefox_use_counters.view.lkml
+++ b/combined_browser_metrics/views/fenix_and_firefox_use_counters.view.lkml
@@ -1,0 +1,40 @@
+include: "//looker-hub/combined_browser_metrics/views/fenix_and_firefox_use_counters.view.lkml"
+
+view: fenix_and_firefox_use_counters {
+
+  dimension: submission_date {
+    description: "The date when the ingestion edge server accepted this message"
+    type: date
+    sql: submission_date ;;
+  }
+
+  dimension: version_major {
+    description: "The user visible main portion of version string (e.g., 1, 2, etc)."
+    type: string
+    sql: version_major ;;
+  }
+
+  dimension: country {
+    description: "Result of a geographic lookup based on the client's IP address; An ISO 3166-1 alpha-2 country code"
+    type: string
+    sql: country ;;
+  }
+
+  dimension: platform {
+    description: "Indicates if the data is from Firefox Desktop or Mobile (Fenix) "
+    type: string
+    sql: platform ;;
+  }
+
+  dimension: metric {
+    description: "The name of the metric; naming matches that found in the Glean dictionary"
+    type: string
+    sql: metric ;;
+  }
+
+  measure: rate {
+    description: "Usage rate; denominator depends on if metric is a doc, page, worker shared, worker service, or worker dedicated type of metric"
+    type: number
+    sql: rate ;;
+  }
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
