### PR TITLE
DS-2963, DS-3301, DS-3398 Updating VPN SaaSboard to hide fraudulent subs, failed payment records, and FPN 6month free subs

### DIFF
--- a/mozilla_vpn/dashboards/vpn_saasboard_active_subs.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_active_subs.dashboard.lookml
@@ -48,6 +48,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 9
     col: 8
     width: 16
@@ -109,6 +110,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 9
     col: 0
     width: 8
@@ -203,6 +205,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 2
     col: 19
     width: 5
@@ -290,6 +293,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 53
     col: 13
     width: 11
@@ -375,6 +379,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 16
     col: 0
     width: 4
@@ -460,6 +465,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 16
     col: 4
     width: 4
@@ -568,6 +574,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 23
     col: 0
     width: 13
@@ -650,6 +657,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 45
     col: 13
     width: 11
@@ -783,6 +791,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 30
     col: 13
     width: 11
@@ -892,6 +901,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 23
     col: 13
     width: 11
@@ -981,6 +991,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 30
     col: 0
     width: 13
@@ -1096,6 +1107,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 45
     col: 0
     width: 13
@@ -1188,6 +1200,7 @@
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
       Product Name: active_subscriptions.product_name
+      Plan ID: active_subscriptions.plan_id
     row: 53
     col: 0
     width: 13
@@ -1196,13 +1209,12 @@
   - name: Provider
     title: Provider
     type: field_filter
-    default_value: ''
+    default_value: "-NULL"
     allow_multiple_values: true
     required: false
     ui_config:
-      type: checkboxes
+      type: advanced
       display: popover
-      options: []
     model: mozilla_vpn
     explore: active_subscriptions
     listens_to_filters: [Plan Interval Type, Active Date, Country, Pricing Plan]
@@ -1276,3 +1288,16 @@
     explore: active_subscriptions
     listens_to_filters: []
     field: active_subscriptions.product_name
+  - name: Plan ID
+    title: Plan ID
+    type: field_filter
+    default_value: -"price_1MzNRCJNcmPzuWtRMCwUWADu"
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: overflow
+    model: mozilla_vpn
+    explore: active_subscriptions
+    listens_to_filters: []
+    field: active_subscriptions.plan_id

--- a/mozilla_vpn/dashboards/vpn_saasboard_churn.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_churn.dashboard.lookml
@@ -5,7 +5,7 @@
   crossfilter_enabled: true
   description: ''
   refresh: 2147484 seconds
-  preferred_slug: 6aSxIuXzGxHD9X4lsYkIIb
+  preferred_slug: eYqxHc9qMbz6bbuVVlyyBp
   elements:
   - name: ''
     type: text
@@ -40,7 +40,6 @@
   - name: " (3)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |2
 
 
@@ -64,16 +63,34 @@
       original_subscriptions__retention.is_cohort_complete: 'Yes'
       original_subscriptions__retention.months_since_original_subscription_start: ">0"
     sorts: [original_subscriptions__retention.months_since_original_subscription_start]
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}",
-        label: Churn Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: churn_rate, _type_hint: number, is_disabled: true},
-      {category: table_calculation, expression: "${previously_retained}-${churned}",
-        label: Retained, value_format: !!null '', value_format_name: !!null '', _kind_hint: measure,
-        table_calculation: retained, _type_hint: number, is_disabled: true}, {category: table_calculation,
-        expression: "${original_subscriptions__retention.churned}/${original_subscriptions__retention.previously_retained}",
-        label: Total Churn Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_churn_rate, _type_hint: number,
-        is_disabled: false}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}"
+      label: Churn Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: churn_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${previously_retained}-${churned}"
+      label: Retained
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: retained
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.churned}/${original_subscriptions__retention.previously_retained}"
+      label: Total Churn Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_churn_rate
+      _type_hint: number
+      is_disabled: false
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -116,7 +133,6 @@
     x_axis_zoom: true
     y_axis_zoom: true
     series_types:
-      churn_rate: line
       total_churn_rate: line
     series_colors:
       churned: "#FF7139"
@@ -147,6 +163,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Plan ID: subscriptions.plan_id
     row: 11
     col: 0
     width: 13
@@ -162,13 +181,25 @@
     filters:
       original_subscriptions__retention.is_cohort_complete: 'Yes'
     sorts: [subscriptions.original_subscription_start_month]
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}",
-        label: Churn Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: churn_rate, _type_hint: number, is_disabled: true},
-      {category: table_calculation, expression: "${original_subscriptions__retention.churned}/${original_subscriptions__retention.previously_retained}",
-        label: Total Churn Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_churn_rate, _type_hint: number,
-        is_disabled: false}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}"
+      label: Churn Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: churn_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.churned}/${original_subscriptions__retention.previously_retained}"
+      label: Total Churn Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_churn_rate
+      _type_hint: number
+      is_disabled: false
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -241,6 +272,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Plan ID: subscriptions.plan_id
     row: 11
     col: 13
     width: 11
@@ -258,12 +292,24 @@
     filters:
       original_subscriptions__retention.is_cohort_complete: 'Yes'
     sorts: [subscriptions.original_subscription_start_month, original_subscriptions__retention.months_since_original_subscription_start]
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}",
-        label: Churn Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: churn_rate, _type_hint: number, is_disabled: true},
-      {category: table_calculation, expression: "${original_subscriptions__retention.churned}/${original_subscriptions__retention.previously_retained}",
-        label: Total Churn Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_churn_rate, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}"
+      label: Churn Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: churn_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.churned}/${original_subscriptions__retention.previously_retained}"
+      label: Total Churn Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_churn_rate
+      _type_hint: number
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -291,7 +337,6 @@
     x_axis_label: Cohort
     x_axis_zoom: true
     y_axis_zoom: true
-    series_types: {}
     series_colors:
       0 - churn_rate: "#ffffff"
       0 - total_churn_rate: "#ffffff"
@@ -356,6 +401,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Plan ID: subscriptions.plan_id
     row: 44
     col: 0
     width: 24
@@ -374,13 +422,25 @@
       original_subscriptions__retention.months_since_original_subscription_start: ">0"
     sorts: [subscriptions.original_subscription_start_month, original_subscriptions__retention.months_since_original_subscription_start]
     total: true
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}",
-        label: Churn Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: churn_rate, _type_hint: number, is_disabled: true},
-      {category: table_calculation, expression: "${original_subscriptions__retention.churned}/${original_subscriptions__retention.previously_retained}",
-        label: Total Churn Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_churn_rate, _type_hint: number,
-        is_disabled: false}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}"
+      label: Churn Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: churn_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.churned}/${original_subscriptions__retention.previously_retained}"
+      label: Total Churn Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_churn_rate
+      _type_hint: number
+      is_disabled: false
     show_view_names: false
     show_row_numbers: false
     transpose: false
@@ -404,19 +464,9 @@
       churned: Subs Churned
       subscriptions__retention.months_since_subscription_start: Months Since Subscription
         Start
-    series_column_widths:
-      subscriptions.subscription_start_month: 256
-      churned: 115
-      churn_rate: 115
     series_cell_visualizations:
       churned:
         is_active: false
-    series_text_format:
-      subscriptions.subscription_start_month:
-        align: center
-        bold: true
-      churn_rate:
-        align: center
     header_background_color: "#D8D8D8"
     conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
         font_color: !!null '', color_application: {collection_id: mozilla, palette_id: mozilla-sequential-0,
@@ -439,7 +489,6 @@
     trellis: ''
     stacking: ''
     legend_position: left
-    series_types: {}
     point_style: circle_outline
     show_value_labels: false
     label_density: 25
@@ -465,6 +514,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Plan ID: subscriptions.plan_id
     row: 53
     col: 0
     width: 24
@@ -484,19 +536,42 @@
       original_subscriptions__retention.months_since_original_subscription_start: ">0"
     sorts: [subscriptions.original_subscription_start_month, original_subscriptions__retention.months_since_original_subscription_start]
     total: true
-    dynamic_fields: [{category: measure, expression: "if(\n  ${subscriptions__retention.months_since_subscription_start}\
-          \ > 0,\n  ${subscriptions__retention.months_since_subscription_start} <=\
-          \ ${subscriptions.months_retained} + 1,\n  null\n)", label: Previously Retained,
-        based_on: subscriptions__retention.count, filter_expression: "if(\n  ${subscriptions__retention.months_since_subscription_start}\
-          \ > 0,\n  ${subscriptions__retention.months_since_subscription_start} <=\
-          \ ${subscriptions.months_retained} + 1,\n  null\n)", _kind_hint: measure,
-        measure: previously_retained, type: count, _type_hint: number}, {category: measure,
-        expression: "${subscriptions__retention.months_since_subscription_start} =\
-          \ ${subscriptions.months_retained} + 1", label: Churned, based_on: subscriptions__retention.count,
-        filter_expression: "${subscriptions__retention.months_since_subscription_start}\
-          \ = ${subscriptions.months_retained} + 1", _kind_hint: measure, measure: churned,
-        type: count, _type_hint: number}, {table_calculation: churn_rate, expression: "${churned}/${previously_retained}",
-        label: Churn Rate, value_format_name: percent_2, is_disabled: true}]
+    dynamic_fields:
+    - category: measure
+      expression: |-
+        if(
+          ${subscriptions__retention.months_since_subscription_start} > 0,
+          ${subscriptions__retention.months_since_subscription_start} <= ${subscriptions.months_retained} + 1,
+          null
+        )
+      label: Previously Retained
+      based_on: subscriptions__retention.count
+      filter_expression: |-
+        if(
+          ${subscriptions__retention.months_since_subscription_start} > 0,
+          ${subscriptions__retention.months_since_subscription_start} <= ${subscriptions.months_retained} + 1,
+          null
+        )
+      _kind_hint: measure
+      measure: previously_retained
+      type: count
+      _type_hint: number
+    - category: measure
+      expression: "${subscriptions__retention.months_since_subscription_start} = ${subscriptions.months_retained}\
+        \ + 1"
+      label: Churned
+      based_on: subscriptions__retention.count
+      filter_expression: "${subscriptions__retention.months_since_subscription_start}\
+        \ = ${subscriptions.months_retained} + 1"
+      _kind_hint: measure
+      measure: churned
+      type: count
+      _type_hint: number
+    - table_calculation: churn_rate
+      expression: "${churned}/${previously_retained}"
+      label: Churn Rate
+      value_format_name: percent_2
+      is_disabled: true
     show_view_names: false
     show_row_numbers: false
     transpose: false
@@ -521,21 +596,9 @@
       subscriptions__retention.months_since_subscription_start: Months Since Subscription
         Start
       subscriptions.subscription_start_month: Cohort
-    series_column_widths:
-      subscriptions.subscription_start_month: 256
-      churned: 115
     series_cell_visualizations:
       churned:
         is_active: false
-    series_text_format:
-      subscriptions__retention.months_since_subscription_start:
-        bold: true
-        align: center
-      subscriptions.subscription_start_month:
-        bold: true
-        align: center
-      churned:
-        align: center
     header_background_color: "#D8D8D8"
     conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
         font_color: !!null '', color_application: {collection_id: mozilla, palette_id: mozilla-sequential-0,
@@ -558,7 +621,6 @@
     trellis: ''
     stacking: ''
     legend_position: left
-    series_types: {}
     point_style: circle_outline
     show_value_labels: false
     label_density: 25
@@ -584,6 +646,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Plan ID: subscriptions.plan_id
     row: 60
     col: 0
     width: 24
@@ -599,9 +664,15 @@
       subscriptions__active.is_max_active_date: 'Yes'
     sorts: [metadata.last_modified_date desc]
     limit: 1
-    dynamic_fields: [{category: table_calculation, expression: 'add_days(-1,${metadata.last_modified_date})',
-        label: New Calculation, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: dimension, table_calculation: new_calculation, _type_hint: date}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: add_days(-1,${metadata.last_modified_date})
+      label: New Calculation
+      value_format:
+      value_format_name:
+      _kind_hint: dimension
+      table_calculation: new_calculation
+      _type_hint: date
     custom_color_enabled: true
     show_single_value_title: true
     show_comparison: false
@@ -637,13 +708,15 @@
     show_null_points: true
     interpolation: linear
     defaults_version: 1
-    series_types: {}
     hidden_fields: [metadata.last_modified_date]
     listen:
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_date
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Plan ID: subscriptions.plan_id
     row: 3
     col: 19
     width: 5
@@ -651,7 +724,6 @@
   - name: " (4)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |2-
 
 
@@ -667,7 +739,6 @@
   - name: " (5)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |2-
 
 
@@ -727,26 +798,62 @@
     sorts: [subscriptions__retention.months_since_subscription_start, subscriptions__retention.churned
         desc 0]
     total: true
-    dynamic_fields: [{category: measure, expression: "if(\n  ${subscriptions__retention.months_since_subscription_start}\
-          \ > 0,\n  ${subscriptions__retention.months_since_subscription_start} <=\
-          \ ${subscriptions.months_retained} + 1,\n  null\n)", label: Previously Retained,
-        based_on: subscriptions__retention.count, filter_expression: "if(\n  ${subscriptions__retention.months_since_subscription_start}\
-          \ > 0,\n  ${subscriptions__retention.months_since_subscription_start} <=\
-          \ ${subscriptions.months_retained} + 1,\n  null\n)", _kind_hint: measure,
-        measure: previously_retained, type: count, _type_hint: number}, {category: measure,
-        expression: "${subscriptions__retention.months_since_subscription_start} =\
-          \ ${subscriptions.months_retained} + 1", label: Churned, based_on: subscriptions__retention.count,
-        filter_expression: "${subscriptions__retention.months_since_subscription_start}\
-          \ = ${subscriptions.months_retained} + 1", _kind_hint: measure, measure: churned,
-        type: count, _type_hint: number}, {category: table_calculation, expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}",
-        label: Churn Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: churn_rate, _type_hint: number}, {
-        category: table_calculation, expression: 'max(pivot_row(if(is_null(${subscriptions__retention.previously_retained}),null,${subscriptions__retention.months_since_subscription_start})))',
-        label: Months Since Plan Start, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: supermeasure, table_calculation: months_since_plan_start, _type_hint: number},
-      {category: table_calculation, description: for sorting plans by volume, expression: 'pivot_offset(${subscriptions__retention.previously_retained},
-          0)', label: Total Subscribers, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: measure, table_calculation: total_subscribers, _type_hint: number}]
+    dynamic_fields:
+    - category: measure
+      expression: |-
+        if(
+          ${subscriptions__retention.months_since_subscription_start} > 0,
+          ${subscriptions__retention.months_since_subscription_start} <= ${subscriptions.months_retained} + 1,
+          null
+        )
+      label: Previously Retained
+      based_on: subscriptions__retention.count
+      filter_expression: |-
+        if(
+          ${subscriptions__retention.months_since_subscription_start} > 0,
+          ${subscriptions__retention.months_since_subscription_start} <= ${subscriptions.months_retained} + 1,
+          null
+        )
+      _kind_hint: measure
+      measure: previously_retained
+      type: count
+      _type_hint: number
+    - category: measure
+      expression: "${subscriptions__retention.months_since_subscription_start} = ${subscriptions.months_retained}\
+        \ + 1"
+      label: Churned
+      based_on: subscriptions__retention.count
+      filter_expression: "${subscriptions__retention.months_since_subscription_start}\
+        \ = ${subscriptions.months_retained} + 1"
+      _kind_hint: measure
+      measure: churned
+      type: count
+      _type_hint: number
+    - category: table_calculation
+      expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}"
+      label: Churn Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: churn_rate
+      _type_hint: number
+    - category: table_calculation
+      expression: max(pivot_row(if(is_null(${subscriptions__retention.previously_retained}),null,${subscriptions__retention.months_since_subscription_start})))
+      label: Months Since Plan Start
+      value_format:
+      value_format_name:
+      _kind_hint: supermeasure
+      table_calculation: months_since_plan_start
+      _type_hint: number
+    - category: table_calculation
+      description: for sorting plans by volume
+      expression: pivot_offset(${subscriptions__retention.previously_retained}, 0)
+      label: Total Subscribers
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: total_subscribers
+      _type_hint: number
     show_view_names: false
     show_row_numbers: false
     transpose: false
@@ -772,22 +879,14 @@
       subscriptions__retention.months_since_subscription_start: Months Since Subscription
         Start
     series_column_widths:
-      subscriptions.subscription_start_month: 243
-      churned: 115
       churn_rate: 115
-      subscriptions.pricing_plan: 256
       subscriptions.plan_interval_type: 243
     series_cell_visualizations:
       churned:
         is_active: false
     series_text_format:
-      subscriptions.subscription_start_month:
-        align: center
-        bold: true
       churn_rate:
         align: center
-      subscriptions.pricing_plan:
-        bold: true
     header_background_color: "#D8D8D8"
     conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
         font_color: !!null '', color_application: {collection_id: mozilla, palette_id: mozilla-sequential-0,
@@ -810,7 +909,6 @@
     trellis: ''
     stacking: ''
     legend_position: left
-    series_types: {}
     point_style: circle_outline
     show_value_labels: false
     label_density: 25
@@ -836,6 +934,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_date
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Plan ID: subscriptions.plan_id
     row: 29
     col: 0
     width: 24
@@ -854,15 +955,33 @@
     sorts: [subscriptions__retention.months_since_subscription_start, subscriptions__retention.churned
         desc 0]
     total: true
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}",
-        label: Churn Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: churn_rate, _type_hint: number, is_disabled: true},
-      {category: table_calculation, expression: 'max(pivot_row(if(is_null(${subscriptions__retention.previously_retained}),null,${subscriptions__retention.months_since_subscription_start})))',
-        label: Months Since Plan Start, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: supermeasure, table_calculation: months_since_plan_start, _type_hint: number},
-      {category: table_calculation, description: for sorting plans by volume, expression: 'pivot_offset(${subscriptions__retention.previously_retained},
-          0)', label: Total Subscribers, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: measure, table_calculation: total_subscribers, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}"
+      label: Churn Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: churn_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: max(pivot_row(if(is_null(${subscriptions__retention.previously_retained}),null,${subscriptions__retention.months_since_subscription_start})))
+      label: Months Since Plan Start
+      value_format:
+      value_format_name:
+      _kind_hint: supermeasure
+      table_calculation: months_since_plan_start
+      _type_hint: number
+    - category: table_calculation
+      description: for sorting plans by volume
+      expression: pivot_offset(${subscriptions__retention.previously_retained}, 0)
+      label: Total Subscribers
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: total_subscribers
+      _type_hint: number
     show_view_names: false
     show_row_numbers: false
     transpose: false
@@ -888,23 +1007,11 @@
       subscriptions__retention.months_since_subscription_start: Months Since Subscription
         Start
     series_column_widths:
-      subscriptions.subscription_start_month: 243
-      churned: 115
-      churn_rate: 115
-      subscriptions.pricing_plan: 256
       subscriptions.plan_interval_type: 243
       subscriptions__retention.churned: 115
     series_cell_visualizations:
       churned:
         is_active: false
-    series_text_format:
-      subscriptions.subscription_start_month:
-        align: center
-        bold: true
-      churn_rate:
-        align: center
-      subscriptions.pricing_plan:
-        bold: true
     header_background_color: "#D8D8D8"
     conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
         font_color: !!null '', color_application: {collection_id: mozilla, palette_id: mozilla-sequential-0,
@@ -927,7 +1034,6 @@
     trellis: ''
     stacking: ''
     legend_position: left
-    series_types: {}
     point_style: circle_outline
     show_value_labels: false
     label_density: 25
@@ -952,6 +1058,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_date
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Plan ID: subscriptions.plan_id
     row: 35
     col: 0
     width: 24
@@ -971,15 +1080,32 @@
       months_since_plan_start desc 0, total_subscribers desc 0]
     limit: 1000
     column_limit: 50
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}",
-        label: Churn Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: churn_rate, _type_hint: number}, {
-        category: table_calculation, expression: 'max(pivot_row(if(is_null(${subscriptions__retention.previously_retained}),null,${subscriptions__retention.months_since_subscription_start})))',
-        label: Months Since Plan Start, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: supermeasure, table_calculation: months_since_plan_start, _type_hint: number},
-      {category: table_calculation, description: for sorting plans by volume, expression: 'pivot_offset(${subscriptions__retention.previously_retained},
-          0)', label: Total Subscribers, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: measure, table_calculation: total_subscribers, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.churned}/${subscriptions__retention.previously_retained}"
+      label: Churn Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: churn_rate
+      _type_hint: number
+    - category: table_calculation
+      expression: max(pivot_row(if(is_null(${subscriptions__retention.previously_retained}),null,${subscriptions__retention.months_since_subscription_start})))
+      label: Months Since Plan Start
+      value_format:
+      value_format_name:
+      _kind_hint: supermeasure
+      table_calculation: months_since_plan_start
+      _type_hint: number
+    - category: table_calculation
+      description: for sorting plans by volume
+      expression: pivot_offset(${subscriptions__retention.previously_retained}, 0)
+      label: Total Subscribers
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: total_subscribers
+      _type_hint: number
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -1010,7 +1136,6 @@
       options:
         steps: 5
     x_axis_label: Months Since Subscription Start
-    series_types: {}
     series_colors:
       1-month-usd-4.99 - churn_rate: "#7363A9"
       6-month-chf-47.94 - churn_rate: "#82a6a8"
@@ -1041,21 +1166,13 @@
     show_totals: true
     show_row_totals: true
     series_column_widths:
-      subscriptions.subscription_start_month: 243
-      churned: 115
       churn_rate: 115
-      subscriptions.pricing_plan: 256
     series_cell_visualizations:
       churned:
         is_active: false
     series_text_format:
-      subscriptions.subscription_start_month:
-        align: center
-        bold: true
       churn_rate:
         align: center
-      subscriptions.pricing_plan:
-        bold: true
     header_background_color: "#D8D8D8"
     conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
         font_color: !!null '', color_application: {collection_id: mozilla, palette_id: mozilla-sequential-0,
@@ -1077,6 +1194,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_date
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Plan ID: subscriptions.plan_id
     row: 23
     col: 0
     width: 24
@@ -1085,11 +1205,11 @@
   - name: Provider
     title: Provider
     type: field_filter
-    default_value: ''
+    default_value: "-NULL"
     allow_multiple_values: true
     required: false
     ui_config:
-      type: checkboxes
+      type: advanced
       display: popover
     model: mozilla_vpn
     explore: subscriptions
@@ -1179,3 +1299,42 @@
     explore: subscriptions
     listens_to_filters: []
     field: subscriptions.original_subscription_start_date
+  - name: Has Fraudulent Charges (Yes / No)
+    title: Has Fraudulent Charges (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: []
+    field: subscriptions.has_fraudulent_charges
+  - name: Has Fraudulent Charge Refunds (Yes / No)
+    title: Has Fraudulent Charge Refunds (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: []
+    field: subscriptions.has_fraudulent_charge_refunds
+  - name: Plan ID
+    title: Plan ID
+    type: field_filter
+    default_value: -"price_1MzNRCJNcmPzuWtRMCwUWADu"
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: overflow
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: []
+    field: subscriptions.plan_id

--- a/mozilla_vpn/dashboards/vpn_saasboard_retention.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_retention.dashboard.lookml
@@ -4,7 +4,7 @@
   preferred_viewer: dashboards-next
   crossfilter_enabled: true
   description: ''
-  refresh: 24 days 20 hrs 31 mins 23 secs
+  refresh: 2147484 seconds
   preferred_slug: Xy9m1LuSVOyM1ql8YcKOGA
   elements:
   - name: ''
@@ -176,6 +176,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 51
     col: 0
     width: 24
@@ -306,6 +309,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 58
     col: 0
     width: 24
@@ -456,6 +462,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 10
     col: 12
     width: 12
@@ -574,6 +583,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 10
     col: 0
     width: 12
@@ -616,6 +628,9 @@
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 2
     col: 19
     width: 5
@@ -849,6 +864,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 42
     col: 0
     width: 12
@@ -971,6 +989,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 29
     col: 0
     width: 24
@@ -1090,6 +1111,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 34
     col: 0
     width: 24
@@ -1215,6 +1239,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_month
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 23
     col: 0
     width: 24
@@ -1362,6 +1389,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 42
     col: 12
     width: 12
@@ -1489,6 +1519,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Plan ID: subscriptions.plan_id
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
     row: 68
     col: 0
     width: 24
@@ -1497,11 +1530,11 @@
   - name: Provider
     title: Provider
     type: field_filter
-    default_value: ''
+    default_value: "-NULL"
     allow_multiple_values: true
     required: false
     ui_config:
-      type: checkboxes
+      type: advanced
       display: popover
     model: mozilla_vpn
     explore: subscriptions
@@ -1591,3 +1624,42 @@
     explore: subscriptions
     listens_to_filters: []
     field: subscriptions.original_subscription_start_date
+  - name: Has Fraudulent Charge Refunds (Yes / No)
+    title: Has Fraudulent Charge Refunds (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: []
+    field: subscriptions.has_fraudulent_charge_refunds
+  - name: Has Fraudulent Charges (Yes / No)
+    title: Has Fraudulent Charges (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: []
+    field: subscriptions.has_fraudulent_charges
+  - name: Plan ID
+    title: Plan ID
+    type: field_filter
+    default_value: -"price_1MzNRCJNcmPzuWtRMCwUWADu"
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: overflow
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: []
+    field: subscriptions.plan_id

--- a/mozilla_vpn/dashboards/vpn_saasboard_retention.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_retention.dashboard.lookml
@@ -5,7 +5,7 @@
   crossfilter_enabled: true
   description: ''
   refresh: 2147484 seconds
-  preferred_slug: UODkAFmiugD1QWPubfsPSP
+  preferred_slug: Xy9m1LuSVOyM1ql8YcKOGA
   elements:
   - name: ''
     type: text
@@ -38,7 +38,6 @@
   - name: " (3)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |2-
 
 
@@ -65,12 +64,23 @@
       original_subscriptions__retention.is_cohort_complete: 'Yes'
     sorts: [subscriptions.original_subscription_start_month]
     total: true
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.retained}/${subscriptions.count}",
-        label: Retention Rate, value_format_name: percent_2, _kind_hint: measure,
-        table_calculation: retention_rate, _type_hint: number, is_disabled: true},
-      {category: table_calculation, expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}",
-        label: Total Retention Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_retention_rate, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.retained}/${subscriptions.count}"
+      label: Retention Rate
+      value_format_name: percent_2
+      _kind_hint: measure
+      table_calculation: retention_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}"
+      label: Total Retention Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_retention_rate
+      _type_hint: number
     show_view_names: false
     show_row_numbers: false
     transpose: false
@@ -94,19 +104,9 @@
       subscriptions.subscription_start_month: Cohort
       subscriptions__retention.months_since_subscription_start: Months Since Subscription
         Start
-    series_column_widths:
-      subscriptions.subscription_start_month: 243
-      retention_rate: 115
     series_cell_visualizations:
       subscriptions__retention.age_in_months:
         is_active: false
-    series_text_format:
-      subscriptions__retention.age_in_months: {}
-      retention_rate:
-        align: center
-      subscriptions.subscription_start_month:
-        bold: true
-        align: center
     header_background_color: "#D8D8D8"
     conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
         font_color: !!null '', color_application: {collection_id: mozilla, custom: {
@@ -116,13 +116,6 @@
               min: {type: minimum}, mid: {type: number, value: 0}, max: {type: maximum}},
             mirror: false, reverse: false, stepped: true}}, bold: false, italic: false,
         strikethrough: false, fields: !!null ''}]
-    series_value_format:
-      retention_rate:
-        name: percent_1
-        decimals: '1'
-        format_string: "#,##0.0%"
-        label: Percent (1)
-        label_prefix: Percent
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_y_axis_labels: true
@@ -175,7 +168,6 @@
         unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     defaults_version: 1
     hidden_fields: [original_subscriptions__retention.retained, original_subscriptions__retention.subscription_count]
-    series_types: {}
     hidden_pivots: {}
     listen:
       Country: subscriptions.country_name
@@ -184,7 +176,143 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 51
+    col: 0
+    width: 24
+    height: 7
+  - title: Retention Counts Table (by Cohort)
+    name: Retention Counts Table (by Cohort)
+    model: mozilla_vpn
+    explore: subscriptions
+    type: looker_grid
+    fields: [original_subscriptions__retention.months_since_original_subscription_start,
+      original_subscriptions__retention.retained, original_subscriptions__retention.subscription_count,
+      subscriptions.original_subscription_start_month]
+    pivots: [original_subscriptions__retention.months_since_original_subscription_start]
+    fill_fields: [subscriptions.original_subscription_start_month]
+    filters:
+      original_subscriptions__retention.is_cohort_complete: 'Yes'
+    sorts: [subscriptions.original_subscription_start_month]
+    total: true
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.retained}/${subscriptions.count}"
+      label: Retention Rate
+      value_format_name: percent_2
+      _kind_hint: measure
+      table_calculation: retention_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}"
+      label: Total Retention Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_retention_rate
+      _type_hint: number
+    show_view_names: false
+    show_row_numbers: false
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: true
+    header_text_alignment: center
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    series_labels:
+      subscriptions__retention.age_in_months: Months Since Subcription Started
+      subscriptions.subscription_start_month: Cohort
+      subscriptions__retention.months_since_subscription_start: Months Since Subscription
+        Start
+    series_cell_visualizations:
+      subscriptions__retention.age_in_months:
+        is_active: false
+    header_background_color: "#D8D8D8"
+    conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
+        font_color: !!null '', color_application: {collection_id: mozilla, custom: {
+            id: 0a238a55-cee3-6513-fab8-e325a1654f8e, label: Custom, type: continuous,
+            stops: [{color: "#fff", offset: 0}, {color: "#a5e6ff", offset: 50}, {
+                color: "#0060E0", offset: 100}]}, options: {steps: 100, constraints: {
+              min: {type: minimum}, mid: {type: number, value: 0}, max: {type: maximum}},
+            mirror: false, reverse: false, stepped: true}}, bold: false, italic: false,
+        strikethrough: false, fields: !!null ''}]
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: pivot
+    stacking: ''
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    y_axes: [{label: '', orientation: left, series: [{axisId: retention_rate, id: 2019-10
+              - retention_rate, name: 2019-10}, {axisId: retention_rate, id: 2019-11
+              - retention_rate, name: 2019-11}, {axisId: retention_rate, id: 2019-12
+              - retention_rate, name: 2019-12}, {axisId: retention_rate, id: 2020-01
+              - retention_rate, name: 2020-01}, {axisId: retention_rate, id: 2020-02
+              - retention_rate, name: 2020-02}, {axisId: retention_rate, id: 2020-03
+              - retention_rate, name: 2020-03}, {axisId: retention_rate, id: 2020-04
+              - retention_rate, name: 2020-04}, {axisId: retention_rate, id: 2020-05
+              - retention_rate, name: 2020-05}, {axisId: retention_rate, id: 2020-06
+              - retention_rate, name: 2020-06}, {axisId: retention_rate, id: 2020-07
+              - retention_rate, name: 2020-07}, {axisId: retention_rate, id: 2020-08
+              - retention_rate, name: 2020-08}, {axisId: retention_rate, id: 2020-09
+              - retention_rate, name: 2020-09}, {axisId: retention_rate, id: 2020-10
+              - retention_rate, name: 2020-10}, {axisId: retention_rate, id: 2020-11
+              - retention_rate, name: 2020-11}, {axisId: retention_rate, id: 2020-12
+              - retention_rate, name: 2020-12}, {axisId: retention_rate, id: 2021-01
+              - retention_rate, name: 2021-01}, {axisId: retention_rate, id: 2021-02
+              - retention_rate, name: 2021-02}, {axisId: retention_rate, id: 2021-03
+              - retention_rate, name: 2021-03}, {axisId: retention_rate, id: 2021-04
+              - retention_rate, name: 2021-04}, {axisId: retention_rate, id: 2021-05
+              - retention_rate, name: 2021-05}, {axisId: retention_rate, id: 2021-06
+              - retention_rate, name: 2021-06}, {axisId: retention_rate, id: 2021-07
+              - retention_rate, name: 2021-07}, {axisId: retention_rate, id: 2021-08
+              - retention_rate, name: 2021-08}], showLabels: true, showValues: true,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    defaults_version: 1
+    hidden_fields: [original_subscriptions__retention.subscription_count, total_retention_rate]
+    hidden_pivots: {}
+    listen:
+      Country: subscriptions.country_name
+      Pricing Plan: subscriptions.pricing_plan
+      Provider: subscriptions.provider
+      Plan Interval Type: subscriptions.plan_interval_type
+      Product Name: subscriptions.product_name
+      Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
+    row: 58
     col: 0
     width: 24
     height: 7
@@ -199,27 +327,66 @@
     filters:
       original_subscriptions__retention.is_cohort_complete: 'Yes'
     sorts: [subscriptions.original_subscription_start_month desc]
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.retained}/${subscriptions.count}",
-        label: Retention Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: retention_rate, _type_hint: number,
-        is_disabled: true}, {category: table_calculation, expression: "${subscriptions.count}-${subscriptions__retention.retained}",
-        label: Not Retained, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: measure, table_calculation: not_retained, _type_hint: number,
-        is_disabled: true}, {category: measure, expression: !!null '', label: Filtered
-          Retention - Retained - Updated, value_format: !!null '', value_format_name: !!null '',
-        based_on: subscriptions__retention.retained, _kind_hint: measure, measure: filtered_retention_retained_updated,
-        type: count_distinct, _type_hint: number, filters: {subscriptions.is_ended: 'No'}},
-      {category: table_calculation, expression: "${filtered_retention_retained_updated}/${subscriptions.count}",
-        label: Retention Rate - Updated, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: retention_rate_updated, _type_hint: number,
-        is_disabled: true}, {category: measure, expression: !!null '', label: Filtered
-          Original Subscription Retention - Retained - Updated, value_format: !!null '',
-        value_format_name: !!null '', based_on: original_subscriptions__retention.retained,
-        _kind_hint: measure, measure: filtered_original_subscription_retention_retained_updated,
-        type: count_distinct, _type_hint: number, filters: {subscriptions.is_ended: 'No'}},
-      {category: table_calculation, expression: "${filtered_original_subscription_retention_retained_updated}/${original_subscriptions__retention.subscription_count}",
-        label: Total Rentention Rate - Updated, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_rentention_rate_updated, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.retained}/${subscriptions.count}"
+      label: Retention Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: retention_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${subscriptions.count}-${subscriptions__retention.retained}"
+      label: Not Retained
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: not_retained
+      _type_hint: number
+      is_disabled: true
+    - category: measure
+      expression:
+      label: Filtered Retention - Retained - Updated
+      value_format:
+      value_format_name:
+      based_on: subscriptions__retention.retained
+      _kind_hint: measure
+      measure: filtered_retention_retained_updated
+      type: count_distinct
+      _type_hint: number
+      filters:
+        subscriptions.is_ended: 'No'
+    - category: table_calculation
+      expression: "${filtered_retention_retained_updated}/${subscriptions.count}"
+      label: Retention Rate - Updated
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: retention_rate_updated
+      _type_hint: number
+      is_disabled: true
+    - category: measure
+      expression:
+      label: Filtered Original Subscription Retention - Retained - Updated
+      value_format:
+      value_format_name:
+      based_on: original_subscriptions__retention.retained
+      _kind_hint: measure
+      measure: filtered_original_subscription_retention_retained_updated
+      type: count_distinct
+      _type_hint: number
+      filters:
+        subscriptions.is_ended: 'No'
+    - category: table_calculation
+      expression: "${filtered_original_subscription_retention_retained_updated}/${original_subscriptions__retention.subscription_count}"
+      label: Total Rentention Rate - Updated
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_rentention_rate_updated
+      _type_hint: number
     x_axis_gridlines: true
     y_axis_gridlines: true
     show_view_names: false
@@ -264,8 +431,6 @@
     y_axis_zoom: true
     hidden_series: [subscriptions.count]
     series_types:
-      retention_rate: line
-      retention_rate_updated: line
       total_rentention_rate_updated: line
     series_colors:
       retained: "#0060E0"
@@ -297,6 +462,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 10
     col: 12
     width: 12
@@ -311,15 +479,33 @@
     filters:
       original_subscriptions__retention.is_cohort_complete: 'Yes'
     sorts: [original_subscriptions__retention.retained desc]
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.retained}/${subscriptions.count}",
-        label: Retention Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: retention_rate, _type_hint: number,
-        is_disabled: true}, {category: table_calculation, expression: "${subscriptions.count}-${subscriptions__retention.retained}",
-        label: Not Retained, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: measure, table_calculation: not_retained, _type_hint: number,
-        is_disabled: true}, {category: table_calculation, expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}",
-        label: Total Retention Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_retention_rate, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.retained}/${subscriptions.count}"
+      label: Retention Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: retention_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${subscriptions.count}-${subscriptions__retention.retained}"
+      label: Not Retained
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: not_retained
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}"
+      label: Total Retention Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_retention_rate
+      _type_hint: number
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -365,7 +551,6 @@
     x_axis_zoom: true
     y_axis_zoom: true
     series_types:
-      retention_rate: line
       total_retention_rate: line
     series_colors:
       retention_rate: "#000000"
@@ -398,6 +583,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 10
     col: 0
     width: 12
@@ -411,9 +599,15 @@
     fill_fields: [metadata.last_modified_date]
     sorts: [metadata.last_modified_date desc]
     limit: 1
-    dynamic_fields: [{category: table_calculation, expression: 'add_days(-1, ${metadata.last_modified_date})',
-        label: New Calculation, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: dimension, table_calculation: new_calculation, _type_hint: date}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: add_days(-1, ${metadata.last_modified_date})
+      label: New Calculation
+      value_format:
+      value_format_name:
+      _kind_hint: dimension
+      table_calculation: new_calculation
+      _type_hint: date
     custom_color_enabled: true
     show_single_value_title: true
     show_comparison: false
@@ -424,7 +618,6 @@
     conditional_formatting_include_totals: false
     conditional_formatting_include_nulls: false
     single_value_title: Data Last Updated
-    series_types: {}
     defaults_version: 1
     hidden_fields: [metadata.last_modified_date]
     listen:
@@ -435,6 +628,9 @@
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
       Subscription Start Date: subscriptions.subscription_start_month
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 2
     col: 19
     width: 5
@@ -442,7 +638,6 @@
   - name: " (4)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |2-
 
 
@@ -458,7 +653,6 @@
   - name: " (5)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |2-
 
 
@@ -474,7 +668,6 @@
   - name: " (6)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |2-
 
 
@@ -533,12 +726,24 @@
     filters:
       original_subscriptions__retention.is_cohort_complete: 'Yes'
     sorts: [subscriptions.original_subscription_start_month, original_subscriptions__retention.months_since_original_subscription_start]
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.retained}/${subscriptions.count}",
-        label: Retention Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: retention_rate, _type_hint: number,
-        is_disabled: true}, {category: table_calculation, expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}",
-        label: Total Retention Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_retention_rate, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.retained}/${subscriptions.count}"
+      label: Retention Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: retention_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}"
+      label: Total Retention Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_retention_rate
+      _type_hint: number
     x_axis_gridlines: true
     y_axis_gridlines: true
     show_view_names: false
@@ -592,7 +797,6 @@
     x_axis_zoom: true
     y_axis_zoom: true
     hidden_series: []
-    series_types: {}
     series_labels:
       0 - retention_rate: Month 0
       1 - retention_rate: Month 1
@@ -660,6 +864,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 42
     col: 0
     width: 12
@@ -677,15 +884,32 @@
     sorts: [subscriptions__retention.months_since_subscription_start]
     column_limit: 50
     total: true
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.retained}/${subscriptions.count}",
-        label: Retention Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: retention_rate, _type_hint: number},
-      {category: table_calculation, expression: 'max(pivot_row(if(is_null(${subscriptions.count}),null,${subscriptions__retention.months_since_subscription_start})))',
-        label: Months Since Plan Start, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: supermeasure, table_calculation: months_since_plan_start, _type_hint: number},
-      {category: table_calculation, description: for sorting plans by volume, expression: 'pivot_offset(${subscriptions.count},
-          0)', label: Total Subscribers, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: measure, table_calculation: total_subscribers, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.retained}/${subscriptions.count}"
+      label: Retention Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: retention_rate
+      _type_hint: number
+    - category: table_calculation
+      expression: max(pivot_row(if(is_null(${subscriptions.count}),null,${subscriptions__retention.months_since_subscription_start})))
+      label: Months Since Plan Start
+      value_format:
+      value_format_name:
+      _kind_hint: supermeasure
+      table_calculation: months_since_plan_start
+      _type_hint: number
+    - category: table_calculation
+      description: for sorting plans by volume
+      expression: pivot_offset(${subscriptions.count}, 0)
+      label: Total Subscribers
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: total_subscribers
+      _type_hint: number
     show_view_names: false
     show_row_numbers: false
     transpose: false
@@ -718,8 +942,6 @@
     series_text_format:
       retention_rate:
         align: center
-      subscriptions.pricing_plan:
-        bold: true
       subscriptions__retention.months_since_subscription_start:
         align: center
     header_background_color: "#D8D8D8"
@@ -760,7 +982,6 @@
     hidden_fields: [subscriptions.count, new_calculation, months_since_plan_start,
       pricing_plan_for_sorting, total_subscriptions, total_subscriptions_for_sorting,
       total_subscribers, subscriptions__retention.retained]
-    series_types: {}
     listen:
       Country: subscriptions.country_name
       Pricing Plan: subscriptions.pricing_plan
@@ -768,6 +989,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_month
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 29
     col: 0
     width: 24
@@ -785,15 +1009,31 @@
     sorts: [subscriptions__retention.months_since_subscription_start]
     column_limit: 50
     total: true
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.retained}/${subscriptions.count}",
-        label: Retention Rate, value_format_name: percent_2, _kind_hint: measure,
-        table_calculation: retention_rate, _type_hint: number}, {category: table_calculation,
-        expression: 'max(pivot_row(if(is_null(${subscriptions.count}),null,${subscriptions__retention.months_since_subscription_start})))',
-        label: Months Since Plan Start, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: supermeasure, table_calculation: months_since_plan_start, _type_hint: number},
-      {category: table_calculation, description: for sorting plans by volume, expression: 'pivot_offset(${subscriptions.count},
-          0)', label: Total Subscribers, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: measure, table_calculation: total_subscribers, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.retained}/${subscriptions.count}"
+      label: Retention Rate
+      value_format_name: percent_2
+      _kind_hint: measure
+      table_calculation: retention_rate
+      _type_hint: number
+    - category: table_calculation
+      expression: max(pivot_row(if(is_null(${subscriptions.count}),null,${subscriptions__retention.months_since_subscription_start})))
+      label: Months Since Plan Start
+      value_format:
+      value_format_name:
+      _kind_hint: supermeasure
+      table_calculation: months_since_plan_start
+      _type_hint: number
+    - category: table_calculation
+      description: for sorting plans by volume
+      expression: pivot_offset(${subscriptions.count}, 0)
+      label: Total Subscribers
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: total_subscribers
+      _type_hint: number
     show_view_names: false
     show_row_numbers: false
     transpose: false
@@ -826,8 +1066,6 @@
         is_active: false
     series_text_format:
       retention_rate: {}
-      subscriptions.pricing_plan:
-        bold: true
     header_background_color: "#D8D8D8"
     conditional_formatting: [{type: along a scale..., value: !!null '', background_color: !!null '',
         font_color: !!null '', color_application: {collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e,
@@ -866,7 +1104,6 @@
     hidden_fields: [subscriptions.count, new_calculation, months_since_plan_start,
       pricing_plan_for_sorting, total_subscriptions, total_subscriptions_for_sorting,
       total_subscribers, retention_rate]
-    series_types: {}
     listen:
       Country: subscriptions.country_name
       Pricing Plan: subscriptions.pricing_plan
@@ -874,6 +1111,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_month
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 34
     col: 0
     width: 24
@@ -892,15 +1132,32 @@
       months_since_plan_start desc 0, total_subscribers desc 0]
     limit: 1000
     column_limit: 50
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.retained}/${subscriptions.count}",
-        label: Retention Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: retention_rate, _type_hint: number},
-      {category: table_calculation, expression: 'max(pivot_row(if(is_null(${subscriptions.count}),null,${subscriptions__retention.months_since_subscription_start})))',
-        label: Months Since Plan Start, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: supermeasure, table_calculation: months_since_plan_start, _type_hint: number},
-      {category: table_calculation, description: for sorting plans by volume, expression: 'pivot_offset(${subscriptions.count},
-          0)', label: Total Subscribers, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: measure, table_calculation: total_subscribers, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.retained}/${subscriptions.count}"
+      label: Retention Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: retention_rate
+      _type_hint: number
+    - category: table_calculation
+      expression: max(pivot_row(if(is_null(${subscriptions.count}),null,${subscriptions__retention.months_since_subscription_start})))
+      label: Months Since Plan Start
+      value_format:
+      value_format_name:
+      _kind_hint: supermeasure
+      table_calculation: months_since_plan_start
+      _type_hint: number
+    - category: table_calculation
+      description: for sorting plans by volume
+      expression: pivot_offset(${subscriptions.count}, 0)
+      label: Total Subscribers
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: total_subscribers
+      _type_hint: number
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -931,7 +1188,6 @@
       options:
         steps: 5
     x_axis_label: Months Since Subscription Start
-    series_types: {}
     series_colors:
       1-month-usd-4.99 - retention_rate: "#7363A9"
       6-month-chf-47.94 - retention_rate: "#82a6a8"
@@ -960,8 +1216,6 @@
         is_active: false
     series_text_format:
       retention_rate: {}
-      subscriptions.pricing_plan:
-        bold: true
     header_background_color: "#D8D8D8"
     conditional_formatting: [{type: along a scale..., value: !!null '', background_color: !!null '',
         font_color: !!null '', color_application: {collection_id: 5f313589-67ce-44ba-b084-ec5107a7bb7e,
@@ -985,6 +1239,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_month
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 23
     col: 0
     width: 24
@@ -1002,12 +1259,24 @@
     filters:
       original_subscriptions__retention.is_cohort_complete: 'Yes'
     sorts: [original_subscriptions__retention.retained desc 0, subscriptions.original_subscription_start_month]
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.retained}/${subscriptions.count}",
-        label: Retention Rate, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: retention_rate, _type_hint: number,
-        is_disabled: true}, {category: table_calculation, expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}",
-        label: Total Retention Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_retention_rate, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${subscriptions__retention.retained}/${subscriptions.count}"
+      label: Retention Rate
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: retention_rate
+      _type_hint: number
+      is_disabled: true
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}"
+      label: Total Retention Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_retention_rate
+      _type_hint: number
     x_axis_gridlines: true
     y_axis_gridlines: true
     show_view_names: false
@@ -1059,7 +1328,6 @@
         unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: ''
     hidden_series: []
-    series_types: {}
     series_labels:
       0 - retention_rate: Month 0
       1 - retention_rate: Month 1
@@ -1121,6 +1389,9 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 42
     col: 12
     width: 12
@@ -1139,9 +1410,15 @@
     sorts: [original_subscriptions__retention.months_since_original_subscription_start,
       subscriptions.forecast_region]
     total: true
-    dynamic_fields: [{category: table_calculation, expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}",
-        label: Total Retention Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_retention_rate, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}"
+      label: Total Retention Rate
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      table_calculation: total_retention_rate
+      _type_hint: number
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -1194,7 +1471,6 @@
     x_axis_zoom: true
     y_axis_zoom: true
     trellis_rows: 1
-    series_types: {}
     series_labels:
       subscriptions__retention.age_in_months: Months Since Subcription Started
       subscriptions.subscription_start_month: Cohort
@@ -1216,19 +1492,9 @@
     show_sql_query_menu_options: false
     show_totals: true
     show_row_totals: true
-    series_column_widths:
-      subscriptions.subscription_start_month: 243
-      retention_rate: 115
     series_cell_visualizations:
       subscriptions__retention.age_in_months:
         is_active: false
-    series_text_format:
-      subscriptions__retention.age_in_months: {}
-      retention_rate:
-        align: center
-      subscriptions.subscription_start_month:
-        bold: true
-        align: center
     header_background_color: "#D8D8D8"
     conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
         font_color: !!null '', color_application: {collection_id: mozilla, custom: {
@@ -1238,13 +1504,6 @@
               min: {type: minimum}, mid: {type: number, value: 0}, max: {type: maximum}},
             mirror: false, reverse: false, stepped: true}}, bold: false, italic: false,
         strikethrough: false, fields: !!null ''}]
-    series_value_format:
-      retention_rate:
-        name: percent_1
-        decimals: '1'
-        format_string: "#,##0.0%"
-        label: Percent (1)
-        label_prefix: Percent
     ordering: none
     show_null_labels: false
     show_totals_labels: false
@@ -1260,144 +1519,10 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
+      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
+      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
+      Plan ID: subscriptions.plan_id
     row: 68
-    col: 0
-    width: 24
-    height: 7
-  - title: Retention Counts Table (by Cohort)
-    name: Retention Counts Table (by Cohort)
-    model: mozilla_vpn
-    explore: subscriptions
-    type: looker_grid
-    fields: [original_subscriptions__retention.months_since_original_subscription_start,
-      original_subscriptions__retention.retained, original_subscriptions__retention.subscription_count,
-      subscriptions.original_subscription_start_month]
-    pivots: [original_subscriptions__retention.months_since_original_subscription_start]
-    fill_fields: [subscriptions.original_subscription_start_month]
-    filters:
-      original_subscriptions__retention.is_cohort_complete: 'Yes'
-    sorts: [subscriptions.original_subscription_start_month]
-    total: true
-    dynamic_fields: [{category: table_calculation, expression: "${subscriptions__retention.retained}/${subscriptions.count}",
-        label: Retention Rate, value_format_name: percent_2, _kind_hint: measure,
-        table_calculation: retention_rate, _type_hint: number, is_disabled: true},
-      {category: table_calculation, expression: "${original_subscriptions__retention.retained}/${original_subscriptions__retention.subscription_count}",
-        label: Total Retention Rate, value_format: !!null '', value_format_name: percent_0,
-        _kind_hint: measure, table_calculation: total_retention_rate, _type_hint: number}]
-    show_view_names: false
-    show_row_numbers: false
-    transpose: false
-    truncate_text: true
-    hide_totals: false
-    hide_row_totals: false
-    size_to_fit: true
-    table_theme: white
-    limit_displayed_rows: false
-    enable_conditional_formatting: true
-    header_text_alignment: center
-    header_font_size: '12'
-    rows_font_size: '12'
-    conditional_formatting_include_totals: false
-    conditional_formatting_include_nulls: false
-    show_sql_query_menu_options: false
-    show_totals: true
-    show_row_totals: true
-    series_labels:
-      subscriptions__retention.age_in_months: Months Since Subcription Started
-      subscriptions.subscription_start_month: Cohort
-      subscriptions__retention.months_since_subscription_start: Months Since Subscription
-        Start
-    series_column_widths:
-      subscriptions.subscription_start_month: 243
-      retention_rate: 115
-    series_cell_visualizations:
-      subscriptions__retention.age_in_months:
-        is_active: false
-    series_text_format:
-      subscriptions__retention.age_in_months: {}
-      retention_rate:
-        align: center
-      subscriptions.subscription_start_month:
-        bold: true
-        align: center
-    header_background_color: "#D8D8D8"
-    conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
-        font_color: !!null '', color_application: {collection_id: mozilla, custom: {
-            id: 0a238a55-cee3-6513-fab8-e325a1654f8e, label: Custom, type: continuous,
-            stops: [{color: "#fff", offset: 0}, {color: "#a5e6ff", offset: 50}, {
-                color: "#0060E0", offset: 100}]}, options: {steps: 100, constraints: {
-              min: {type: minimum}, mid: {type: number, value: 0}, max: {type: maximum}},
-            mirror: false, reverse: false, stepped: true}}, bold: false, italic: false,
-        strikethrough: false, fields: !!null ''}]
-    series_value_format:
-      retention_rate:
-        name: percent_1
-        decimals: '1'
-        format_string: "#,##0.0%"
-        label: Percent (1)
-        label_prefix: Percent
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: pivot
-    stacking: ''
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    y_axes: [{label: '', orientation: left, series: [{axisId: retention_rate, id: 2019-10
-              - retention_rate, name: 2019-10}, {axisId: retention_rate, id: 2019-11
-              - retention_rate, name: 2019-11}, {axisId: retention_rate, id: 2019-12
-              - retention_rate, name: 2019-12}, {axisId: retention_rate, id: 2020-01
-              - retention_rate, name: 2020-01}, {axisId: retention_rate, id: 2020-02
-              - retention_rate, name: 2020-02}, {axisId: retention_rate, id: 2020-03
-              - retention_rate, name: 2020-03}, {axisId: retention_rate, id: 2020-04
-              - retention_rate, name: 2020-04}, {axisId: retention_rate, id: 2020-05
-              - retention_rate, name: 2020-05}, {axisId: retention_rate, id: 2020-06
-              - retention_rate, name: 2020-06}, {axisId: retention_rate, id: 2020-07
-              - retention_rate, name: 2020-07}, {axisId: retention_rate, id: 2020-08
-              - retention_rate, name: 2020-08}, {axisId: retention_rate, id: 2020-09
-              - retention_rate, name: 2020-09}, {axisId: retention_rate, id: 2020-10
-              - retention_rate, name: 2020-10}, {axisId: retention_rate, id: 2020-11
-              - retention_rate, name: 2020-11}, {axisId: retention_rate, id: 2020-12
-              - retention_rate, name: 2020-12}, {axisId: retention_rate, id: 2021-01
-              - retention_rate, name: 2021-01}, {axisId: retention_rate, id: 2021-02
-              - retention_rate, name: 2021-02}, {axisId: retention_rate, id: 2021-03
-              - retention_rate, name: 2021-03}, {axisId: retention_rate, id: 2021-04
-              - retention_rate, name: 2021-04}, {axisId: retention_rate, id: 2021-05
-              - retention_rate, name: 2021-05}, {axisId: retention_rate, id: 2021-06
-              - retention_rate, name: 2021-06}, {axisId: retention_rate, id: 2021-07
-              - retention_rate, name: 2021-07}, {axisId: retention_rate, id: 2021-08
-              - retention_rate, name: 2021-08}], showLabels: true, showValues: true,
-        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
-    defaults_version: 1
-    hidden_fields: [original_subscriptions__retention.subscription_count, total_retention_rate]
-    series_types: {}
-    hidden_pivots: {}
-    listen:
-      Country: subscriptions.country_name
-      Pricing Plan: subscriptions.pricing_plan
-      Provider: subscriptions.provider
-      Plan Interval Type: subscriptions.plan_interval_type
-      Product Name: subscriptions.product_name
-      Original Subscription Start Date: subscriptions.original_subscription_start_date
-    row: 58
     col: 0
     width: 24
     height: 7
@@ -1405,11 +1530,11 @@
   - name: Provider
     title: Provider
     type: field_filter
-    default_value: ''
+    default_value: "-NULL"
     allow_multiple_values: true
     required: false
     ui_config:
-      type: checkboxes
+      type: advanced
       display: popover
     model: mozilla_vpn
     explore: subscriptions
@@ -1499,3 +1624,42 @@
     explore: subscriptions
     listens_to_filters: []
     field: subscriptions.original_subscription_start_date
+  - name: Has Fraudulent Charge Refunds (Yes / No)
+    title: Has Fraudulent Charge Refunds (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: []
+    field: subscriptions.has_fraudulent_charge_refunds
+  - name: Has Fraudulent Charges (Yes / No)
+    title: Has Fraudulent Charges (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: []
+    field: subscriptions.has_fraudulent_charges
+  - name: Plan ID
+    title: Plan ID
+    type: field_filter
+    default_value: -"price_1MzNRCJNcmPzuWtRMCwUWADu"
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: overflow
+    model: mozilla_vpn
+    explore: subscriptions
+    listens_to_filters: []
+    field: subscriptions.plan_id

--- a/mozilla_vpn/dashboards/vpn_saasboard_retention.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_retention.dashboard.lookml
@@ -4,7 +4,7 @@
   preferred_viewer: dashboards-next
   crossfilter_enabled: true
   description: ''
-  refresh: 2147484 seconds
+  refresh: 24 days 20 hrs 31 mins 23 secs
   preferred_slug: Xy9m1LuSVOyM1ql8YcKOGA
   elements:
   - name: ''
@@ -176,9 +176,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 51
     col: 0
     width: 24
@@ -309,9 +306,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 58
     col: 0
     width: 24
@@ -462,9 +456,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 10
     col: 12
     width: 12
@@ -583,9 +574,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 10
     col: 0
     width: 12
@@ -628,9 +616,6 @@
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
       Subscription Start Date: subscriptions.subscription_start_month
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 2
     col: 19
     width: 5
@@ -864,9 +849,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 42
     col: 0
     width: 12
@@ -989,9 +971,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_month
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 29
     col: 0
     width: 24
@@ -1111,9 +1090,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_month
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 34
     col: 0
     width: 24
@@ -1239,9 +1215,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Subscription Start Date: subscriptions.subscription_start_month
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 23
     col: 0
     width: 24
@@ -1389,9 +1362,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 42
     col: 12
     width: 12
@@ -1519,9 +1489,6 @@
       Plan Interval Type: subscriptions.plan_interval_type
       Product Name: subscriptions.product_name
       Original Subscription Start Date: subscriptions.original_subscription_start_date
-      Has Fraudulent Charges (Yes / No): subscriptions.has_fraudulent_charges
-      Has Fraudulent Charge Refunds (Yes / No): subscriptions.has_fraudulent_charge_refunds
-      Plan ID: subscriptions.plan_id
     row: 68
     col: 0
     width: 24
@@ -1530,11 +1497,11 @@
   - name: Provider
     title: Provider
     type: field_filter
-    default_value: "-NULL"
+    default_value: ''
     allow_multiple_values: true
     required: false
     ui_config:
-      type: advanced
+      type: checkboxes
       display: popover
     model: mozilla_vpn
     explore: subscriptions
@@ -1624,42 +1591,3 @@
     explore: subscriptions
     listens_to_filters: []
     field: subscriptions.original_subscription_start_date
-  - name: Has Fraudulent Charge Refunds (Yes / No)
-    title: Has Fraudulent Charge Refunds (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: mozilla_vpn
-    explore: subscriptions
-    listens_to_filters: []
-    field: subscriptions.has_fraudulent_charge_refunds
-  - name: Has Fraudulent Charges (Yes / No)
-    title: Has Fraudulent Charges (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: mozilla_vpn
-    explore: subscriptions
-    listens_to_filters: []
-    field: subscriptions.has_fraudulent_charges
-  - name: Plan ID
-    title: Plan ID
-    type: field_filter
-    default_value: -"price_1MzNRCJNcmPzuWtRMCwUWADu"
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: advanced
-      display: overflow
-    model: mozilla_vpn
-    explore: subscriptions
-    listens_to_filters: []
-    field: subscriptions.plan_id

--- a/mozilla_vpn/dashboards/vpn_saasboard_revenue.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_revenue.dashboard.lookml
@@ -18,17 +18,34 @@
       active_subscriptions.is_end_of_month: 'Yes'
     sorts: [active_subscriptions.active_month]
     limit: 500
-    dynamic_fields: [{category: table_calculation, expression: "${active_subscriptions.count_sum}\
-          \ / offset(${active_subscriptions.count_sum}, -1) -1", label: Active Subscriptions,
-        value_format: !!null '', value_format_name: percent_1, _kind_hint: measure,
-        table_calculation: active_subscriptions, _type_hint: number}, {category: table_calculation,
-        expression: "${active_subscriptions.annual_recurring_revenue} / offset(${active_subscriptions.annual_recurring_revenue},\
-          \ -1) -1", label: Annual Recurring Revenue, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: annual_recurring_revenue_1, _type_hint: number},
-      {category: table_calculation, expression: "${active_subscriptions.monthly_recurring_revenue}\
-          \ / offset(${active_subscriptions.monthly_recurring_revenue}, -1) -1", label: Monthly
-          Recurring Revenue, value_format: !!null '', value_format_name: percent_1,
-        _kind_hint: measure, table_calculation: monthly_recurring_revenue, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${active_subscriptions.count_sum} / offset(${active_subscriptions.count_sum},\
+        \ -1) -1"
+      label: Active Subscriptions
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: active_subscriptions
+      _type_hint: number
+    - category: table_calculation
+      expression: "${active_subscriptions.annual_recurring_revenue} / offset(${active_subscriptions.annual_recurring_revenue},\
+        \ -1) -1"
+      label: Annual Recurring Revenue
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: annual_recurring_revenue_1
+      _type_hint: number
+    - category: table_calculation
+      expression: "${active_subscriptions.monthly_recurring_revenue} / offset(${active_subscriptions.monthly_recurring_revenue},\
+        \ -1) -1"
+      label: Monthly Recurring Revenue
+      value_format:
+      value_format_name: percent_1
+      _kind_hint: measure
+      table_calculation: monthly_recurring_revenue
+      _type_hint: number
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -60,7 +77,6 @@
     x_axis_label: Month
     font_size: ''
     label_value_format: 0.0%
-    series_types: {}
     series_colors:
       new_calculation: "#0060E0"
       active_subscribers: "#0060E0"
@@ -84,6 +100,7 @@
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
+      Plan ID: active_subscriptions.plan_id
     row: 33
     col: 12
     width: 12
@@ -167,7 +184,6 @@
     x_axis_label: Month
     font_size: 13px
     label_value_format: "$0.00,,"
-    series_types: {}
     series_colors:
       USA - active_subscriptions.annual_recurring_revenue: "#347be3"
     x_axis_datetime_label: ''
@@ -184,6 +200,7 @@
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
+      Plan ID: active_subscriptions.plan_id
     row: 24
     col: 0
     width: 12
@@ -240,7 +257,6 @@
     x_axis_label: Month
     font_size: 13px
     label_value_format: "$0.00,,"
-    series_types: {}
     series_colors:
       6-month-chf-47.94 - active_subscriptions.annual_recurring_revenue: "#82a6a8"
       1-month-usd-4.99 - active_subscriptions.annual_recurring_revenue: "#7363A9"
@@ -255,6 +271,7 @@
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
+      Plan ID: active_subscriptions.plan_id
     row: 24
     col: 12
     width: 12
@@ -302,9 +319,15 @@
     sorts: [metadata.last_modified_date desc]
     limit: 3
     column_limit: 50
-    dynamic_fields: [{category: table_calculation, expression: 'add_days(-1, ${metadata.last_modified_date})',
-        label: New Calculation, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: dimension, table_calculation: new_calculation, _type_hint: date}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: add_days(-1, ${metadata.last_modified_date})
+      label: New Calculation
+      value_format:
+      value_format_name:
+      _kind_hint: dimension
+      table_calculation: new_calculation
+      _type_hint: date
     custom_color_enabled: true
     show_single_value_title: true
     show_comparison: false
@@ -318,7 +341,6 @@
     conditional_formatting: [{type: not equal to, value: 0, background_color: "#cdbfff",
         font_color: !!null '', color_application: {collection_id: mozilla, palette_id: mozilla-sequential-0},
         bold: false, italic: false, strikethrough: false, fields: !!null ''}]
-    series_types: {}
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -347,7 +369,8 @@
     note_state: collapsed
     note_display: below
     hidden_fields: [metadata.last_modified_date]
-    listen: {}
+    listen:
+      Plan ID: active_subscriptions.plan_id
     row: 2
     col: 18
     width: 6
@@ -406,7 +429,6 @@
     x_axis_label: Month
     font_size: 13px
     label_value_format: "$0.00,,"
-    series_types: {}
     series_colors:
       USA - active_subscriptions.annual_recurring_revenue: "#347be3"
     x_axis_datetime_label: ''
@@ -423,6 +445,7 @@
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
+      Plan ID: active_subscriptions.plan_id
     row: 15
     col: 0
     width: 12
@@ -479,7 +502,6 @@
     x_axis_label: Month
     font_size: 13px
     label_value_format: "$0.00,,"
-    series_types: {}
     series_colors:
       6-month-chf-47.94 - active_subscriptions.annual_recurring_revenue: "#82a6a8"
       1-month-usd-4.99 - active_subscriptions.annual_recurring_revenue: "#7363A9"
@@ -494,6 +516,7 @@
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
+      Plan ID: active_subscriptions.plan_id
     row: 15
     col: 12
     width: 12
@@ -511,9 +534,15 @@
     sorts: [active_subscriptions.active_month desc]
     limit: 500
     column_limit: 50
-    dynamic_fields: [{category: table_calculation, expression: "${active_subscriptions.monthly_recurring_revenue}/${active_subscriptions.count_sum}",
-        label: ARPU(MRR/EoM Active subs), value_format: !!null '', value_format_name: decimal_1,
-        _kind_hint: measure, table_calculation: arpumrreom_active_subs, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${active_subscriptions.monthly_recurring_revenue}/${active_subscriptions.count_sum}"
+      label: ARPU(MRR/EoM Active subs)
+      value_format:
+      value_format_name: decimal_1
+      _kind_hint: measure
+      table_calculation: arpumrreom_active_subs
+      _type_hint: number
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -579,6 +608,7 @@
       Country: active_subscriptions.country_name
       Active Date: active_subscriptions.active_date
       Plan Interval Type: active_subscriptions.plan_interval_type
+      Plan ID: active_subscriptions.plan_id
     row: 6
     col: 0
     width: 24
@@ -587,11 +617,11 @@
   - name: Provider
     title: Provider
     type: field_filter
-    default_value: ''
+    default_value: "-NULL"
     allow_multiple_values: true
     required: false
     ui_config:
-      type: checkboxes
+      type: advanced
       display: popover
     model: mozilla_vpn
     explore: active_subscriptions
@@ -650,3 +680,16 @@
     explore: active_subscriptions
     listens_to_filters: [Active Date, Country, Pricing Plan, Provider]
     field: active_subscriptions.plan_interval_type
+  - name: Plan ID
+    title: Plan ID
+    type: field_filter
+    default_value: -"price_1MzNRCJNcmPzuWtRMCwUWADu"
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: overflow
+    model: mozilla_vpn
+    explore: active_subscriptions
+    listens_to_filters: []
+    field: active_subscriptions.plan_id

--- a/mozilla_vpn/dashboards/vpn_saasboard_subs_growth.dashboard.lookml
+++ b/mozilla_vpn/dashboards/vpn_saasboard_subs_growth.dashboard.lookml
@@ -4,7 +4,7 @@
   preferred_viewer: dashboards-next
   crossfilter_enabled: true
   description: ''
-  preferred_slug: 3P9vNV1kIjXSFhlkcBPJ3j
+  preferred_slug: bVy0t6fx7wpUAM2STbCo5g
   elements:
   - name: ''
     type: text
@@ -41,9 +41,15 @@
     fill_fields: [metadata.last_modified_date]
     sorts: [metadata.last_modified_date desc]
     limit: 1
-    dynamic_fields: [{category: table_calculation, expression: 'add_days(-1, ${metadata.last_modified_date})',
-        label: New Calculation, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: dimension, table_calculation: new_calculation, _type_hint: date}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: add_days(-1, ${metadata.last_modified_date})
+      label: New Calculation
+      value_format:
+      value_format_name:
+      _kind_hint: dimension
+      table_calculation: new_calculation
+      _type_hint: date
     custom_color_enabled: true
     show_single_value_title: true
     show_comparison: false
@@ -57,7 +63,6 @@
     conditional_formatting: [{type: not equal to, value: 0, background_color: "#cdbfff",
         font_color: !!null '', color_application: {collection_id: mozilla, palette_id: mozilla-sequential-0},
         bold: false, italic: false, strikethrough: false, fields: !!null ''}]
-    series_types: {}
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -92,6 +97,7 @@
       Country: subscription_events.country_name
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
+      Plan ID: subscription_events.plan_id
     row: 2
     col: 19
     width: 5
@@ -175,7 +181,6 @@
       first_last: first
       num_rows: 0
     font_size: ''
-    series_types: {}
     series_colors:
       USA - subscription_events.delta: "#347be3"
     x_axis_datetime_label: ''
@@ -212,6 +217,7 @@
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
       Granular Event Type: subscription_events.granular_event_type
+      Plan ID: subscription_events.plan_id
     row: 8
     col: 0
     width: 12
@@ -229,9 +235,15 @@
     sorts: [subscription_events.event_month desc, subscription_events.event_type]
     limit: 500
     column_limit: 50
-    dynamic_fields: [{category: table_calculation, expression: 'sum(pivot_row(${subscription_events.delta}))',
-        label: Net Subscriptions, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: supermeasure, table_calculation: net_subscriptions, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: sum(pivot_row(${subscription_events.delta}))
+      label: Net Subscriptions
+      value_format:
+      value_format_name:
+      _kind_hint: supermeasure
+      table_calculation: net_subscriptions
+      _type_hint: number
     x_axis_gridlines: true
     y_axis_gridlines: false
     show_view_names: false
@@ -299,6 +311,7 @@
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
       Granular Event Type: subscription_events.granular_event_type
+      Plan ID: subscription_events.plan_id
     row: 39
     col: 0
     width: 12
@@ -378,7 +391,6 @@
       first_last: first
       num_rows: 0
     font_size: ''
-    series_types: {}
     series_colors: {}
     x_axis_datetime_label: ''
     show_sql_query_menu_options: false
@@ -413,6 +425,7 @@
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
       Granular Event Type: subscription_events.granular_event_type
+      Plan ID: subscription_events.plan_id
     row: 18
     col: 0
     width: 12
@@ -549,6 +562,7 @@
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
       Granular Event Type: subscription_events.granular_event_type
+      Plan ID: subscription_events.plan_id
     row: 18
     col: 12
     width: 12
@@ -628,7 +642,6 @@
       first_last: first
       num_rows: 0
     font_size: ''
-    series_types: {}
     series_colors:
       1-month-usd-4.99 - subscription_events.delta: "#7363A9"
       6-month-chf-47.94 - subscription_events.delta: "#82a6a8"
@@ -665,6 +678,7 @@
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
       Granular Event Type: subscription_events.granular_event_type
+      Plan ID: subscription_events.plan_id
     row: 28
     col: 12
     width: 12
@@ -682,9 +696,15 @@
     sorts: [subscription_events.event_month desc, subscription_events.event_type]
     limit: 500
     column_limit: 50
-    dynamic_fields: [{category: table_calculation, expression: 'sum(pivot_row(${subscription_events.delta}))',
-        label: Net Subscriptions, value_format: !!null '', value_format_name: !!null '',
-        _kind_hint: supermeasure, table_calculation: net_subscriptions, _type_hint: number}]
+    dynamic_fields:
+    - category: table_calculation
+      expression: sum(pivot_row(${subscription_events.delta}))
+      label: Net Subscriptions
+      value_format:
+      value_format_name:
+      _kind_hint: supermeasure
+      table_calculation: net_subscriptions
+      _type_hint: number
     x_axis_gridlines: true
     y_axis_gridlines: false
     show_view_names: false
@@ -762,6 +782,7 @@
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
       Granular Event Type: subscription_events.granular_event_type
+      Plan ID: subscription_events.plan_id
     row: 39
     col: 12
     width: 12
@@ -845,7 +866,6 @@
       first_last: first
       num_rows: 0
     font_size: ''
-    series_types: {}
     series_colors: {}
     x_axis_datetime_label: ''
     show_sql_query_menu_options: false
@@ -883,6 +903,7 @@
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
       Granular Event Type: subscription_events.granular_event_type
+      Plan ID: subscription_events.plan_id
     row: 28
     col: 0
     width: 12
@@ -944,7 +965,6 @@
       first_last: first
       num_rows: 0
     font_size: ''
-    series_types: {}
     series_colors:
       1-month-usd-4.99 - subscription_events.delta: "#7363A9"
       6-month-chf-47.94 - subscription_events.delta: "#82a6a8"
@@ -983,6 +1003,7 @@
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
       Granular Event Type: subscription_events.granular_event_type
+      Plan ID: subscription_events.plan_id
     row: 8
     col: 18
     width: 6
@@ -1044,7 +1065,6 @@
       first_last: first
       num_rows: 0
     font_size: ''
-    series_types: {}
     series_colors:
       1-month-usd-4.99 - subscription_events.delta: "#7363A9"
       6-month-chf-47.94 - subscription_events.delta: "#82a6a8"
@@ -1081,6 +1101,7 @@
       Event Date: subscription_events.event_date
       Plan Interval Type: subscription_events.plan_interval_type
       Granular Event Type: subscription_events.granular_event_type
+      Plan ID: subscription_events.plan_id
     row: 8
     col: 12
     width: 6
@@ -1098,13 +1119,12 @@
   - name: Provider
     title: Provider
     type: field_filter
-    default_value: ''
+    default_value: "-NULL"
     allow_multiple_values: true
     required: false
     ui_config:
-      type: checkboxes
+      type: advanced
       display: popover
-      options: []
     model: mozilla_vpn
     explore: subscription_events
     listens_to_filters: [Plan Interval Type, Pricing Plan, Country, Event Date]
@@ -1178,3 +1198,17 @@
     explore: subscription_events
     listens_to_filters: []
     field: subscription_events.granular_event_type
+  - name: Plan ID
+    title: Plan ID
+    type: field_filter
+    default_value: -"price_1MzNRCJNcmPzuWtRMCwUWADu"
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: overflow
+      options: []
+    model: mozilla_vpn
+    explore: subscription_events
+    listens_to_filters: []
+    field: subscription_events.plan_id

--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -9,10 +9,6 @@ view: +subscriptions {
     hidden: yes
   }
 
-  dimension: plan_id {
-    hidden: yes
-  }
-
   dimension: product_id {
     hidden: yes
   }


### PR DESCRIPTION
Related tickets:

- https://mozilla-hub.atlassian.net/browse/DS-2963
- https://mozilla-hub.atlassian.net/browse/DS-3303
- https://mozilla-hub.atlassian.net/browse/DS-3398


All changes except the change in subscriptions.view file were done through the GUI so **the LookML codes were autogenerated.** 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
