### PR TITLE
Escape underscores in `LIKE` patterns

### DIFF
--- a/duet/mr1DEVELOPMENT/views/surveys.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/surveys.view.lkml
@@ -7,7 +7,7 @@ view: surveys {
           `moz-fx-data-shared-prod.telemetry.heartbeat`
         WHERE
           date(submission_timestamp) >= '2021-05-18' -- change this to real release date
-          and SPLIT(payload.survey_id, '::')[OFFSET(0)] like '%visual_perception_89%'
+          and SPLIT(payload.survey_id, '::')[OFFSET(0)] like r'%visual\_perception\_89%'
           and normalized_channel = 'release'
          ;;
   }

--- a/duet/views/ctd_uac.view.lkml
+++ b/duet/views/ctd_uac.view.lkml
@@ -24,7 +24,7 @@ view: ctd_uac {
         submission_date >= '2023-06-26'
      AND first_seen_date >= '2023-06-27' --and "2023-07-31"
      AND adjust_network = 'Google Ads ACI'
-     AND adjust_campaign like "%Mozilla_FF_UAC_EU_DE_DE_AllGroups_Event7%"
+     AND adjust_campaign like r"%Mozilla\_FF\_UAC\_EU\_DE\_DE\_AllGroups\_Event7%"
         --AND adjust_adgroup <> "DE Ad Group (150957842358)"
   GROUP BY 1, 2 order by 1
 )

--- a/duet/views/google_uac_android_activation.view.lkml
+++ b/duet/views/google_uac_android_activation.view.lkml
@@ -27,7 +27,7 @@ view: google_uac_android_activation {
            submission_date >= '2022-12-01'
            AND first_seen_date >= '2022-12-01'
            AND adjust_network = 'Google Ads ACI'
-           AND adjust_campaign LIKE 'Mozilla_%'
+           AND adjust_campaign LIKE r'Mozilla\_%'
          GROUP BY
            date,
            campaign,
@@ -37,7 +37,7 @@ view: google_uac_android_activation {
           date,
           campaign,
           ad_group,
-          CASE WHEN campaign LIKE '%_US_%' OR campaign LIKE '%_CA_%' OR campaign LIKE '%NA%' THEN 'NA'
+          CASE WHEN campaign LIKE r'%\_US\_%' OR campaign LIKE r'%\_CA\_%' OR campaign LIKE '%NA%' THEN 'NA'
                WHEN campaign LIKE '%MGFQ3%' THEN 'Expansion'
                ELSE 'EU' END AS region,
           REGEXP_EXTRACT(campaign, '.*(Event\\d).*') as event,

--- a/firefox_accounts/views/fxa_multi_service_dau.view.lkml
+++ b/firefox_accounts/views/fxa_multi_service_dau.view.lkml
@@ -11,7 +11,7 @@ view: fxa_multi_service_dau {
     FROM
       `mozdata.firefox_accounts.fxa_all_events`
     WHERE service IN ('sync', 'mdn-plus', 'guardian-vpn', 'fx-monitor', 'fx-private-relay', 'pocket-web', 'amo-web', 'thunderbird-addons', 'mozilla-iam', 'moz-social', 'mozilla-support', 'pontoon', 'mozilla-hubs-dev')
-    AND event_type like 'fxa_activity%'
+    AND event_type like r'fxa\_activity%'
     GROUP BY
       1, 2
     HAVING ARRAY_LENGTH(services) > 1;;

--- a/mr_2022/views/fx_view_customization.view.lkml
+++ b/mr_2022/views/fx_view_customization.view.lkml
@@ -5,13 +5,13 @@ view: fx_view_customization {
         clients AS (
             SELECT
                 client_id,
-                MAX(CASE WHEN c.key LIKE 'firefox-view-button_remove%' THEN submission_timestamp END) AS latest_remove,
-                MAX(CASE WHEN c.key LIKE 'firefox-view-button_add%' THEN submission_timestamp END) AS latest_add,
+                MAX(CASE WHEN c.key LIKE r'firefox-view-button\_remove%' THEN submission_timestamp END) AS latest_remove,
+                MAX(CASE WHEN c.key LIKE r'firefox-view-button\_add%' THEN submission_timestamp END) AS latest_add,
             FROM telemetry.main_1pct
             CROSS JOIN UNNEST(payload.processes.parent.keyed_scalars.browser_ui_customized_widgets) c
             WHERE DATE(submission_timestamp) >= DATE(2022, 9, 20)
             AND ARRAY_LENGTH(payload.processes.parent.keyed_scalars.browser_ui_customized_widgets) != 0
-            AND (c.key LIKE 'firefox-view-button_remove%' OR c.key LIKE 'firefox-view-button_add%')
+            AND (c.key LIKE r'firefox-view-button\_remove%' OR c.key LIKE r'firefox-view-button\_add%')
             AND SAFE_CAST(SUBSTR(application.display_version, 1, 3) AS float64) >= 106
             GROUP BY 1
         )


### PR DESCRIPTION
In `LIKE` patterns unescaped underscores will match any single character.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
