### PR TITLE
increase CI timout to 15 min

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
       - run:
           command: |
             python ./src/sync_dashboards/main.py sync --config lookml_dashboards.yaml
+          no_output_timeout: 15m
 workflows:
   version: 2
   build:


### PR DESCRIPTION
Increasing the timeout without output for running the sync_dashboards step because it currently routinley times out

Looking back through the CI logs this routinley failed in this step for as long as the records go back. Here is a [link](https://app.circleci.com/pipelines/github/mozilla/looker-spoke-default/3363/workflows/125fe765-f6f0-48f8-bcd0-5cd7b57bba7d/jobs/1002) to a CI run from August where it timed out 

