### PR TITLE
update type hints for looker sdk

### DIFF
--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -16,9 +16,9 @@ logging.basicConfig(
 )
 
 
-def setup_sdk(client_id, client_secret, instance) -> methods.Looker31SDK:
+def setup_sdk(client_id, client_secret, instance) -> methods.Looker40SDK:
     os.environ["LOOKERSDK_BASE_URL"] = instance
-    os.environ["LOOKERSDK_API_VERSION"] = "3.1"
+    os.environ["LOOKERSDK_API_VERSION"] = "4.0"
     os.environ["LOOKERSDK_VERIFY_SSL"] = "true"
     os.environ["LOOKERSDK_TIMEOUT"] = "9000"
     os.environ["LOOKERSDK_CLIENT_ID"] = client_id
@@ -42,7 +42,7 @@ def lookml_uud_mapping(config: dict) -> dict:
     return mappings
 
 
-def get_all_linked_dashboards(sdk: methods.Looker31SDK) -> dict:
+def get_all_linked_dashboards(sdk: methods.Looker40SDK) -> dict:
     """
     Get all dashboards that contain a lookml_link_id.
     """
@@ -61,7 +61,7 @@ def get_all_linked_dashboards(sdk: methods.Looker31SDK) -> dict:
 
 
 def sync_dashboards(
-    sdk: methods.Looker31SDK, mappings: dict, remote_mappings: dict
+    sdk: methods.Looker40SDK, mappings: dict, remote_mappings: dict
 ) -> None:
     try:
         for lookml_dashboard_id, dashboard_ids in mappings.items():


### PR DESCRIPTION
#602
updated to use the looker API 4.0 but not the type hints so adding updated typehints now 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
