### PR TITLE
fix health check dashboard: remove payload_bytes_decodes

### DIFF
--- a/monitoring/views/missing_namespaces_and_document_types.view.lkml
+++ b/monitoring/views/missing_namespaces_and_document_types.view.lkml
@@ -1,24 +1,6 @@
 view: missing_namespaces_and_document_types {
   derived_table: {
-    sql: WITH ping_counts AS (
-      SELECT
-        DATE(submission_timestamp) AS submission_date,
-        metadata.document_namespace,
-        metadata.document_type,
-        metadata.document_version,
-        COUNT(*) AS ping_count
-      FROM
-        mozdata.monitoring.payload_bytes_decoded_structured
-      WHERE
-        submission_timestamp >= TIMESTAMP_SUB(current_timestamp, INTERVAL 7 DAY)
-        AND metadata.header.x_debug_id IS NULL
-      GROUP BY
-        submission_date,
-        document_namespace,
-        document_type,
-        document_version
-    ),
-    error_counts AS (
+    sql: WITH error_counts AS (
       SELECT
         DATE(submission_timestamp) AS submission_date,
         document_namespace,
@@ -45,21 +27,17 @@ view: missing_namespaces_and_document_types {
         document_type,
         document_version,
         error_type,
-        COALESCE(ping_count, 0) + COALESCE(error_counts.error_count, 0) AS ping_count,
         COALESCE(error_counts.error_count, 0) AS error_count
       FROM
-        ping_counts
-      FULL OUTER JOIN
         error_counts
-      USING
-        (submission_date, document_namespace, document_type, document_version)
     )
     SELECT
       document_namespace,
       submission_date,
       document_type,
       document_version,
-      SUM(ping_count) AS total_pings
+      SUM(error_count) as total_errors,
+      null AS total_pings
     FROM
       structured_daily_errors
     GROUP BY
@@ -68,11 +46,10 @@ view: missing_namespaces_and_document_types {
       document_type,
       document_version
     HAVING
-      SUM(ping_count) > 20
-      AND SAFE_DIVIDE(1.0 * SUM(error_count), SUM(ping_count)) > 0.99
+      SUM(error_count) > 20
       AND NOT REGEXP_CONTAINS(document_namespace, '^org-mozilla-firefo.$')
     ORDER BY
-      total_pings DESC
+      total_errors DESC
     ;;
   }
 
@@ -158,5 +135,9 @@ view: missing_namespaces_and_document_types {
   measure: total_pings {
     type: sum
     sql: ${TABLE}.total_pings ;;
+  }
+  measure: total_errors {
+    type: sum
+    sql: ${TABLE}.total_errors ;;
   }
 }


### PR DESCRIPTION
`payload_bytes_decoded_structured` was removed, which broke this look and the platform health check dashboard. This removes the query to that table. Side effect is that we lose the ping counts, but we can use error counts instead for a "good enough" signal of severity for the dashboard.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
