### PR TITLE
fix #725 currently still importing methods and models for sdk 31

### DIFF
--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -6,7 +6,8 @@ import yaml
 import click
 import looker_sdk
 
-from looker_sdk.sdk.api40 import methods, models
+from looker_sdk import methods40 as methods
+from looker_sdk import models40 as models 
 
 
 logging.basicConfig(

--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -6,7 +6,7 @@ import yaml
 import click
 import looker_sdk
 
-from looker_sdk import methods, models
+from looker_sdk.sdk.api40 import methods, models
 
 
 logging.basicConfig(


### PR DESCRIPTION
when looking at this locally (I did not get super far without looker credentials) it looks like one needs to import the methods and models specifically for api40 otherswise it will still try to get them for API 3.1
![image](https://github.com/mozilla/looker-spoke-default/assets/33942105/b081f429-faea-4c64-990a-d7d536635370)
