### PR TITLE
expose measures in android onboarding explore

### DIFF
--- a/fenix/explores/android_onboarding.explore.lkml
+++ b/fenix/explores/android_onboarding.explore.lkml
@@ -1,4 +1,4 @@
-include: "//looker-hub/fenix/views/android_onboarding.view.lkml"
+include: "../views/android_onboarding.view.lkml"
 
 explore: android_onboarding {
   label: "Android Onboarding Funnel"

--- a/fenix/views/android_onboarding.view.lkml
+++ b/fenix/views/android_onboarding.view.lkml
@@ -1,0 +1,140 @@
+include: "//looker-hub/fenix/views/android_onboarding.view.lkml"
+
+view: +android_onboarding {
+
+  # hide dimensions that we will use as measures
+  dimension: new_profile {
+    hidden: yes
+  }
+
+  dimension: first_card_impression {
+    hidden: yes
+  }
+
+  dimension: first_card_primary_click {
+    hidden: yes
+  }
+
+  dimension: first_card_secondary_click {
+    hidden: yes
+  }
+
+  dimension: second_card_impression {
+    hidden: yes
+  }
+
+  dimension: second_card_primary_click {
+    hidden: yes
+  }
+
+  dimension: second_card_secondary_click {
+    hidden: yes
+  }
+
+  dimension: third_card_impression {
+    hidden: yes
+  }
+
+  dimension: third_card_primary_click {
+    hidden: yes
+  }
+
+  dimension: third_card_secondary_click {
+    hidden: yes
+  }
+
+  dimension: sync_sign_in {
+    hidden: yes
+  }
+
+  dimension: default_browser {
+    hidden: yes
+  }
+
+  # define measures
+
+  measure: new_profile_measure {
+    sql: ${TABLE}.new_profile ;;
+    type: sum
+    label: "New Profiles (Count)"
+    description: "Total number of new profiles. Not all of them will have gone through or been assigned an onboarding funnel."
+  }
+
+  measure: first_card_impression_measure {
+    sql: ${TABLE}.first_card_impression ;;
+    type: sum
+    label: "First Card Impression (Count of Users)"
+    description: "Number of users with an impression on the first card."
+  }
+
+  measure: first_card_primary_click_measure {
+    sql: ${TABLE}.first_card_primary_click ;;
+    type: sum
+    label: "First Card Primary Click (Count of Users)"
+    description: "Number of users with a click on the primary button of the first card."
+  }
+
+  measure: first_card_secondary_click_measure {
+    sql: ${TABLE}.first_card_secondary_click ;;
+    type: sum
+    label: "First Card Primary Click (Count of Users)"
+    description: "Number of users with a click on the secondary button of the first card. (This is almost always the 'skip' button)"
+  }
+
+  measure: second_card_impression_measure {
+    sql: ${TABLE}.second_card_impression ;;
+    type: sum
+    label: "Second Card Impression (Count of Users)"
+    description: "Number of users with an impression on the second card."
+  }
+
+  measure: second_card_primary_click_measure {
+    sql: ${TABLE}.second_card_primary_click ;;
+    type: sum
+    label: "Second Card Primary Click (Count of Users)"
+    description: "Number of users with a click on the primary button of the second card."
+  }
+
+  measure: second_card_secondary_click_measure {
+    sql: ${TABLE}.second_card_secondary_click ;;
+    type: sum
+    label: "Second Card Primary Click (Count of Users)"
+    description: "Number of users with a click on the secondary button of the second card. (This is almost always the 'skip' button)"
+  }
+
+  measure: third_card_impression_measure {
+    sql: ${TABLE}.third_card_impression ;;
+    type: sum
+    label: "Third Card Impression (Count of Users)"
+    description: "Number of users with an impression on the third card."
+  }
+
+  measure: third_card_primary_click_measure {
+    sql: ${TABLE}.third_card_primary_click ;;
+    type: sum
+    label: "Third Card Primary Click (Count of Users)"
+    description: "Number of users with a click on the primary button of the third card."
+  }
+
+  measure: third_card_secondary_click_measure {
+    sql: ${TABLE}.third_card_secondary_click ;;
+    type: sum
+    label: "Third Card Primary Click (Count of Users)"
+    description: "Number of users with a click on the secondary button of the third card. (This is almost always the 'skip' button)"
+  }
+
+  measure: sync_sign_in_measure {
+    sql: ${TABLE}.sync_sign_in ;;
+    type: sum
+    label: "Clients Signing into Sync"
+    description: "Total number of new profiles signing into sync. Could be either a login or signup."
+  }
+
+  measure: default_browser_measure {
+    sql: ${TABLE}.default_browser ;;
+    type: sum
+    label: "Clients Setting Default"
+    description: "Total number of new profiles setting Firefox as default."
+  }
+
+}


### PR DESCRIPTION
This changes some dimensions from the android_onboarding to instead be measures. 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
