### PR TITLE
Remove filter for year to date (YTD) only update.

### DIFF
--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -22,8 +22,7 @@ explore: active_users_aggregates {
       filters: [
         active_users_aggregates.choose_breakdown: "Month^_Day",
         active_users_aggregates.choose_comparison: "Year",
-        active_users_aggregates.submission_date: "after 1 year ago",
-        active_users_aggregates.ytd_only: "Yes"
+        active_users_aggregates.submission_date: "after 1 year ago"
       ]
     }
 


### PR DESCRIPTION
Fixes [DENG-2542](https://mozilla-hub.atlassian.net/browse/DENG-2542).

The YTD  (Year To Date) only filter in the PDT limits the update of the PDT until the current day of year for previous periods:  ```AND (EXTRACT(DAYOFYEAR FROM active_users_aggregates.submission_date)) < SELECT EXTRACT(DAYOFYEAR FROM CURRENT_DATE())```

Removing it allows for a full update of the PDT while still being able to use it when the YTD filter is used in Views.

For testing, this [query](https://sql.telemetry.mozilla.org/queries/97302/source) shows the update of data for the previous year even when there isn't data yet in the current year, while the Explore still uses the PDT when the YTD filter is applied.
