### PR TITLE
Add "Monthly New Subscriptions by Campaign" chart to Monitor SaaSboard (DS-3013)

### DIFF
--- a/subscription_platform/dashboards/monitor_saasboard__churn.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__churn.dashboard.lookml
@@ -545,9 +545,9 @@
     show_null_points: true
     interpolation: linear
     defaults_version: 1
-    note_state: collapsed
-    note_display: hover
-    note_text: 'Note: Subscription Start Date filter does not apply to this chart.'
+    note:
+      text: "The Subscription Start Date filter does not apply to this chart."
+      display: hover
     listen:
       Plan Interval: logical_subscriptions.plan_interval
       Has Refunds (Yes / No): logical_subscriptions.has_refunds

--- a/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
@@ -822,7 +822,7 @@
     defaults_version: 1
     hidden_pivots: {}
     note:
-      text: This chart only includes new subscriptions that were attributed to a campaign.
+      text: "This chart only includes new subscriptions that were attributed to a campaign."
       display: hover
     listen:
       Payment Provider: logical_subscription_events.subscription__payment_provider

--- a/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
@@ -769,6 +769,75 @@
     col: 0
     width: 12
     height: 10
+  - title: Monthly New Subscriptions by Campaign
+    name: Monthly New Subscriptions by Campaign
+    model: subscription_platform
+    explore: logical_subscription_events
+    type: looker_column
+    fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.timestamp_month,
+      logical_subscription_events.subscription__last_touch_attribution__utm_campaign]
+    pivots: [logical_subscription_events.subscription__last_touch_attribution__utm_campaign]
+    filters:
+      logical_subscription_events.type: Subscription Start
+      logical_subscription_events.subscription__last_touch_attribution__utm_campaign: "-EMPTY"
+    sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.subscription__last_touch_attribution__utm_campaign]
+    limit: 5000
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: false
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: false
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: normal
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: desc
+    show_null_labels: false
+    show_totals_labels: true
+    show_silhouette: false
+    totals_color: "#808080"
+    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
+            id: logical_subscription_events.logical_subscription_count, name: Logical
+              Subscription Count}], showLabels: false, showValues: true, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}]
+    x_axis_label: Date
+    x_axis_zoom: true
+    y_axis_zoom: true
+    show_null_points: false
+    interpolation: linear
+    defaults_version: 1
+    hidden_pivots: {}
+    note:
+      text: This chart only includes new subscriptions that were attributed to a campaign.
+      display: hover
+    listen:
+      Payment Provider: logical_subscription_events.subscription__payment_provider
+      Subscription Start Date: logical_subscription_events.timestamp_date
+      Plan Interval: logical_subscription_events.subscription__plan_interval
+      Plan: logical_subscription_events.subscription__plan_summary
+      Region: countries.region_name
+      Country: countries.name
+      Has Refunds (Yes / No): current_subscription_state.has_refunds
+      Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
+      Service ID: subscription_services.id
+    row: 37
+    col: 12
+    width: 12
+    height: 10
   - name: Net New Subscriptions heading
     type: text
     title_text: ''


### PR DESCRIPTION
## [DS-3013](https://mozilla-hub.atlassian.net/browse/DS-3013): Subscription Growth dashboard

This is in place of the coupons chart from the VPN SaaSboard, which we can't replicate for Monitor at the moment because the SubPlat ETL doesn't currently include coupons data.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
