### PR TITLE
GA3 to GA4 Migration: tables www_site_events_metric, www_site_landing_page_metrics, blogs_landing_page_summary

### DIFF
--- a/duet/mr1DEVELOPMENT/views/forecasts_various.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/forecasts_various.view.lkml
@@ -198,7 +198,7 @@ view: forecast_dls {
 
     (SELECT date as submission_date,
              sum(non_fx_downloads) AS non_fx_downloads
-FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics`
+FROM `moz-fx-data-marketing-prod.ga.www_site_landing_page_metrics`
 WHERE device_category = 'desktop'
   AND date >= '2021-05-18'
 GROUP BY 1) a

--- a/duet/mr1DEVELOPMENT/views/forecasts_various.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/forecasts_various.view.lkml
@@ -198,7 +198,7 @@ view: forecast_dls {
 
     (SELECT date as submission_date,
              sum(non_fx_downloads) AS non_fx_downloads
-FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v1`
+FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v2`
 WHERE device_category = 'desktop'
   AND date >= '2021-05-18'
 GROUP BY 1) a

--- a/duet/mr1DEVELOPMENT/views/forecasts_various.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/forecasts_various.view.lkml
@@ -198,7 +198,7 @@ view: forecast_dls {
 
     (SELECT date as submission_date,
              sum(non_fx_downloads) AS non_fx_downloads
-FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v2`
+FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics`
 WHERE device_category = 'desktop'
   AND date >= '2021-05-18'
 GROUP BY 1) a

--- a/duet/mr1DEVELOPMENT/views/mozblogs_ga.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/mozblogs_ga.view.lkml
@@ -66,7 +66,7 @@ view: mozblogs_ga {
                      WHEN device_category IN ('mobile', 'tablet') THEN sessions
                      ELSE 0
                  END) AS mobile_sessions
-FROM `moz-fx-data-marketing-prod.ga_derived.blogs_landing_page_summary_v1`
+FROM `moz-fx-data-marketing-prod.ga_derived.blogs_landing_page_summary_v2`
 WHERE date >= '2021-05-18'
 GROUP BY 1,
          2,

--- a/duet/mr1DEVELOPMENT/views/mozblogs_ga.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/mozblogs_ga.view.lkml
@@ -66,7 +66,7 @@ view: mozblogs_ga {
                      WHEN device_category IN ('mobile', 'tablet') THEN sessions
                      ELSE 0
                  END) AS mobile_sessions
-FROM `moz-fx-data-marketing-prod.ga_derived.blogs_landing_page_summary`
+FROM `moz-fx-data-marketing-prod.ga.blogs_landing_page_summary`
 WHERE date >= '2021-05-18'
 GROUP BY 1,
          2,

--- a/duet/mr1DEVELOPMENT/views/mozblogs_ga.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/mozblogs_ga.view.lkml
@@ -66,7 +66,7 @@ view: mozblogs_ga {
                      WHEN device_category IN ('mobile', 'tablet') THEN sessions
                      ELSE 0
                  END) AS mobile_sessions
-FROM `moz-fx-data-marketing-prod.ga_derived.blogs_landing_page_summary_v2`
+FROM `moz-fx-data-marketing-prod.ga_derived.blogs_landing_page_summary`
 WHERE date >= '2021-05-18'
 GROUP BY 1,
          2,

--- a/duet/mr1DEVELOPMENT/views/mozorg_ga.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/mozorg_ga.view.lkml
@@ -76,7 +76,7 @@ view: mozorg_ga {
                       sum(non_fx_sessions) AS non_fx_sessions,
                       sum(downloads) AS downloads,
                       sum(non_fx_downloads) AS non_fx_downloads
-         FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v1`
+         FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v2`
          WHERE date >= '2020-04-18'
          GROUP BY 1,
                   2,

--- a/duet/mr1DEVELOPMENT/views/mozorg_ga.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/mozorg_ga.view.lkml
@@ -76,7 +76,7 @@ view: mozorg_ga {
                       sum(non_fx_sessions) AS non_fx_sessions,
                       sum(downloads) AS downloads,
                       sum(non_fx_downloads) AS non_fx_downloads
-         FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics`
+         FROM `moz-fx-data-marketing-prod.ga.www_site_landing_page_metrics`
          WHERE date >= '2020-04-18'
          GROUP BY 1,
                   2,

--- a/duet/mr1DEVELOPMENT/views/mozorg_ga.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/mozorg_ga.view.lkml
@@ -76,7 +76,7 @@ view: mozorg_ga {
                       sum(non_fx_sessions) AS non_fx_sessions,
                       sum(downloads) AS downloads,
                       sum(non_fx_downloads) AS non_fx_downloads
-         FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics_v2`
+         FROM `moz-fx-data-marketing-prod.ga_derived.www_site_landing_page_metrics`
          WHERE date >= '2020-04-18'
          GROUP BY 1,
                   2,

--- a/websites/views/firefox_whats_new_page_summary.view.lkml
+++ b/websites/views/firefox_whats_new_page_summary.view.lkml
@@ -12,7 +12,7 @@ view: firefox_whats_new_page_summary {
               page_level_2 AS version,
               country,
               IF(hit_number = first_interaction AND bounces = 1, TRUE, FALSE) AS is_bounce
-         FROM `moz-fx-data-marketing-prod.ga_derived.www_site_hits_v2`
+         FROM `moz-fx-data-marketing-prod.ga_derived.www_site_hits_v1`
          WHERE page_name LIKE '/firefox/%/whatsnew%'
            AND hit_type = 'PAGE'
            AND page_level_1 = 'firefox'

--- a/websites/views/firefox_whats_new_page_summary.view.lkml
+++ b/websites/views/firefox_whats_new_page_summary.view.lkml
@@ -12,7 +12,7 @@ view: firefox_whats_new_page_summary {
               page_level_2 AS version,
               country,
               IF(hit_number = first_interaction AND bounces = 1, TRUE, FALSE) AS is_bounce
-         FROM `moz-fx-data-marketing-prod.ga_derived.www_site_hits_v1`
+         FROM `moz-fx-data-marketing-prod.ga_derived.www_site_hits_v2`
          WHERE page_name LIKE '/firefox/%/whatsnew%'
            AND hit_type = 'PAGE'
            AND page_level_1 = 'firefox'

--- a/websites/views/whats_new_page_events.view.lkml
+++ b/websites/views/whats_new_page_events.view.lkml
@@ -8,7 +8,7 @@ view: whats_new_page_events {
              event_label,
              sum(total_events) as total_events,
             sum(unique_events) as unique_events
-     FROM `moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics_v2`
+     FROM `moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics`
      WHERE page_level_1 = 'firefox'
     AND REGEXP_CONTAINS(page_level_2, r'^\d{1,3}(\.\d{1,3}){1,3}((a|b(eta)?)\d*)?(pre\d*)?(esr)?$')
     AND page_level_3 = 'whatsnew'

--- a/websites/views/whats_new_page_events.view.lkml
+++ b/websites/views/whats_new_page_events.view.lkml
@@ -8,7 +8,7 @@ view: whats_new_page_events {
              event_label,
              sum(total_events) as total_events,
             sum(unique_events) as unique_events
-     FROM `moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics_v1`
+     FROM `moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics_v2`
      WHERE page_level_1 = 'firefox'
     AND REGEXP_CONTAINS(page_level_2, r'^\d{1,3}(\.\d{1,3}){1,3}((a|b(eta)?)\d*)?(pre\d*)?(esr)?$')
     AND page_level_3 = 'whatsnew'

--- a/websites/views/whats_new_page_events.view.lkml
+++ b/websites/views/whats_new_page_events.view.lkml
@@ -8,7 +8,7 @@ view: whats_new_page_events {
              event_label,
              sum(total_events) as total_events,
             sum(unique_events) as unique_events
-     FROM `moz-fx-data-marketing-prod.ga_derived.www_site_events_metrics`
+     FROM `moz-fx-data-marketing-prod.ga.www_site_events_metrics`
      WHERE page_level_1 = 'firefox'
     AND REGEXP_CONTAINS(page_level_2, r'^\d{1,3}(\.\d{1,3}){1,3}((a|b(eta)?)\d*)?(pre\d*)?(esr)?$')
     AND page_level_3 = 'whatsnew'


### PR DESCRIPTION
Updating downstream Looker dependencies to pull from the GA4 datasets.


Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
