### PR TITLE
Add explores for Google Search Console data (DENG-1733)

### DIFF
--- a/websites/explores/google_search_impressions_by_page.explore.lkml
+++ b/websites/explores/google_search_impressions_by_page.explore.lkml
@@ -1,0 +1,14 @@
+include: "../views/google_search_impressions_by_page.view.lkml"
+include: "/shared/views/countries.view.lkml"
+
+explore: google_search_impressions_by_page {
+  conditionally_filter: {
+    filters: [google_search_impressions_by_page.date_date: "30 days"]
+  }
+
+  join: countries {
+    sql_on: ${google_search_impressions_by_page.country_code} = ${countries.code_3} ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+}

--- a/websites/explores/google_search_impressions_by_site.explore.lkml
+++ b/websites/explores/google_search_impressions_by_site.explore.lkml
@@ -1,0 +1,14 @@
+include: "../views/google_search_impressions_by_site.view.lkml"
+include: "/shared/views/countries.view.lkml"
+
+explore: google_search_impressions_by_site {
+  conditionally_filter: {
+    filters: [google_search_impressions_by_site.date_date: "30 days"]
+  }
+
+  join: countries {
+    sql_on: ${google_search_impressions_by_site.country_code} = ${countries.code_3} ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+}

--- a/websites/views/google_search_impressions_by_page.view.lkml
+++ b/websites/views/google_search_impressions_by_page.view.lkml
@@ -1,0 +1,50 @@
+include: "//looker-hub/websites/views/google_search_impressions_by_page.view.lkml"
+
+view: +google_search_impressions_by_page {
+  dimension: impressions {
+    hidden: yes
+  }
+  measure: total_impressions {
+    type: sum
+    sql: ${TABLE}.impressions ;;
+    description: "The number of times that search results with a link to the page were shown to a user."
+  }
+  measure: total_impressions_with_position {
+    type: sum
+    sql: ${TABLE}.impressions ;;
+    filters: [average_position: "NOT NULL"]
+    hidden: yes
+  }
+
+  dimension: clicks {
+    hidden: yes
+  }
+  measure: total_clicks {
+    type: sum
+    sql: ${TABLE}.clicks ;;
+    description: "The number of times a user clicked a search result link to the page."
+  }
+
+  measure: click_through_rate {
+    type: number
+    sql: SAFE_DIVIDE(${total_clicks}, ${total_impressions}) ;;
+    value_format_name: percent_2
+    label: "Click-Through Rate"
+    description: "The total click count divided by the total impression count."
+  }
+
+  dimension: average_position {
+    hidden: yes
+  }
+  measure: total_average_position_times_impressions {
+    type: sum
+    sql: ${TABLE}.average_position * ${TABLE}.impressions ;;
+    hidden: yes
+  }
+  measure: average_result_position {
+    type: number
+    sql: SAFE_DIVIDE(${total_average_position_times_impressions}, ${total_impressions_with_position}) ;;
+    value_format_name: decimal_2
+    description: "The average position of the page in the search results, where `1` is the topmost position. This will be null for Discover and Google News search impressions."
+  }
+}

--- a/websites/views/google_search_impressions_by_site.view.lkml
+++ b/websites/views/google_search_impressions_by_site.view.lkml
@@ -1,0 +1,44 @@
+include: "//looker-hub/websites/views/google_search_impressions_by_site.view.lkml"
+
+view: +google_search_impressions_by_site {
+  dimension: impressions {
+    hidden: yes
+  }
+  measure: total_impressions {
+    type: sum
+    sql: ${TABLE}.impressions ;;
+    description: "The number of times that search results with at least one link to the site were shown to a user."
+  }
+
+  dimension: clicks {
+    hidden: yes
+  }
+  measure: total_clicks {
+    type: sum
+    sql: ${TABLE}.clicks ;;
+    description: "The number of times a user clicked at least one search result link to the site."
+  }
+
+  measure: click_through_rate {
+    type: number
+    sql: SAFE_DIVIDE(${total_clicks}, ${total_impressions}) ;;
+    value_format_name: percent_2
+    label: "Click-Through Rate"
+    description: "The total click count divided by the total impression count."
+  }
+
+  dimension: average_top_position {
+    hidden: yes
+  }
+  measure: total_average_top_position_times_impressions {
+    type: sum
+    sql: ${TABLE}.average_top_position * ${TABLE}.impressions ;;
+    hidden: yes
+  }
+  measure: average_top_result_position {
+    type: number
+    sql: SAFE_DIVIDE(${total_average_top_position_times_impressions}, ${total_impressions}) ;;
+    value_format_name: decimal_2
+    description: "The average top position of the site in the search results, where `1` is the topmost position."
+  }
+}

--- a/websites/websites.model.lkml
+++ b/websites/websites.model.lkml
@@ -1,6 +1,7 @@
 connection: "telemetry"
 label: "Websites"
 
+include: "explores/*"
 include: "views/*"
 
 


### PR DESCRIPTION
## [DENG-1733](https://mozilla-hub.atlassian.net/browse/DENG-1733): Make Google Search Console data available for use

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
