### PR TITLE
fix suggestions for enrollments explore

### DIFF
--- a/experimentation/views/analysis_enrollments.view.lkml
+++ b/experimentation/views/analysis_enrollments.view.lkml
@@ -1,6 +1,7 @@
 view: analysis_enrollments {
   parameter: slug {
-    type: unquoted
+    type: string
+    suggest_dimension: slug_name
   }
 
   parameter: segment {
@@ -9,18 +10,34 @@ view: analysis_enrollments {
 
   derived_table: {
     sql:
+      WITH enrollments AS (
+        SELECT
+          client_id,
+          branch,
+          enrollment_date,
+          exposure_date,
+          num_enrollment_events,
+          num_exposure_events,
+          {% parameter slug %} AS slug_name
+        FROM
+          `moz-fx-data-experiments.mozanalysis.enrollments_*`
+        WHERE _TABLE_SUFFIX = REPLACE({% parameter slug %}, "-", "_")
+        {% if segment._parameter_value != "" %}
+        AND {% parameter segment %} = TRUE
+        {% endif %}
+      ),
+
+      slugs AS (
+        SELECT
+          DISTINCT normandy_slug AS slug_name
+        FROM moz-fx-data-experiments.monitoring.experimenter_experiments_v1
+      )
+
       SELECT
-        client_id,
-        branch,
-        enrollment_date,
-        exposure_date,
-        num_enrollment_events,
-        num_exposure_events,
-      FROM
-        `moz-fx-data-experiments.mozanalysis.enrollments_{% parameter slug %}`
-      {% if segment._parameter_value != "" %}
-      WHERE {% parameter segment %} = TRUE
-      {% endif %}
+        *
+      FROM slugs
+      FULL OUTER JOIN enrollments
+      USING(slug_name)
     ;;
   }
 
@@ -36,13 +53,13 @@ view: analysis_enrollments {
   }
 
   dimension: enrollment_date {
-    sql: ${TABLE}.enrollment_date ;;
-    type: date
+    sql: TIMESTAMP(${TABLE}.enrollment_date) ;;
+    type: date_time
   }
 
   dimension: exposure_date {
-    sql: ${TABLE}.exposure_date ;;
-    type: date
+    sql: TIMESTAMP(${TABLE}.exposure_date) ;;
+    type: date_time
   }
 
   dimension: num_enrollment_events {
@@ -53,6 +70,12 @@ view: analysis_enrollments {
   dimension: num_exposure_events {
     sql: ${TABLE}.num_exposure_events ;;
     type: number
+  }
+
+  dimension: slug_name {
+    sql: ${TABLE}.slug_name ;;
+    type: string
+    hidden: yes
   }
 
   measure: total_clients {

--- a/experimentation/views/analysis_enrollments.view.lkml
+++ b/experimentation/views/analysis_enrollments.view.lkml
@@ -1,10 +1,6 @@
 view: analysis_enrollments {
   parameter: slug {
     type: unquoted
-    suggest_explore: experimenter_experiments
-    suggest_dimension: slug
-    suggestable: yes
-    full_suggestions: yes
   }
 
   parameter: segment {


### PR DESCRIPTION
This removes the "suggest" parameters from the `slug` filter-only field from [this explore](https://mozilla.cloud.looker.com/explore/experimentation/analysis_enrollments?qid=RiCUoUY1yJOt0P9LheZcru&toggle=fil). The suggestions don't work, so it prevents you from trying to add a dashboard-level filter on this field. 

