### PR TITLE
Reformat Monitor SaaSboards' LookML to match Looker's default format (DS-3009)

### DIFF
--- a/subscription_platform/dashboards/monitor_saasboard__active_subscriptions.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__active_subscriptions.dashboard.lookml
@@ -6,10 +6,9 @@
   description: ''
   preferred_slug: wNM1LnNxpIHORchipapYYV
   elements:
-  - name: Navbar
+  - name: ''
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |
       <div style="border-radius: 5px; padding: 5px 10px; background: #412399; height: 60px;">
 
@@ -46,10 +45,9 @@
     col: 0
     width: 24
     height: 2
-  - name: Notes
+  - name: " (2)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style='background-color: #ffffdd; padding: 5px 10px; border: solid 3px #ededed; border-radius: 5px; height:160px'>
 
@@ -116,10 +114,9 @@
     col: 16
     width: 8
     height: 4
-  - name: Active Subscriptions heading
+  - name: " (3)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -251,10 +248,9 @@
     col: 8
     width: 16
     height: 8
-  - name: Active Subscriptions by Plan heading
+  - name: " (4)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -345,8 +341,6 @@
     fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.logical_subscription_count,
       monthly_active_logical_subscriptions.subscription__plan_summary]
     pivots: [monthly_active_logical_subscriptions.subscription__plan_summary]
-    fill_fields: []
-    filters: {}
     sorts: [monthly_active_logical_subscriptions.month_month desc, monthly_active_logical_subscriptions.subscription__plan_summary]
     limit: 5000
     column_limit: 100
@@ -395,10 +389,9 @@
     col: 12
     width: 12
     height: 8
-  - name: Active Subscriptions by Plan Interval heading
+  - name: " (5)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -489,8 +482,6 @@
     fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.logical_subscription_count,
       monthly_active_logical_subscriptions.subscription__plan_interval]
     pivots: [monthly_active_logical_subscriptions.subscription__plan_interval]
-    fill_fields: []
-    filters: {}
     sorts: [monthly_active_logical_subscriptions.month_month desc, monthly_active_logical_subscriptions.subscription__plan_interval]
     limit: 500
     column_limit: 50
@@ -539,10 +530,9 @@
     col: 12
     width: 12
     height: 8
-  - name: Active Subscriptions by Payment Provider heading
+  - name: " (6)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -633,8 +623,6 @@
     fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.logical_subscription_count,
       monthly_active_logical_subscriptions.subscription__payment_provider]
     pivots: [monthly_active_logical_subscriptions.subscription__payment_provider]
-    fill_fields: []
-    filters: {}
     sorts: [monthly_active_logical_subscriptions.month_month desc, monthly_active_logical_subscriptions.subscription__payment_provider]
     limit: 500
     column_limit: 50
@@ -683,10 +671,9 @@
     col: 12
     width: 12
     height: 8
-  - name: Active Subscriptions by Country heading
+  - name: " (7)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -777,8 +764,6 @@
     fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.logical_subscription_count,
       countries.name]
     pivots: [countries.name]
-    fill_fields: []
-    filters: {}
     sorts: [monthly_active_logical_subscriptions.month_month desc, countries.name]
     limit: 5000
     column_limit: 100

--- a/subscription_platform/dashboards/monitor_saasboard__active_subscriptions.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__active_subscriptions.dashboard.lookml
@@ -5,127 +5,6 @@
   preferred_viewer: dashboards-next
   description: ''
   preferred_slug: wNM1LnNxpIHORchipapYYV
-  filters:
-  - name: Active Date
-    title: Active Date
-    type: field_filter
-    default_value: after 2024-02-01
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: advanced
-      display: popover
-      options: []
-    model: subscription_platform
-    explore: daily_active_logical_subscriptions
-    listens_to_filters: []
-    field: daily_active_logical_subscriptions.date_date
-  - name: Payment Provider
-    title: Payment Provider
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: daily_active_logical_subscriptions
-    listens_to_filters: [Service ID, Active Date]
-    field: daily_active_logical_subscriptions.subscription__payment_provider
-  - name: Plan Interval
-    title: Plan Interval
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: daily_active_logical_subscriptions
-    listens_to_filters: [Service ID, Active Date]
-    field: daily_active_logical_subscriptions.subscription__plan_interval
-  - name: Plan
-    title: Plan
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: daily_active_logical_subscriptions
-    listens_to_filters: [Service ID, Active Date, Plan Interval]
-    field: daily_active_logical_subscriptions.subscription__plan_summary
-  - name: Region
-    title: Region
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: daily_active_logical_subscriptions
-    listens_to_filters: [Service ID, Active Date]
-    field: countries.region_name
-  - name: Country
-    title: Country
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: daily_active_logical_subscriptions
-    listens_to_filters: [Region, Service ID, Active Date]
-    field: countries.name
-  - name: Has Fraudulent Charges (Yes / No)
-    title: Has Fraudulent Charges (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: subscription_platform
-    explore: daily_active_logical_subscriptions
-    listens_to_filters: []
-    field: current_subscription_state.has_fraudulent_charges
-  - name: Has Refunds (Yes / No)
-    title: Has Refunds (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: subscription_platform
-    explore: daily_active_logical_subscriptions
-    listens_to_filters: []
-    field: current_subscription_state.has_refunds
-  - name: Service ID
-    title: Service ID
-    type: field_filter
-    default_value: Monitor
-    allow_multiple_values: true
-    required: true
-    ui_config:
-      type: button_toggles
-      display: overflow
-      options:
-      - Monitor
-    model: subscription_platform
-    explore: daily_active_logical_subscriptions
-    listens_to_filters: []
-    field: subscription_services.id
   elements:
   - name: Navbar
     type: text
@@ -948,3 +827,124 @@
     col: 12
     width: 12
     height: 7
+  filters:
+  - name: Active Date
+    title: Active Date
+    type: field_filter
+    default_value: after 2024-02-01
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: popover
+      options: []
+    model: subscription_platform
+    explore: daily_active_logical_subscriptions
+    listens_to_filters: []
+    field: daily_active_logical_subscriptions.date_date
+  - name: Payment Provider
+    title: Payment Provider
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: daily_active_logical_subscriptions
+    listens_to_filters: [Service ID, Active Date]
+    field: daily_active_logical_subscriptions.subscription__payment_provider
+  - name: Plan Interval
+    title: Plan Interval
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: daily_active_logical_subscriptions
+    listens_to_filters: [Service ID, Active Date]
+    field: daily_active_logical_subscriptions.subscription__plan_interval
+  - name: Plan
+    title: Plan
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: daily_active_logical_subscriptions
+    listens_to_filters: [Service ID, Active Date, Plan Interval]
+    field: daily_active_logical_subscriptions.subscription__plan_summary
+  - name: Region
+    title: Region
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: daily_active_logical_subscriptions
+    listens_to_filters: [Service ID, Active Date]
+    field: countries.region_name
+  - name: Country
+    title: Country
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: daily_active_logical_subscriptions
+    listens_to_filters: [Region, Service ID, Active Date]
+    field: countries.name
+  - name: Has Fraudulent Charges (Yes / No)
+    title: Has Fraudulent Charges (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: subscription_platform
+    explore: daily_active_logical_subscriptions
+    listens_to_filters: []
+    field: current_subscription_state.has_fraudulent_charges
+  - name: Has Refunds (Yes / No)
+    title: Has Refunds (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: subscription_platform
+    explore: daily_active_logical_subscriptions
+    listens_to_filters: []
+    field: current_subscription_state.has_refunds
+  - name: Service ID
+    title: Service ID
+    type: field_filter
+    default_value: Monitor
+    allow_multiple_values: true
+    required: true
+    ui_config:
+      type: button_toggles
+      display: overflow
+      options:
+      - Monitor
+    model: subscription_platform
+    explore: daily_active_logical_subscriptions
+    listens_to_filters: []
+    field: subscription_services.id

--- a/subscription_platform/dashboards/monitor_saasboard__churn.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__churn.dashboard.lookml
@@ -6,10 +6,9 @@
   description: ''
   preferred_slug: LO0Ak9rf8cBqZdEeuvl7BN
   elements:
-  - name: Navbar
+  - name: ''
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |
       <div style="border-radius: 5px; padding: 5px 10px; background: #412399; height: 60px;">
 
@@ -46,10 +45,9 @@
     col: 0
     width: 24
     height: 2
-  - name: Notes
+  - name: " (2)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style='background-color: #ffffdd; padding: 5px 10px; border: solid 3px #ededed; border-radius: 5px; height:160px'>
 
@@ -123,7 +121,6 @@
     type: looker_column
     fields: [retention_by_month.subscription_month_number, retention_by_month.churned_subscription_count,
       retention_by_month.previously_retained_subscription_count]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
@@ -167,8 +164,8 @@
             id: retention_by_month.churned_subscription_count, name: Churned Subscription
               Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: custom,
         tickDensityCustom: 70, type: linear}, {label: !!null '', orientation: right,
-        series: [{axisId: churn_rate, id: churn_rate, name: Churn Rate}],
-        showLabels: true, showValues: true, valueFormat: 0%, unpinAxis: false, tickDensity: default,
+        series: [{axisId: churn_rate, id: churn_rate, name: Churn Rate}], showLabels: true,
+        showValues: true, valueFormat: 0%, unpinAxis: false, tickDensity: default,
         tickDensityCustom: 5, type: linear}]
     x_axis_zoom: true
     y_axis_zoom: true
@@ -200,7 +197,6 @@
     type: looker_line
     fields: [retention_by_month.churned_subscription_count, retention_by_month.previously_retained_subscription_count,
       logical_subscriptions.started_at_month]
-    filters: {}
     sorts: [logical_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
@@ -237,10 +233,9 @@
     y_axis_combined: true
     show_null_points: false
     interpolation: linear
-    y_axes: [{label: !!null '', orientation: left, series: [{axisId: churn_rate,
-            id: churn_rate, name: Churn Rate}], showLabels: false, showValues: true,
-        valueFormat: 0%, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
-        type: linear}]
+    y_axes: [{label: !!null '', orientation: left, series: [{axisId: churn_rate, id: churn_rate,
+            name: Churn Rate}], showLabels: false, showValues: true, valueFormat: 0%,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Cohort
     x_axis_zoom: true
     y_axis_zoom: true
@@ -333,9 +328,10 @@
     y_axes: [{label: '', orientation: left, series: [{axisId: churned_subscription_count,
             id: churned_subscription_count, name: Churned Subscription Count}], showLabels: true,
         showValues: true, unpinAxis: false, tickDensity: default, type: linear}, {
-        label: !!null '', orientation: right, series: [{axisId: pooled_churn_rate, id: pooled_churn_rate,
-            name: Pooled Churn Rate}], showLabels: true, showValues: true, valueFormat: 0%,
-        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
+        label: !!null '', orientation: right, series: [{axisId: pooled_churn_rate,
+            id: pooled_churn_rate, name: Pooled Churn Rate}], showLabels: true, showValues: true,
+        valueFormat: 0%, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
+        type: linear}]
     x_axis_zoom: true
     y_axis_zoom: true
     hide_legend: true
@@ -425,9 +421,9 @@
     show_null_points: true
     interpolation: linear
     defaults_version: 1
-    note:
-      text: "The Subscription Start Date filter does not apply to this chart."
-      display: hover
+    note_state: collapsed
+    note_display: hover
+    note_text: The Subscription Start Date filter does not apply to this chart.
     listen:
       Plan Interval: logical_subscriptions.plan_interval
       Has Refunds (Yes / No): logical_subscriptions.has_refunds
@@ -441,10 +437,9 @@
     col: 12
     width: 12
     height: 8
-  - name: Churn by Plan Interval heading
+  - name: " (3)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -463,7 +458,6 @@
     fields: [retention_by_month.churned_subscription_count, retention_by_month.previously_retained_subscription_count,
       retention_by_month.subscription_month_number, logical_subscriptions.plan_interval]
     pivots: [logical_subscriptions.plan_interval]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval]
     limit: 500
     column_limit: 50
@@ -536,7 +530,6 @@
       retention_by_month.subscription_month_number, logical_subscriptions.plan_interval,
       logical_subscriptions.plan_interval_months]
     pivots: [retention_by_month.subscription_month_number]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval_months]
     limit: 500
     column_limit: 50
@@ -580,9 +573,9 @@
             id: retention_by_month.churned_subscription_count, name: Churned Subscription
               Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: custom,
         tickDensityCustom: 70, type: linear}, {label: !!null '', orientation: left,
-        series: [{axisId: churn_rate, id: churn_rate, name: Churn Rate}],
-        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}]
+        series: [{axisId: churn_rate, id: churn_rate, name: Churn Rate}], showLabels: true,
+        showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
+        type: linear}]
     show_y_axis_labels: true
     show_y_axis_ticks: true
     y_axis_tick_density: default
@@ -639,7 +632,6 @@
     fields: [retention_by_month.churned_subscription_count, retention_by_month.subscription_month_number,
       logical_subscriptions.plan_interval, logical_subscriptions.plan_interval_months]
     pivots: [retention_by_month.subscription_month_number]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval_months]
     limit: 500
     column_limit: 50
@@ -687,9 +679,9 @@
             id: retention_by_month.churned_subscription_count, name: Churned Subscription
               Count}], showLabels: true, showValues: true, unpinAxis: false, tickDensity: custom,
         tickDensityCustom: 70, type: linear}, {label: !!null '', orientation: left,
-        series: [{axisId: churn_rate, id: churn_rate, name: Churn Rate}],
-        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}]
+        series: [{axisId: churn_rate, id: churn_rate, name: Churn Rate}], showLabels: true,
+        showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
+        type: linear}]
     show_y_axis_labels: true
     show_y_axis_ticks: true
     y_axis_tick_density: default
@@ -737,10 +729,9 @@
     col: 0
     width: 24
     height: 4
-  - name: Churn by Cohort heading
+  - name: " (4)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -759,8 +750,6 @@
     fields: [logical_subscriptions.started_at_month, retention_by_month.churned_subscription_count,
       retention_by_month.previously_retained_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    fill_fields: []
-    filters: {}
     sorts: [retention_by_month.subscription_month_number, logical_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
@@ -849,7 +838,6 @@
     fields: [logical_subscriptions.started_at_month, retention_by_month.churned_subscription_count,
       retention_by_month.previously_retained_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number, logical_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
@@ -945,7 +933,6 @@
     fields: [logical_subscriptions.started_at_month, retention_by_month.churned_subscription_count,
       retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number, logical_subscriptions.started_at_month]
     limit: 500
     column_limit: 50

--- a/subscription_platform/dashboards/monitor_saasboard__churn.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__churn.dashboard.lookml
@@ -5,127 +5,6 @@
   preferred_viewer: dashboards-next
   description: ''
   preferred_slug: LO0Ak9rf8cBqZdEeuvl7BN
-  filters:
-  - name: Subscription Start Date
-    title: Subscription Start Date
-    type: field_filter
-    default_value: after 2024-02-01
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: advanced
-      display: popover
-      options: []
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: []
-    field: logical_subscriptions.started_at_date
-  - name: Payment Provider
-    title: Payment Provider
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Subscription Start Date, Service ID]
-    field: logical_subscriptions.payment_provider
-  - name: Plan Interval
-    title: Plan Interval
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Subscription Start Date, Service ID]
-    field: logical_subscriptions.plan_interval
-  - name: Plan
-    title: Plan
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Subscription Start Date, Plan Interval, Service ID]
-    field: logical_subscriptions.plan_summary
-  - name: Region
-    title: Region
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Subscription Start Date, Service ID]
-    field: countries.region_name
-  - name: Country
-    title: Country
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Region, Subscription Start Date, Service ID]
-    field: countries.name
-  - name: Has Fraudulent Charges (Yes / No)
-    title: Has Fraudulent Charges (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: []
-    field: logical_subscriptions.has_fraudulent_charges
-  - name: Has Refunds (Yes / No)
-    title: Has Refunds (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: []
-    field: logical_subscriptions.has_refunds
-  - name: Service ID
-    title: Service ID
-    type: field_filter
-    default_value: Monitor
-    allow_multiple_values: true
-    required: true
-    ui_config:
-      type: button_toggles
-      display: overflow
-      options:
-      - Monitor
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: []
-    field: subscription_services.id
   elements:
   - name: Navbar
     type: text
@@ -1166,3 +1045,124 @@
     col: 0
     width: 24
     height: 5
+  filters:
+  - name: Subscription Start Date
+    title: Subscription Start Date
+    type: field_filter
+    default_value: after 2024-02-01
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: popover
+      options: []
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: []
+    field: logical_subscriptions.started_at_date
+  - name: Payment Provider
+    title: Payment Provider
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Subscription Start Date, Service ID]
+    field: logical_subscriptions.payment_provider
+  - name: Plan Interval
+    title: Plan Interval
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Subscription Start Date, Service ID]
+    field: logical_subscriptions.plan_interval
+  - name: Plan
+    title: Plan
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Subscription Start Date, Plan Interval, Service ID]
+    field: logical_subscriptions.plan_summary
+  - name: Region
+    title: Region
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Subscription Start Date, Service ID]
+    field: countries.region_name
+  - name: Country
+    title: Country
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Region, Subscription Start Date, Service ID]
+    field: countries.name
+  - name: Has Fraudulent Charges (Yes / No)
+    title: Has Fraudulent Charges (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: []
+    field: logical_subscriptions.has_fraudulent_charges
+  - name: Has Refunds (Yes / No)
+    title: Has Refunds (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: []
+    field: logical_subscriptions.has_refunds
+  - name: Service ID
+    title: Service ID
+    type: field_filter
+    default_value: Monitor
+    allow_multiple_values: true
+    required: true
+    ui_config:
+      type: button_toggles
+      display: overflow
+      options:
+      - Monitor
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: []
+    field: subscription_services.id

--- a/subscription_platform/dashboards/monitor_saasboard__retention.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__retention.dashboard.lookml
@@ -6,10 +6,9 @@
   description: ''
   preferred_slug: 4OLpCAQsglh1d434LNOjP5
   elements:
-  - name: Navbar
+  - name: ''
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |
       <div style="border-radius: 5px; padding: 5px 10px; background: #412399; height: 60px;">
 
@@ -46,10 +45,9 @@
     col: 0
     width: 24
     height: 2
-  - name: Notes
+  - name: " (2)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style='background-color: #ffffdd; padding: 5px 10px; border: solid 3px #ededed; border-radius: 5px; height:160px'>
 
@@ -116,10 +114,9 @@
     col: 16
     width: 8
     height: 4
-  - name: Retention Rate heading
+  - name: " (3)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -137,7 +134,6 @@
     type: looker_column
     fields: [retention_by_month.subscription_month_number, retention_by_month.retained_subscription_count,
       logical_subscriptions.logical_subscription_count]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
@@ -217,7 +213,6 @@
     type: looker_column
     fields: [retention_by_month.retained_subscription_count, logical_subscriptions.started_at_month,
       logical_subscriptions.logical_subscription_count]
-    filters: {}
     sorts: [logical_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
@@ -291,10 +286,9 @@
     col: 12
     width: 12
     height: 9
-  - name: Retention by Plan Interval heading
+  - name: " (4)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -306,14 +300,13 @@
     width: 24
     height: 2
   - title: Retention Rate by Plan Interval
-    name: Retention by Plan Interval
+    name: Retention Rate by Plan Interval
     model: subscription_platform
     explore: logical_subscriptions
     type: looker_line
     fields: [retention_by_month.subscription_month_number, retention_by_month.retained_subscription_count,
       logical_subscriptions.logical_subscription_count, logical_subscriptions.plan_interval]
     pivots: [logical_subscriptions.plan_interval]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval]
     limit: 500
     column_limit: 50
@@ -390,7 +383,6 @@
       logical_subscriptions.logical_subscription_count, logical_subscriptions.plan_interval,
       logical_subscriptions.plan_interval_months]
     pivots: [retention_by_month.subscription_month_number]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval_months]
     limit: 500
     column_limit: 50
@@ -504,7 +496,6 @@
     fields: [retention_by_month.subscription_month_number, retention_by_month.retained_subscription_count,
       logical_subscriptions.plan_interval, logical_subscriptions.plan_interval_months]
     pivots: [retention_by_month.subscription_month_number]
-    filters: {}
     sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval_months]
     limit: 500
     column_limit: 50
@@ -612,10 +603,9 @@
     col: 0
     width: 24
     height: 4
-  - name: Retention by Cohort heading
+  - name: " (5)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -634,8 +624,6 @@
     fields: [logical_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
       logical_subscriptions.logical_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    fill_fields: []
-    filters: {}
     sorts: [logical_subscriptions.started_at_month, retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
@@ -709,8 +697,6 @@
     fields: [logical_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
       logical_subscriptions.logical_subscription_count, retention_by_month.subscription_month_number]
     pivots: [logical_subscriptions.started_at_month]
-    fill_fields: []
-    filters: {}
     sorts: [logical_subscriptions.started_at_month, retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
@@ -782,7 +768,6 @@
     fields: [logical_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
       logical_subscriptions.logical_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    filters: {}
     sorts: [logical_subscriptions.started_at_month, retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
@@ -895,8 +880,6 @@
     fields: [logical_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
       logical_subscriptions.logical_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    fill_fields: []
-    filters: {}
     sorts: [logical_subscriptions.started_at_month, retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50

--- a/subscription_platform/dashboards/monitor_saasboard__retention.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__retention.dashboard.lookml
@@ -5,127 +5,6 @@
   preferred_viewer: dashboards-next
   description: ''
   preferred_slug: 4OLpCAQsglh1d434LNOjP5
-  filters:
-  - name: Subscription Start Date
-    title: Subscription Start Date
-    type: field_filter
-    default_value: after 2024-02-01
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: advanced
-      display: popover
-      options: []
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: []
-    field: logical_subscriptions.started_at_date
-  - name: Payment Provider
-    title: Payment Provider
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Subscription Start Date, Service ID]
-    field: logical_subscriptions.payment_provider
-  - name: Plan Interval
-    title: Plan Interval
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Subscription Start Date, Service ID]
-    field: logical_subscriptions.plan_interval
-  - name: Plan
-    title: Plan
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Plan Interval, Subscription Start Date, Service ID]
-    field: logical_subscriptions.plan_summary
-  - name: Region
-    title: Region
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Subscription Start Date, Service ID]
-    field: countries.region_name
-  - name: Country
-    title: Country
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: [Region, Subscription Start Date, Service ID]
-    field: countries.name
-  - name: Has Fraudulent Charges (Yes / No)
-    title: Has Fraudulent Charges (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: []
-    field: logical_subscriptions.has_fraudulent_charges
-  - name: Has Refunds (Yes / No)
-    title: Has Refunds (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: []
-    field: logical_subscriptions.has_refunds
-  - name: Service ID
-    title: Service ID
-    type: field_filter
-    default_value: Monitor
-    allow_multiple_values: true
-    required: true
-    ui_config:
-      type: button_toggles
-      display: overflow
-      options:
-      - Monitor
-    model: subscription_platform
-    explore: logical_subscriptions
-    listens_to_filters: []
-    field: subscription_services.id
   elements:
   - name: Navbar
     type: text
@@ -1118,3 +997,124 @@
     col: 0
     width: 24
     height: 5
+  filters:
+  - name: Subscription Start Date
+    title: Subscription Start Date
+    type: field_filter
+    default_value: after 2024-02-01
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: popover
+      options: []
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: []
+    field: logical_subscriptions.started_at_date
+  - name: Payment Provider
+    title: Payment Provider
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Subscription Start Date, Service ID]
+    field: logical_subscriptions.payment_provider
+  - name: Plan Interval
+    title: Plan Interval
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Subscription Start Date, Service ID]
+    field: logical_subscriptions.plan_interval
+  - name: Plan
+    title: Plan
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Plan Interval, Subscription Start Date, Service ID]
+    field: logical_subscriptions.plan_summary
+  - name: Region
+    title: Region
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Subscription Start Date, Service ID]
+    field: countries.region_name
+  - name: Country
+    title: Country
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: [Region, Subscription Start Date, Service ID]
+    field: countries.name
+  - name: Has Fraudulent Charges (Yes / No)
+    title: Has Fraudulent Charges (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: []
+    field: logical_subscriptions.has_fraudulent_charges
+  - name: Has Refunds (Yes / No)
+    title: Has Refunds (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: []
+    field: logical_subscriptions.has_refunds
+  - name: Service ID
+    title: Service ID
+    type: field_filter
+    default_value: Monitor
+    allow_multiple_values: true
+    required: true
+    ui_config:
+      type: button_toggles
+      display: overflow
+      options:
+      - Monitor
+    model: subscription_platform
+    explore: logical_subscriptions
+    listens_to_filters: []
+    field: subscription_services.id

--- a/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
@@ -5,127 +5,6 @@
   preferred_viewer: dashboards-next
   description: ''
   preferred_slug: STOyQVJV1ejgsvmUcLxFFH
-  filters:
-  - name: Subscription Start Date
-    title: Subscription Start Date
-    type: field_filter
-    default_value: after 2024-02-01
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: advanced
-      display: popover
-      options: []
-    model: subscription_platform
-    explore: logical_subscription_events
-    listens_to_filters: []
-    field: logical_subscription_events.timestamp_date
-  - name: Payment Provider
-    title: Payment Provider
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscription_events
-    listens_to_filters: [Service ID, Subscription Start Date]
-    field: logical_subscription_events.subscription__payment_provider
-  - name: Plan Interval
-    title: Plan Interval
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscription_events
-    listens_to_filters: [Service ID, Subscription Start Date]
-    field: logical_subscription_events.subscription__plan_interval
-  - name: Plan
-    title: Plan
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscription_events
-    listens_to_filters: [Service ID, Subscription Start Date, Plan Interval]
-    field: logical_subscription_events.subscription__plan_summary
-  - name: Region
-    title: Region
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscription_events
-    listens_to_filters: [Service ID, Subscription Start Date]
-    field: countries.region_name
-  - name: Country
-    title: Country
-    type: field_filter
-    default_value: ''
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: checkboxes
-      display: popover
-    model: subscription_platform
-    explore: logical_subscription_events
-    listens_to_filters: [Region, Service ID, Subscription Start Date]
-    field: countries.name
-  - name: Has Fraudulent Charges (Yes / No)
-    title: Has Fraudulent Charges (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: subscription_platform
-    explore: logical_subscription_events
-    listens_to_filters: []
-    field: current_subscription_state.has_fraudulent_charges
-  - name: Has Refunds (Yes / No)
-    title: Has Refunds (Yes / No)
-    type: field_filter
-    default_value: 'No'
-    allow_multiple_values: true
-    required: false
-    ui_config:
-      type: dropdown_menu
-      display: overflow
-    model: subscription_platform
-    explore: logical_subscription_events
-    listens_to_filters: []
-    field: current_subscription_state.has_refunds
-  - name: Service ID
-    title: Service ID
-    type: field_filter
-    default_value: Monitor
-    allow_multiple_values: true
-    required: true
-    ui_config:
-      type: button_toggles
-      display: overflow
-      options:
-      - Monitor
-    model: subscription_platform
-    explore: logical_subscription_events
-    listens_to_filters: []
-    field: subscription_services.id
   elements:
   - name: Navbar
     type: text
@@ -939,3 +818,124 @@
     col: 0
     width: 12
     height: 9
+  filters:
+  - name: Subscription Start Date
+    title: Subscription Start Date
+    type: field_filter
+    default_value: after 2024-02-01
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: advanced
+      display: popover
+      options: []
+    model: subscription_platform
+    explore: logical_subscription_events
+    listens_to_filters: []
+    field: logical_subscription_events.timestamp_date
+  - name: Payment Provider
+    title: Payment Provider
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscription_events
+    listens_to_filters: [Service ID, Subscription Start Date]
+    field: logical_subscription_events.subscription__payment_provider
+  - name: Plan Interval
+    title: Plan Interval
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscription_events
+    listens_to_filters: [Service ID, Subscription Start Date]
+    field: logical_subscription_events.subscription__plan_interval
+  - name: Plan
+    title: Plan
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscription_events
+    listens_to_filters: [Service ID, Subscription Start Date, Plan Interval]
+    field: logical_subscription_events.subscription__plan_summary
+  - name: Region
+    title: Region
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscription_events
+    listens_to_filters: [Service ID, Subscription Start Date]
+    field: countries.region_name
+  - name: Country
+    title: Country
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: subscription_platform
+    explore: logical_subscription_events
+    listens_to_filters: [Region, Service ID, Subscription Start Date]
+    field: countries.name
+  - name: Has Fraudulent Charges (Yes / No)
+    title: Has Fraudulent Charges (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: subscription_platform
+    explore: logical_subscription_events
+    listens_to_filters: []
+    field: current_subscription_state.has_fraudulent_charges
+  - name: Has Refunds (Yes / No)
+    title: Has Refunds (Yes / No)
+    type: field_filter
+    default_value: 'No'
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: dropdown_menu
+      display: overflow
+    model: subscription_platform
+    explore: logical_subscription_events
+    listens_to_filters: []
+    field: current_subscription_state.has_refunds
+  - name: Service ID
+    title: Service ID
+    type: field_filter
+    default_value: Monitor
+    allow_multiple_values: true
+    required: true
+    ui_config:
+      type: button_toggles
+      display: overflow
+      options:
+      - Monitor
+    model: subscription_platform
+    explore: logical_subscription_events
+    listens_to_filters: []
+    field: subscription_services.id

--- a/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
@@ -6,10 +6,9 @@
   description: ''
   preferred_slug: STOyQVJV1ejgsvmUcLxFFH
   elements:
-  - name: Navbar
+  - name: ''
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |
       <div style="border-radius: 5px; padding: 5px 10px; background: #412399; height: 60px;">
 
@@ -46,10 +45,9 @@
     col: 0
     width: 24
     height: 2
-  - name: Notes
+  - name: " (2)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style='background-color: #ffffdd; padding: 5px 10px; border: solid 3px #ededed; border-radius: 5px; height:160px'>
 
@@ -116,10 +114,9 @@
     col: 16
     width: 8
     height: 4
-  - name: New Subscriptions heading
+  - name: " (3)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 
@@ -231,6 +228,11 @@
     label_density: 25
     x_axis_scale: auto
     y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
     show_null_points: true
     interpolation: linear
     y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
@@ -263,7 +265,6 @@
     fields: [logical_subscription_events.logical_subscription_count, countries.name,
       logical_subscription_events.timestamp_month]
     pivots: [countries.name]
-    fill_fields: []
     filters:
       logical_subscription_events.type: Subscription Start
     sorts: [logical_subscription_events.timestamp_month desc, countries.name]
@@ -329,7 +330,6 @@
     fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.subscription__plan_interval,
       logical_subscription_events.timestamp_month]
     pivots: [logical_subscription_events.subscription__plan_interval]
-    fill_fields: []
     filters:
       logical_subscription_events.type: Subscription Start
     sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.subscription__plan_interval]
@@ -525,7 +525,6 @@
     fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.subscription__plan_summary,
       logical_subscription_events.timestamp_month]
     pivots: [logical_subscription_events.subscription__plan_summary]
-    fill_fields: []
     filters:
       logical_subscription_events.type: Subscription Start
     sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.subscription__plan_summary]
@@ -700,9 +699,10 @@
     interpolation: linear
     defaults_version: 1
     hidden_pivots: {}
-    note:
-      text: "This chart only includes new subscriptions that were attributed to a campaign."
-      display: hover
+    note_state: collapsed
+    note_display: hover
+    note_text: This chart only includes new subscriptions that were attributed to
+      a campaign.
     listen:
       Payment Provider: logical_subscription_events.subscription__payment_provider
       Subscription Start Date: logical_subscription_events.timestamp_date
@@ -717,10 +717,9 @@
     col: 12
     width: 12
     height: 10
-  - name: Net New Subscriptions heading
+  - name: " (4)"
     type: text
     title_text: ''
-    subtitle_text: ''
     body_text: |-
       <div style="border-top: solid 2px #e0e0e0;">
 


### PR DESCRIPTION
## [DS-3009](https://mozilla-hub.atlassian.net/browse/DS-3009): create dashboards for Monitor Premium's Q4 release

We're planning to use the following process for editing the Monitor SaaSboards via the Looker UI:
1. Copy the LookML dashboard as a user-defined dashboard in your personal folder.
2. Edit the copy of the dashboard as needed.
3. Copy the LookML for the edited dashboard.
4. Replace the contents of the LookML dashboard file with the edited LookML copied in the previous step.
5. Do the usual LookML deployment steps (commit changes, create PR, get PR approved, merge PR).
6. Delete the copy of the LookML dashboard from your personal folder.

This reformatting of the Monitor SaaSboards' LookML to match Looker's default format should make it so that following the above process results in the minimum changes to the LookML necessary each time, which will make things easier to review and maintain.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
