### PR TITLE
Add placeholder measures for subscriptions ARR

### DIFF
--- a/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
@@ -126,4 +126,29 @@ view: +daily_active_logical_subscriptions {
       ) ;;
   }
 
+  measure: total_annual_recurring_revenue_usd {
+    label: "Total Annual Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${subscription__id} ;;
+    sql:
+      CASE
+        WHEN ${subscription__is_active}
+          AND ${subscription__auto_renew}
+          AND ${subscription__plan_currency} = 'USD'
+          THEN
+            CASE ${subscription__plan_interval_type}
+              WHEN 'year'
+                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count}
+              WHEN 'month'
+                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} * 12
+              WHEN 'week'
+                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} * 52
+              WHEN 'day'
+                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} * 365
+            END
+        ELSE NULL
+      END ;;
+    value_format_name: usd
+  }
+
 }

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -135,6 +135,31 @@ view: +logical_subscriptions {
         ${TABLE}.provider_subscription_id
       ) ;;
   }
+
+  measure: total_annual_recurring_revenue_usd {
+    label: "Total Annual Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${id} ;;
+    sql:
+      CASE
+        WHEN ${is_active}
+          AND ${auto_renew}
+          AND ${plan_currency} = 'USD'
+          THEN
+            CASE ${plan_interval_type}
+              WHEN 'year'
+                THEN ${plan_amount} / ${plan_interval_count}
+              WHEN 'month'
+                THEN ${plan_amount} / ${plan_interval_count} * 12
+              WHEN 'week'
+                THEN ${plan_amount} / ${plan_interval_count} * 52
+              WHEN 'day'
+                THEN ${plan_amount} / ${plan_interval_count} * 365
+            END
+        ELSE NULL
+      END ;;
+    value_format_name: usd
+  }
 }
 
 view: logical_subscriptions__retention_by_month {

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -137,4 +137,29 @@ view: +monthly_active_logical_subscriptions {
       ) ;;
   }
 
+  measure: total_annual_recurring_revenue_usd {
+    label: "Total Annual Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${subscription__id} ;;
+    sql:
+      CASE
+        WHEN ${subscription__is_active}
+          AND ${subscription__auto_renew}
+          AND ${subscription__plan_currency} = 'USD'
+          THEN
+            CASE ${subscription__plan_interval_type}
+              WHEN 'year'
+                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count}
+              WHEN 'month'
+                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} * 12
+              WHEN 'week'
+                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} * 52
+              WHEN 'day'
+                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} * 365
+            END
+        ELSE NULL
+      END ;;
+    value_format_name: usd
+  }
+
 }


### PR DESCRIPTION
These placeholder ARR measures don't yet account for discounts, VAT, or exchange rates.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
