### PR TITLE
Ignore leap day in active_users_aggregates

### DIFF
--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -15,6 +15,8 @@ explore: active_users_aggregates {
     sql_on: ${active_users_aggregates.country} = ${countries.code} ;;
   }
 
+  sql_always_where: NOT (${active_users_aggregates.is_leap_year} AND EXTRACT(DAYOFYEAR FROM ${submission_date}) = 60) ;;
+
   aggregate_table: rollup__period_over_period {
     query: {
       dimensions: [period_over_period_pivot, period_over_period_row, active_users_aggregates.app_name, active_users_aggregates.submission_date, active_users_aggregates.ytd_only]

--- a/combined_browser_metrics/views/active_users_aggregates.view.lkml
+++ b/combined_browser_metrics/views/active_users_aggregates.view.lkml
@@ -121,13 +121,28 @@ view: +active_users_aggregates {
     sql: ${TABLE}.attribution_source ;;
   }
 
+  dimension: is_leap_year {
+    type: yesno
+    sql:  MOD(EXTRACT(YEAR FROM ${TABLE}.submission_date), 4) = 0
+          AND MOD(EXTRACT(YEAR FROM ${TABLE}.submission_date), 100) != 0;;
+    hidden: yes
+  }
+
+  dimension: day_of_year_w_leap_day {
+    type: number
+    sql:
+      EXTRACT(DAYOFYEAR FROM ${TABLE}.submission_date) +
+      IF(${is_leap_year} AND EXTRACT(DAYOFYEAR FROM ${TABLE}.submission_date) >= 60, -1, 0)
+      ;;
+  }
+
 # These dimensions are just to make sure the dimensions sort correctly
   dimension: sort_by1 {
     hidden: yes
     type: number
     sql:
           {% if choose_breakdown._parameter_value == 'Month' %} ${submission_month_num}
-          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${submission_day_of_year}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${day_of_year_w_leap_day}
           {% elsif choose_breakdown._parameter_value == 'WOY' %} ${submission_week_of_year}
           {% elsif choose_breakdown._parameter_value == 'DOY' %} ${submission_day_of_year}
           {% elsif choose_breakdown._parameter_value == 'DOM' %} ${submission_day_of_month}
@@ -142,7 +157,7 @@ view: +active_users_aggregates {
           {% if choose_comparison._parameter_value == 'Year' %} ${submission_year}
           {% elsif choose_comparison._parameter_value == 'Month' %} ${submission_month_num}
           {% elsif choose_breakdown._parameter_value == 'WOY' %} ${submission_week_of_year}
-          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${submission_day_of_year}
+          {% elsif choose_breakdown._parameter_value == 'Month_Day' %} ${day_of_year_w_leap_day}
           {% elsif choose_comparison._parameter_value == 'Week' %} ${submission_week}
           {% else %}NULL{% endif %} ;;
 


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
