### PR TITLE
feat(): firefox ios firefox android clients remove submission date dimension

### DIFF
--- a/fenix/explores/firefox_android_clients.explore.lkml
+++ b/fenix/explores/firefox_android_clients.explore.lkml
@@ -1,21 +1,21 @@
 include: "../views/firefox_android_clients.view.lkml"
 
 explore: firefox_android_clients {
-  sql_always_where: ${firefox_android_clients.submission_date} >= '2010-01-01' ;;
+  sql_always_where: ${firefox_android_clients.first_seen_date} >= '2010-01-01' ;;
   view_name: firefox_android_clients
 
   always_filter: {
     filters: [
-      submission_date: "28 days",
+      first_seen_date: "28 days",
     ]
   }
 
   query: activated_client_count {
     dimensions: [firefox_android_clients.first_seen_month, firefox_android_clients.activated, firefox_android_clients.client_count]
-    label: "Number of clients activated in the last 6 complete months."
-    description: "Number of clients activated in the last 6 complete months."
+    label: "Number of clients activated in the last 6 complete months (release channel)."
+    description: "Number of clients activated in the last 6 complete months (release channel)."
     sorts: [firefox_android_clients.first_seen_month: desc, firefox_android_clients.activated: desc]
-    filters: [firefox_android_clients.submission_date: "7 month ago for 7 month", firefox_android_clients.first_seen_month: "6 month ago for 6 month", firefox_android_clients.channel: "release"]
+    filters: [firefox_android_clients.first_seen_month: "6 month ago for 6 month", firefox_android_clients.channel: "release"]
     limit: 100
   }
 }

--- a/fenix/views/firefox_android_clients.view.lkml
+++ b/fenix/views/firefox_android_clients.view.lkml
@@ -83,6 +83,10 @@ view: +firefox_android_clients {
     group_item_label: "App Channel"
   }
 
+  dimension_group: submission {
+    hidden: yes
+  }
+
   dimension: last_reported_adjust_ad_group {
     hidden: yes
   }

--- a/firefox_ios/explores/firefox_ios_clients.explore.lkml
+++ b/firefox_ios/explores/firefox_ios_clients.explore.lkml
@@ -1,21 +1,21 @@
 include: "../views/firefox_ios_clients.view.lkml"
 
 explore: firefox_ios_clients {
-  sql_always_where: ${firefox_ios_clients.submission_date} >= '2010-01-01' ;;
+  sql_always_where: ${firefox_ios_clients.first_seen_date} >= '2010-01-01' ;;
   view_name: firefox_ios_clients
 
   always_filter: {
     filters: [
-      submission_date: "28 days",
+      first_seen_date: "28 days",
     ]
   }
 
   query: activated_client_count {
     dimensions: [firefox_ios_clients.first_seen_month, firefox_ios_clients.is_activated, firefox_ios_clients.client_count]
-    label: "Number of clients activated in the last 6 complete months."
-    description: "Number of clients activated in the last 6 complete months."
+    label: "Number of clients activated in the last 6 complete months (release channel)."
+    description: "Number of clients activated in the last 6 complete months (release channel)."
     sorts: [firefox_ios_clients.first_seen_month: desc, firefox_ios_clients.is_activated: desc]
-    filters: [firefox_ios_clients.submission_date: "7 month ago for 7 month", firefox_ios_clients.first_seen_month: "6 month ago for 6 month", firefox_ios_clients.channel: "release"]
+    filters: [firefox_ios_clients.first_seen_month: "6 month ago for 6 month", firefox_ios_clients.channel: "release"]
     limit: 100
   }
 }

--- a/firefox_ios/views/firefox_ios_clients.view.lkml
+++ b/firefox_ios/views/firefox_ios_clients.view.lkml
@@ -53,6 +53,10 @@ view: +firefox_ios_clients {
     group_item_label: "App Channel"
   }
 
+  dimension_group: submission {
+    hidden: yes
+  }
+
   dimension: is_suspicious_device_client {
     hidden: yes
   }

--- a/moso_mastodon_web/moso_mastodon_web.model.lkml
+++ b/moso_mastodon_web/moso_mastodon_web.model.lkml
@@ -1,0 +1,9 @@
+connection: "telemetry"
+label: "Mozilla Social Web App"
+# Include files from looker-hub or spoke-default below. For example:
+# include: "//looker-hub/moso_mastodon_web/explores/*"
+# include: "//looker-hub/moso_mastodon_web/dashboards/*"
+# include: "//looker-hub/moso_mastodon_web/views/*"
+# include: "views/*"
+# include: "explores/*"
+# include: "dashboards/*"

--- a/moso_mastodon_web/moso_mastodon_web.model.lkml
+++ b/moso_mastodon_web/moso_mastodon_web.model.lkml
@@ -1,9 +1,0 @@
-connection: "telemetry"
-label: "Mozilla Social Web App"
-# Include files from looker-hub or spoke-default below. For example:
-# include: "//looker-hub/moso_mastodon_web/explores/*"
-# include: "//looker-hub/moso_mastodon_web/dashboards/*"
-# include: "//looker-hub/moso_mastodon_web/views/*"
-# include: "views/*"
-# include: "explores/*"
-# include: "dashboards/*"


### PR DESCRIPTION
# feat(): firefox ios firefox android clients remove submission date dimension

Making this change as submission_date has no analytical meaning and is purely an ETL specific detail. We should remove it from the explore to avoid confusion among the users.