### PR TITLE
Bug #1879531 Design and implement a "Web Properties" dashboard

### DIFF
--- a/websites/dashboards/web_sessions.dashboard.lookml
+++ b/websites/dashboards/web_sessions.dashboard.lookml
@@ -1,0 +1,1265 @@
+---
+- dashboard: website_sessions
+  title: Website Sessions
+  layout: newspaper
+  preferred_viewer: dashboards-next
+  description: ''
+  preferred_slug: m5X74lUFBW3irBLM8vVtXC
+  elements:
+  - title: Top Page Paths
+    name: Top Page Paths
+    model: websites
+    explore: web_sessions
+    type: looker_grid
+    fields: [web_sessions.page_path, web_sessions.session_count, web_sessions.client_count]
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    defaults_version: 1
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 28
+    col: 12
+    width: 12
+    height: 8
+  - title: Client Countries
+    name: Client Countries
+    model: websites
+    explore: web_sessions
+    type: looker_geo_choropleth
+    fields: [web_sessions.client_count, web_sessions.normalized_country_code]
+    sorts: [web_sessions.client_count desc]
+    limit: 500
+    column_limit: 50
+    map: auto
+    map_projection: ''
+    show_view_names: false
+    quantize_colors: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    defaults_version: 1
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 6
+    col: 8
+    width: 8
+    height: 8
+  - title: Unique Clients and Sessions Daily
+    name: Unique Clients and Sessions Daily
+    model: websites
+    explore: web_sessions
+    type: looker_line
+    fields: [web_sessions.submission_date, web_sessions.client_count, web_sessions.session_count]
+    fill_fields: [web_sessions.submission_date]
+    sorts: [web_sessions.submission_date desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - category: measure
+      expression: "${web_sessions.new_session}"
+      label: New Session Count
+      value_format:
+      value_format_name:
+      based_on: web_sessions.session_count
+      filter_expression: "${web_sessions.new_session}"
+      _kind_hint: measure
+      measure: new_session_count
+      type: count_distinct
+      _type_hint: number
+      filters: {}
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    defaults_version: 1
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 0
+    col: 0
+    width: 16
+    height: 6
+  - title: Browsers
+    name: Browsers
+    model: websites
+    explore: web_sessions
+    type: looker_pie
+    fields: [web_sessions.client_count, web_sessions.metadata__user_agent__browser]
+    sorts: [web_sessions.client_count desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - args:
+      - web_sessions.client_count
+      calculation_type: percent_of_column_sum
+      category: table_calculation
+      based_on: web_sessions.client_count
+      label: Percent of Events Stream Table Client Count
+      source_field: web_sessions.client_count
+      table_calculation: percent_of_events_stream_table_client_count
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      _type_hint: number
+      is_disabled: true
+    value_labels: legend
+    label_type: labPer
+    inner_radius: 50
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    truncate_header: false
+    size_to_fit: true
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+      percent_of_events_stream_table_client_count:
+        is_active: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hide_totals: false
+    hide_row_totals: false
+    defaults_version: 1
+    hidden_pivots: {}
+    show_value_labels: true
+    font_size: 12
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 6
+    col: 16
+    width: 4
+    height: 8
+  - title: External Referrers
+    name: External Referrers
+    model: websites
+    explore: web_sessions
+    type: looker_bar
+    fields: [web_sessions.session_count, web_sessions.client_count, web_sessions.external_referrer]
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    defaults_version: 1
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 42
+    col: 0
+    width: 12
+    height: 8
+  - title: Top Visited Pages
+    name: Top Visited Pages
+    model: websites
+    explore: web_sessions
+    type: looker_bar
+    fields: [web_sessions.session_count, web_sessions.client_count, web_sessions.page_title]
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    defaults_version: 1
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 28
+    col: 0
+    width: 12
+    height: 8
+  - title: Operating Systems
+    name: Operating Systems
+    model: websites
+    explore: web_sessions
+    type: looker_pie
+    fields: [web_sessions.client_count, web_sessions.metadata__user_agent__os]
+    sorts: [web_sessions.client_count desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - args:
+      - web_sessions.client_count
+      calculation_type: percent_of_column_sum
+      category: table_calculation
+      based_on: web_sessions.client_count
+      label: Percent of Events Stream Table Client Count
+      source_field: web_sessions.client_count
+      table_calculation: percent_of_events_stream_table_client_count
+      value_format:
+      value_format_name: percent_0
+      _kind_hint: measure
+      _type_hint: number
+      is_disabled: true
+    value_labels: legend
+    label_type: labPer
+    inner_radius: 50
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    truncate_header: false
+    size_to_fit: true
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+      percent_of_events_stream_table_client_count:
+        is_active: false
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hide_totals: false
+    hide_row_totals: false
+    defaults_version: 1
+    hidden_pivots: {}
+    show_value_labels: true
+    font_size: 12
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 6
+    col: 20
+    width: 4
+    height: 8
+  - title: Total Unique Clients
+    name: Total Unique Clients
+    model: websites
+    explore: web_sessions
+    type: single_value
+    fields: [web_sessions.client_count]
+    limit: 500
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hidden_pivots: {}
+    defaults_version: 1
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 0
+    col: 16
+    width: 4
+    height: 3
+  - title: Total Unique Sessions
+    name: Total Unique Sessions
+    model: websites
+    explore: web_sessions
+    type: single_value
+    fields: [web_sessions.session_count]
+    limit: 500
+    column_limit: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hidden_pivots: {}
+    defaults_version: 1
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 3
+    col: 16
+    width: 4
+    height: 3
+  - title: Client Countries (detail)
+    name: Client Countries (detail)
+    model: websites
+    explore: web_sessions
+    type: looker_grid
+    fields: [web_sessions.client_count, countries.name]
+    sorts: [web_sessions.client_count desc]
+    limit: 500
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    conditional_formatting: [{type: along a scale..., value: !!null '', background_color: "#3FE1B0",
+        font_color: !!null '', color_application: {collection_id: mozilla, palette_id: mozilla-sequential-0},
+        bold: false, italic: false, strikethrough: false, fields: !!null ''}]
+    map: auto
+    map_projection: ''
+    quantize_colors: false
+    defaults_version: 1
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 6
+    col: 0
+    width: 8
+    height: 8
+  - title: Sessions Per Client (avg)
+    name: Sessions Per Client (avg)
+    model: websites
+    explore: web_sessions
+    type: single_value
+    fields: [web_sessions.client_count, web_sessions.session_count]
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${web_sessions.session_count}/${web_sessions.client_count}"
+      label: Average Sessions per Client
+      value_format:
+      value_format_name: decimal_3
+      _kind_hint: measure
+      table_calculation: average_sessions_per_client
+      _type_hint: number
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    hidden_pivots: {}
+    defaults_version: 1
+    hidden_fields: [web_sessions.client_count, web_sessions.session_count]
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 0
+    col: 20
+    width: 4
+    height: 3
+  - title: Total New Sessions
+    name: Total New Sessions
+    model: websites
+    explore: web_sessions
+    type: single_value
+    fields: [web_sessions.session_count]
+    filters:
+      web_sessions.new_session: 'Yes'
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    defaults_version: 1
+    hidden_pivots: {}
+    show_null_points: true
+    interpolation: linear
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 3
+    col: 20
+    width: 4
+    height: 3
+  - title: Bounce Rate
+    name: Bounce Rate
+    model: websites
+    explore: web_sessions
+    type: looker_pie
+    fields: [web_sessions.is_bounce, web_sessions.session_count]
+    fill_fields: [web_sessions.is_bounce]
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    value_labels: legend
+    label_type: labPer
+    inner_radius: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 14
+    col: 20
+    width: 4
+    height: 6
+  - title: New and Returning Sessions Daily
+    name: New and Returning Sessions Daily
+    model: websites
+    explore: web_sessions
+    type: looker_area
+    fields: [web_sessions.submission_date, web_sessions.session_count, new_sessions]
+    fill_fields: [web_sessions.submission_date]
+    sorts: [web_sessions.submission_date desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${web_sessions.session_count} - ${new_sessions}"
+      label: Returning Sessions
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: returning_sessions
+      _type_hint: number
+    - category: measure
+      expression: "${web_sessions.new_session}"
+      label: New Sessions
+      value_format:
+      value_format_name:
+      based_on: web_sessions.session_count
+      filter_expression: "${web_sessions.new_session}"
+      _kind_hint: measure
+      measure: new_sessions
+      type: count_distinct
+      _type_hint: number
+      filters: {}
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: normal
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    y_axes: [{label: '', orientation: left, series: [{axisId: new_session_count, id: new_session_count,
+            name: New Session Count}, {axisId: returning_sessions, id: returning_sessions,
+            name: Returning Sessions}], showLabels: true, showValues: true, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}, {label: !!null '',
+        orientation: right, series: [{axisId: web_sessions.bounced_count, id: web_sessions.bounced_count,
+            name: Bounced Count}], showLabels: true, showValues: true, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}]
+    x_axis_zoom: true
+    y_axis_zoom: true
+    defaults_version: 1
+    hidden_pivots: {}
+    hidden_fields: [web_sessions.session_count]
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 14
+    col: 0
+    width: 12
+    height: 6
+  - title: Top Exit Pages
+    name: Top Exit Pages
+    model: websites
+    explore: web_sessions
+    type: looker_bar
+    fields: [web_sessions.session_count, web_sessions.client_count, web_sessions.exit_title]
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    defaults_version: 1
+    listen:
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 20
+    col: 12
+    width: 12
+    height: 8
+  - title: 'Top Landing Pages '
+    name: 'Top Landing Pages '
+    model: websites
+    explore: web_sessions
+    type: looker_bar
+    fields: [web_sessions.session_count, web_sessions.client_count, web_sessions.landing_title]
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    defaults_version: 1
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 20
+    col: 0
+    width: 12
+    height: 8
+  - title: New and Returning Sessions
+    name: New and Returning Sessions
+    model: websites
+    explore: web_sessions
+    type: looker_pie
+    fields: [web_sessions.session_count, new_and_returning_sessions]
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - category: dimension
+      expression: if(${web_sessions.new_session}, "New", "Returning")
+      label: New and Returning Sessions
+      value_format:
+      value_format_name:
+      dimension: new_and_returning_sessions
+      _kind_hint: dimension
+      _type_hint: string
+    value_labels: legend
+    label_type: labPer
+    inner_radius: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 14
+    col: 12
+    width: 4
+    height: 6
+  - title: Engaged Sessions
+    name: Engaged Sessions
+    model: websites
+    explore: web_sessions
+    type: looker_pie
+    fields: [web_sessions.session_count, engaged_sessions]
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    dynamic_fields:
+    - category: dimension
+      expression: "${web_sessions.session_page_load_count} >= 2 AND ${web_sessions.session_duration}\
+        \ > 60"
+      label: Engaged Sessions
+      value_format:
+      value_format_name:
+      dimension: engaged_sessions
+      _kind_hint: dimension
+      _type_hint: yesno
+    value_labels: legend
+    label_type: labPer
+    inner_radius: 50
+    custom_color_enabled: true
+    show_single_value_title: true
+    show_comparison: false
+    comparison_type: value
+    comparison_reverse_colors: false
+    show_comparison_label: true
+    enable_conditional_formatting: false
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 14
+    col: 16
+    width: 4
+    height: 6
+  - title: Traffic Sources Daily
+    name: Traffic Sources Daily
+    model: websites
+    explore: web_sessions
+    type: looker_line
+    fields: [web_sessions.submission_date, web_sessions.traffic_source, web_sessions.session_count]
+    pivots: [web_sessions.traffic_source]
+    fill_fields: [web_sessions.submission_date]
+    sorts: [web_sessions.submission_date desc, web_sessions.traffic_source]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: monotone
+    x_axis_zoom: true
+    y_axis_zoom: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 36
+    col: 0
+    width: 24
+    height: 6
+  - title: Traffic Source Breakdown
+    name: Traffic Source Breakdown
+    model: websites
+    explore: web_sessions
+    type: looker_bar
+    fields: [web_sessions.session_count, web_sessions.traffic_source]
+    sorts: [web_sessions.session_count desc]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: '12'
+    rows_font_size: '12'
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    show_sql_query_menu_options: false
+    show_totals: true
+    show_row_totals: true
+    truncate_header: false
+    minimum_column_width: 75
+    series_cell_visualizations:
+      web_sessions.client_count:
+        is_active: true
+      web_sessions.session_count:
+        is_active: true
+    defaults_version: 1
+    hidden_pivots: {}
+    listen:
+      Country Name: countries.name
+      External Referrer: web_sessions.external_referrer
+      App Channel: web_sessions.app_channel
+      UA - Browser: web_sessions.metadata__user_agent__browser
+      Submission Date: web_sessions.submission_date_filter
+      Traffic Source: web_sessions.traffic_source
+      App ID: web_sessions.app_id
+    row: 42
+    col: 12
+    width: 12
+    height: 8
+  filters:
+  - name: App ID
+    title: App ID
+    type: field_filter
+    default_value: debug^_ping^_view
+    allow_multiple_values: true
+    required: true
+    ui_config:
+      type: dropdown_menu
+      display: inline
+    model: websites
+    explore: web_sessions
+    listens_to_filters: []
+    field: web_sessions.app_id
+  - name: Submission Date
+    title: Submission Date
+    type: field_filter
+    default_value: 7 day
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: relative_timeframes
+      display: inline
+      options: []
+    model: websites
+    explore: web_sessions
+    listens_to_filters: []
+    field: web_sessions.submission_date_filter
+  - name: Country Name
+    title: Country Name
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: tag_list
+      display: popover
+    model: websites
+    explore: web_sessions
+    listens_to_filters: []
+    field: countries.name
+  - name: External Referrer
+    title: External Referrer
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: checkboxes
+      display: popover
+    model: websites
+    explore: web_sessions
+    listens_to_filters: []
+    field: web_sessions.external_referrer
+  - name: App Channel
+    title: App Channel
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: button_group
+      display: inline
+    model: websites
+    explore: web_sessions
+    listens_to_filters: []
+    field: web_sessions.app_channel
+  - name: UA - Browser
+    title: UA - Browser
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: tag_list
+      display: popover
+    model: websites
+    explore: web_sessions
+    listens_to_filters: []
+    field: web_sessions.metadata__user_agent__browser
+  - name: Traffic Source
+    title: Traffic Source
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: button_group
+      display: inline
+    model: websites
+    explore: web_sessions
+    listens_to_filters: []
+    field: web_sessions.traffic_source

--- a/websites/explores/web_sessions.explore.lkml
+++ b/websites/explores/web_sessions.explore.lkml
@@ -1,0 +1,20 @@
+include: "../views/web_sessions.view.lkml"
+include: "/shared/views/*"
+
+explore: web_sessions {
+  view_name: web_sessions
+
+  always_filter: {
+    filters: [
+      web_sessions.submission_date_filter: "28 days",
+      web_sessions.app_id: ""
+    ]
+  }
+
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${web_sessions.normalized_country_code} = ${countries.code} ;;
+  }
+
+}

--- a/websites/views/web_sessions.view.lkml
+++ b/websites/views/web_sessions.view.lkml
@@ -1,0 +1,270 @@
+view: web_sessions {
+  derived_table: {
+    sql:
+    with page_session_dimensions as (
+      select
+        client_info.session_id as session_id,
+        first_value(safe.string(event_extra.url)) over (session_win) as landing_url,
+        first_value(safe.string(event_extra.referrer)) over (session_win) as landing_referrer,
+        first_value(safe.string(event_extra.title)) over (session_win) as landing_title,
+        last_value(safe.string(event_extra.title)) over (session_win) as exit_title,
+        timestamp_diff(
+          last_value(submission_timestamp) over (session_win),
+          first_value(submission_timestamp) over (session_win), millisecond) as session_length_ms,
+        count(1) over (session_win) as session_page_load_count,
+        max(submission_timestamp) over (session_win) as max_timestamp,
+      from `mozdata.{% parameter app_id %}.events_stream`
+      where event_name = 'page_load' and event_category = 'glean'
+      and submission_timestamp >= coalesce({% date_start submission_date_filter %}, timestamp_sub(current_timestamp(), interval 28 day))
+      and submission_timestamp <= coalesce({% date_end submission_date_filter %}, current_timestamp())
+      qualify submission_timestamp = max_timestamp
+      window session_win as (partition by client_info.session_id order by submission_timestamp ROWS BETWEEN unbounded preceding AND unbounded following)
+    )
+    select
+      page_session_dimensions.*,
+      events_stream.*
+    from `mozdata.{% parameter app_id %}.events_stream` events_stream
+    left join page_session_dimensions on (page_session_dimensions.session_id = events_stream.client_info.session_id)
+    where event_category = 'glean'
+      and submission_timestamp >= coalesce({% date_start submission_date_filter %}, timestamp_sub(current_timestamp(), interval 28 day))
+      and submission_timestamp <= coalesce({% date_end submission_date_filter %}, current_timestamp())
+    ;;
+  }
+
+  filter: submission_date_filter {
+    type: date
+  }
+
+  parameter: app_id {
+    type: unquoted
+    default_value: "debug_ping_view"
+    allowed_value: {
+      label: "Glean Debug Ping View"
+      value: "debug_ping_view"
+    }
+    allowed_value: {
+      label: "Glean Dictionary"
+      value: "glean_dictionary"
+    }
+  }
+
+  dimension_group: submission {
+    sql: ${TABLE}.submission_timestamp ;;
+    type: time
+    timeframes: [
+      raw,
+      time,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+  }
+
+  dimension: session_id {
+    # primary_key: yes
+    sql: ${TABLE}.session_id ;;
+    type: string
+  }
+
+  dimension: client_id {
+    # primary_key: yes
+    sql: ${TABLE}.client_id ;;
+    type: string
+  }
+
+  ##
+  # Session level dimensions
+  ##
+  dimension: landing_url {
+    type: string
+    sql: ${TABLE}.landing_url ;;
+  }
+
+  dimension: landing_referrer {
+    type: string
+    sql: ${TABLE}.landing_referrer ;;
+  }
+
+  dimension: landing_title {
+    type: string
+    sql: ${TABLE}.landing_title ;;
+  }
+
+  dimension: exit_title {
+    type: string
+    sql: ${TABLE}.exit_title ;;
+  }
+
+  dimension: session_page_load_count {
+    type: number
+    sql: ${TABLE}.session_page_load_count ;;
+  }
+
+  dimension: session_duration {
+    type: number
+    sql: round(${TABLE}.session_length_ms/1000, 1) ;;
+  }
+
+  dimension: is_bounce {
+    type: yesno
+    sql: ${session_page_load_count} = 1 ;;
+  }
+
+  dimension: traffic_source {
+    type: string
+    sql: case
+      when regexp_contains(${landing_referrer}, r"bing|google|baidu|yahoo|duckduckgo") then
+        if(regexp_contains(${landing_referrer}, r'utm_(campaign|source|medium)'), "Paid Search", "Organic Search")
+      when trim(${landing_referrer}) = "" then "Direct"
+      when regexp_contains(${landing_referrer}, r'utm_(campaign|source|medium)') then "Paid"
+      else "Other"
+    end;;
+  }
+
+  ##
+  # Event level dimensions
+  ##
+  dimension: new_session {
+    sql: ${TABLE}.client_info.session_count = 1 ;;
+    type: yesno
+  }
+
+  dimension: normalized_country_code {
+    sql: ${TABLE}.normalized_country_code ;;
+    type: string
+    map_layer_name: countries
+  }
+
+  dimension: page_url {
+    type: string
+    sql: safe.string(${TABLE}.event_extra.url) ;;
+    hidden: yes
+  }
+
+  dimension: page_path {
+    type: string
+    sql: regexp_extract(${page_url},r"(?:http[s]?:\/\/)?(?:[^\/\s]+)(\/.*)") ;;
+  }
+
+  dimension: page_title {
+    type: string
+    sql: safe.string(${TABLE}.event_extra.title) ;;
+  }
+
+  dimension: referrer {
+    type: string
+    sql: safe.string(${TABLE}.event_extra.referrer) ;;
+  }
+
+  dimension: external_referrer {
+    type: string
+    sql: if(net.host(${referrer}) = net.host(${page_url}) or ${referrer} = "", null, ${referrer}) ;;
+  }
+
+  dimension: referrer_host {
+    type: string
+    sql: net.host(${referrer}) ;;
+  }
+
+  dimension: utm_params__utm_source {
+    sql: mozfun.utils.extract_utm_from_url(${page_url}).utm_source ;;
+    type: string
+    group_label: "UTM Parameters"
+    group_item_label: "UTM Source"
+  }
+
+  dimension: utm_params__utm_medium {
+    sql: mozfun.utils.extract_utm_from_url(${page_url}).utm_medium ;;
+    type: string
+    group_label: "UTM Parameters"
+    group_item_label: "UTM Medium"
+  }
+
+  dimension: utm_params__utm_campaign {
+    sql: mozfun.utils.extract_utm_from_url(${page_url}).utm_campaign ;;
+    type: string
+    group_label: "UTM Parameters"
+    group_item_label: "UTM Campaign"
+  }
+
+  dimension: utm_params__utm_content {
+    sql: mozfun.utils.extract_utm_from_url(${page_url}).utm_content ;;
+    type: string
+    group_label: "UTM Parameters"
+    group_item_label: "UTM Content"
+  }
+
+  ##
+  # A Selection of Events Stream Dimensions
+  ##
+
+  dimension: app_channel {
+    type: string
+    sql: ${TABLE}.client_info.app_channel ;;
+  }
+
+  dimension: metadata__isp__name {
+    sql: ${TABLE}.metadata.isp.name ;;
+    type: string
+    group_label: "Metadata Isp"
+    group_item_label: "Name"
+  }
+
+  dimension: metadata__isp__organization {
+    sql: ${TABLE}.metadata.isp.organization ;;
+    type: string
+    group_label: "Metadata Isp"
+    group_item_label: "Organization"
+  }
+
+  dimension: metadata__user_agent__browser {
+    sql: ${TABLE}.metadata.user_agent.browser ;;
+    type: string
+    group_label: "Metadata User Agent"
+    group_item_label: "Browser"
+  }
+
+  dimension: metadata__user_agent__os {
+    sql: ${TABLE}.metadata.user_agent.os ;;
+    type: string
+    group_label: "Metadata User Agent"
+    group_item_label: "Os"
+  }
+
+  dimension: metadata__user_agent__version {
+    sql: ${TABLE}.metadata.user_agent.version ;;
+    type: string
+    group_label: "Metadata User Agent"
+    group_item_label: "Version"
+  }
+
+
+
+  measure: client_count {
+    type: count_distinct
+    sql: ${client_id} ;;
+  }
+
+  measure: session_count {
+    type: count_distinct
+    sql: ${session_id} ;;
+  }
+
+  measure: average_session_duration {
+    type: average
+    sql: ${session_duration} ;;
+  }
+
+  measure: bounced_count {
+    type: sum_distinct
+    sql: if(${is_bounce}, 1, 0)  ;;
+    sql_distinct_key: ${session_id} ;;
+  }
+
+  measure: bounce_rate {
+    type: number
+    sql: safe_divide(${bounced_count}, ${session_count}) ;;
+  }
+}

--- a/websites/websites.model.lkml
+++ b/websites/websites.model.lkml
@@ -1,6 +1,7 @@
 connection: "telemetry"
 label: "Websites"
 
+include: "dashboards/*"
 include: "explores/*"
 include: "views/*"
 


### PR DESCRIPTION
New explore/view and dashboard to support https://bugzilla.mozilla.org/show_bug.cgi?id=1879531

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
