### PR TITLE
Rewrite the query to use page_ids. add click dimension, measure support.

### DIFF
--- a/websites/views/web_sessions.view.lkml
+++ b/websites/views/web_sessions.view.lkml
@@ -1,9 +1,20 @@
 view: web_sessions {
   derived_table: {
     sql:
-    with page_session_dimensions as (
+    with events_with_page_ids as (
       select
+        *,
         client_info.session_id as session_id,
+        sum(if(event_name = 'page_load', 1, 0)) over (session_window) page_id
+      from `mozdata.{% parameter app_id %}.events_stream`
+      where event_category = 'glean' and client_info.session_id is not null
+        and submission_timestamp >= coalesce({% date_start submission_date_filter %}, timestamp_sub(current_timestamp(), interval 28 day))
+        and submission_timestamp <= coalesce({% date_end submission_date_filter %}, current_timestamp())
+      window session_window as (partition by client_info.session_id order by submission_timestamp)
+    ),
+    session_level_metrics as (
+      select
+        session_id,
         first_value(safe.string(event_extra.url)) over (session_win) as landing_url,
         first_value(safe.string(event_extra.referrer)) over (session_win) as landing_referrer,
         first_value(safe.string(event_extra.title)) over (session_win) as landing_title,
@@ -11,24 +22,79 @@ view: web_sessions {
         timestamp_diff(
           last_value(submission_timestamp) over (session_win),
           first_value(submission_timestamp) over (session_win), millisecond) as session_length_ms,
-        count(1) over (session_win) as session_page_load_count,
+        countif(event_name = 'page_load') over (session_win) as session_page_load_count,
+        countif(event_name = 'element_click') over (session_win) as session_click_count,
         max(submission_timestamp) over (session_win) as max_timestamp,
-      from `mozdata.{% parameter app_id %}.events_stream`
-      where event_name = 'page_load' and event_category = 'glean'
-      and submission_timestamp >= coalesce({% date_start submission_date_filter %}, timestamp_sub(current_timestamp(), interval 28 day))
-      and submission_timestamp <= coalesce({% date_end submission_date_filter %}, current_timestamp())
+      from events_with_page_ids
       qualify submission_timestamp = max_timestamp
-      window session_win as (partition by client_info.session_id order by submission_timestamp ROWS BETWEEN unbounded preceding AND unbounded following)
+      window session_win as (partition by session_id order by submission_timestamp ROWS BETWEEN unbounded preceding AND unbounded following)
+    ),
+    page_level_metrics as (
+      select
+        session_id,
+        document_id,
+        -- Add page title and url to the click event extras
+        case
+          when event_name = 'element_click' then
+          json_set(event_extra,
+            '$.title', first_value(safe.string(event_extra.title)) over (session_page_window),
+            '$.url', first_value(safe.string(event_extra.url)) over (session_page_window),
+            '$.referrer', first_value(safe.string(event_extra.referrer)) over (session_page_window)
+          )
+          else event_extra
+        end as event_extra,
+        case
+          when event_name = 'page_load' then
+            timestamp_diff(
+              greatest(
+                -- next page load ts
+                max(if(event_name = 'page_load', submission_timestamp, timestamp_millis(0))) over (session_event_window rows between current row and 1 following),
+                -- last event on page ts
+                max(submission_timestamp) over (session_page_window rows between current row and unbounded following)
+              ),
+              submission_timestamp,
+              MILLISECOND
+            )
+          else null
+        end page_dwell_ms,
+        case
+          when event_name = 'page_load' then
+            countif(event_name = 'element_click') over (session_page_window ROWS BETWEEN current row AND unbounded following)
+          else null
+        end page_click_count,
+      from events_with_page_ids
+      window session_page_window as (partition by session_id, page_id order by submission_timestamp),
+        session_event_window as (partition by session_id, event_name order by submission_timestamp)
     )
+
     select
-      page_session_dimensions.*,
-      events_stream.*
-    from `mozdata.{% parameter app_id %}.events_stream` events_stream
-    left join page_session_dimensions on (page_session_dimensions.session_id = events_stream.client_info.session_id)
-    where event_category = 'glean'
-      and submission_timestamp >= coalesce({% date_start submission_date_filter %}, timestamp_sub(current_timestamp(), interval 28 day))
-      and submission_timestamp <= coalesce({% date_end submission_date_filter %}, current_timestamp())
-    ;;
+      events_stream.submission_timestamp as submission_timestamp,
+      events_stream.session_id as session_id,
+      events_stream.document_id as document_id,
+      events_stream.client_info.session_count as session_count,
+      events_stream.client_info.app_channel as app_channel,
+      events_stream.metadata.isp as isp,
+      events_stream.metadata.user_agent as user_agent,
+      events_stream.client_id as client_id,
+      events_stream.normalized_country_code as normalized_country_code,
+      events_stream.event_name as event_name,
+      events_stream.event_category as event_category,
+      page_level_metrics.event_extra as event_extra,
+      session_level_metrics.landing_url as landing_url,
+      session_level_metrics.landing_referrer as landing_referrer,
+      session_level_metrics.landing_title as landing_title,
+      session_level_metrics.exit_title as exit_title,
+      session_level_metrics.session_length_ms as session_length_ms,
+      session_level_metrics.session_page_load_count as session_page_load_count,
+      session_level_metrics.session_click_count as session_click_count,
+      page_level_metrics.page_click_count as page_click_count,
+      page_level_metrics.page_dwell_ms as page_dwell_ms,
+    from events_with_page_ids events_stream
+    left join session_level_metrics on (session_level_metrics.session_id = events_stream.session_id)
+    left join page_level_metrics on (
+      page_level_metrics.session_id = events_stream.session_id and
+      page_level_metrics.document_id = events_stream.document_id
+    );;
   }
 
   filter: submission_date_filter {
@@ -130,8 +196,14 @@ view: web_sessions {
   ##
   # Event level dimensions
   ##
+
+  dimension: event_name {
+    sql: ${TABLE}.event_name ;;
+    type: string
+  }
+
   dimension: new_session {
-    sql: ${TABLE}.client_info.session_count = 1 ;;
+    sql: ${TABLE}.session_count = 1 ;;
     type: yesno
   }
 
@@ -206,45 +278,56 @@ view: web_sessions {
 
   dimension: app_channel {
     type: string
-    sql: ${TABLE}.client_info.app_channel ;;
+    sql: ${TABLE}.app_channel ;;
   }
 
   dimension: metadata__isp__name {
-    sql: ${TABLE}.metadata.isp.name ;;
+    sql: ${TABLE}.isp.name ;;
     type: string
     group_label: "Metadata Isp"
     group_item_label: "Name"
   }
 
   dimension: metadata__isp__organization {
-    sql: ${TABLE}.metadata.isp.organization ;;
+    sql: ${TABLE}.isp.organization ;;
     type: string
     group_label: "Metadata Isp"
     group_item_label: "Organization"
   }
 
   dimension: metadata__user_agent__browser {
-    sql: ${TABLE}.metadata.user_agent.browser ;;
+    sql: ${TABLE}.user_agent.browser ;;
     type: string
     group_label: "Metadata User Agent"
     group_item_label: "Browser"
   }
 
   dimension: metadata__user_agent__os {
-    sql: ${TABLE}.metadata.user_agent.os ;;
+    sql: ${TABLE}.user_agent.os ;;
     type: string
     group_label: "Metadata User Agent"
     group_item_label: "Os"
   }
 
   dimension: metadata__user_agent__version {
-    sql: ${TABLE}.metadata.user_agent.version ;;
+    sql: ${TABLE}.user_agent.version ;;
     type: string
     group_label: "Metadata User Agent"
     group_item_label: "Version"
   }
 
+  ###
+  # Click dimensions
+  ###
+  dimension: click_target {
+    type: string
+    sql: safe.string(${TABLE}.event_extra.target) ;;
+  }
 
+  dimension: click_label {
+    type: string
+    sql: safe.string(${TABLE}.event_extra.label) ;;
+  }
 
   measure: client_count {
     type: count_distinct
@@ -254,6 +337,11 @@ view: web_sessions {
   measure: session_count {
     type: count_distinct
     sql: ${session_id} ;;
+  }
+
+  measure: event_count {
+    type: count_distinct
+    sql: ${TABLE}.document_id ;;
   }
 
   measure: average_session_duration {
@@ -270,5 +358,15 @@ view: web_sessions {
   measure: bounce_rate {
     type: number
     sql: safe_divide(${bounced_count}, ${session_count}) ;;
+  }
+
+  measure: average_page_dwell {
+    type: average
+    sql: ${TABLE}.page_dwell_ms ;;
+  }
+
+  measure: average_clicks_per_page {
+    type: average
+    sql: ${TABLE}.page_click_count ;;
   }
 }


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
