### PR TITLE
add new explore and view: `urlbar_sessions_daily`

### DIFF
--- a/experimentation/experimentation.model.lkml
+++ b/experimentation/experimentation.model.lkml
@@ -339,15 +339,7 @@ explore: unenrollment_reasons {
     hidden: yes
   }
 
-  explore: task_profiling_logs {
-    hidden: yes
-  }
-
   explore: experimenter_experiments {}
-
-  explore: mr_2022_weekly_statistics_desktop_existing_users {}
-
-  explore: mr_2022_weekly_statistic_desktop_new_users {}
 
   explore: +preview {
     join: experimenter_experiments {

--- a/firefox_desktop/explores/urlbar_sessions_daily.explore.lkml
+++ b/firefox_desktop/explores/urlbar_sessions_daily.explore.lkml
@@ -1,0 +1,10 @@
+include: "/firefox_desktop/views/urlbar_sessions_daily.view.lkml"
+
+explore: urlbar_sessions_daily {
+  view_name: urlbar_sessions_daily
+
+  always_filter: {
+    filters: [urlbar_sessions_daily.submission_date: "after 2023-11-01"
+    ]
+  }
+}

--- a/firefox_desktop/views/urlbar_events_daily_table.view.lkml
+++ b/firefox_desktop/views/urlbar_events_daily_table.view.lkml
@@ -69,13 +69,6 @@ view: +urlbar_events_daily_table {
     type: number
   }
 
-  measure: total_urlbar_sessions {
-    group_label: "Urlbar Metrics"
-    description: "The number of times a user initiates an interaction with the urlbar"
-    sql: SUM(${TABLE}.urlbar_sessions) ;;
-    type: number
-  }
-
   measure: total_urlbar_annoyances {
     group_label: "Urlbar Metrics"
     description: "Count of clicks on annoyance signals across all results shown in the urlbar dropdown menu"

--- a/firefox_desktop/views/urlbar_sessions_daily.view.lkml
+++ b/firefox_desktop/views/urlbar_sessions_daily.view.lkml
@@ -1,0 +1,84 @@
+view: urlbar_sessions_daily {
+  derived_table: {
+    sql: SELECT
+        submission_date,
+        normalized_country_code,
+        normalized_channel,
+        firefox_suggest_enabled,
+        sponsored_suggestions_enabled,
+        ANY_VALUE(urlbar_sessions) as total_urlbar_sessions,
+        SUM(urlbar_clicks) as total_urlbar_clicks,
+        SUM(urlbar_annoyances) as total_urlbar_annoyances
+      FROM
+        `mozdata.firefox_desktop.urlbar_events_daily`
+      GROUP BY
+        submission_date,
+        normalized_country_code,
+        normalized_channel,
+        firefox_suggest_enabled,
+        sponsored_suggestions_enabled
+            ;;
+
+  }
+
+  dimension_group: submission {
+    sql: ${TABLE}.submission_date ;;
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+
+  dimension: normalized_country_code {
+    sql: ${TABLE}.normalized_country_code ;;
+    type: string
+  }
+
+  dimension: normalized_channel {
+    sql: ${TABLE}.normalized_channel ;;
+    type: string
+  }
+
+  dimension: firefox_suggest_enabled {
+    sql: ${TABLE}.firefox_suggest_enabled ;;
+    type: yesno
+    group_label: "User Preferences"
+    description: "Whether or not the checkbox for showing Firefox Suggestions is checked in about:preferences"
+  }
+
+  dimension: sponsored_suggestions_enabled {
+    sql: ${TABLE}.sponsored_suggestions_enabled ;;
+    type: yesno
+    group_label: "User Preferences"
+    description: "Whether or not the checkbox for showing sponsored suggestions is checked in about:preferences"
+  }
+
+  measure: total_urlbar_sessions {
+    group_label: "Urlbar Metrics"
+    description: "The number of times a user initiates an interaction with the urlbar"
+    sql: SUM(${TABLE}.total_urlbar_sessions) ;;
+    type: number
+  }
+
+  measure: total_urlbar_clicks {
+    group_label: "Urlbar Metrics"
+    description: "Count of clicks on any result shown in the urlbar dropdown menu"
+    sql: SUM(${TABLE}.total_urlbar_clicks) ;;
+    type: number
+  }
+
+  measure: total_urlbar_annoyances {
+    group_label: "Urlbar Metrics"
+    description: "Count of clicks on annoyance signals across all results shown in the urlbar dropdown menu"
+    sql: SUM(${TABLE}.total_urlbar_annoyances) ;;
+    type: number
+  }
+
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
