### PR TITLE
Fix parantheses error and exclude non-relevant oauth client IDs

### DIFF
--- a/accounts_backend/explores/mozilla_accounts_multi_service_dau.explore.lkml
+++ b/accounts_backend/explores/mozilla_accounts_multi_service_dau.explore.lkml
@@ -10,7 +10,7 @@ explore: mozilla_accounts_multi_service_dau {
 
   join: service_names {
     from: mozilla_accounts_multi_service_dau__service_names
-    sql_table_name: UNNEST(mozilla_accounts_multi_service_dau.service_names} ;;
+    sql_table_name: UNNEST(mozilla_accounts_multi_service_dau.service_names) ;;
     sql_on: TRUE ;;
     type: left_outer
     relationship: one_to_many

--- a/accounts_backend/views/mozilla_accounts_multi_service_dau.view.lkml
+++ b/accounts_backend/views/mozilla_accounts_multi_service_dau.view.lkml
@@ -14,7 +14,32 @@ view: mozilla_accounts_multi_service_dau {
     ON e.metrics.string.relying_party_oauth_client_id = c.id
     WHERE (e.metrics.string.event_name IN ('reg_complete', 'login_complete')
      OR e.metrics.string.event_name like r'access\_token%')
-    AND c.id NOT IN ('c87d36d7fd9a1bcf', '00efbcb5b2dbfa0e', '6cd7216e25bc0fc0', 'b8a3bdc3790a61f6', '2a54021236022573', '1e5a77cf09e5b4b5', '7377719276ad44ee', '2963d96620413b9f', 'c40f32fd2938f0b6', 'b966b5f51190da9e', '3c32bf6654542211', '6c6c2958595c38de', '7f368c6886429f19', 'a3dbd8c5a6fd93e2', '85da77264642d6a1', '7ad9917f6c55fb77', '0d1a8469632d0f61', '565585c1745a144d', '798de7affc08df8b', 'ea3ca969f8c6bb0d', 'e7ce535d93522896', '98adfa37698f255b', '3c49430b43dfba77', '59cceb6f8c32317c')
+    AND c.id NOT IN (
+      '00efbcb5b2dbfa0e',  -- Mozilla.social invitation flow
+      '0d1a8469632d0f61',  -- Hubs Reticulum
+      '1e5a77cf09e5b4b5',  -- AMO Stage
+      '2963d96620413b9f',  -- 123done-heroku-untrusted
+      '2a54021236022573',  -- Cinder Report Form
+      '3c32bf6654542211',  -- 123done-heroku
+      '3c49430b43dfba77',  -- Android Components Reference Browser
+      '565585c1745a144d',  -- Firefox Private Network
+      '59cceb6f8c32317c',  -- Mozilla subscriptions management
+      '6c6c2958595c38de',  -- Thunderbird Appointment
+      '6cd7216e25bc0fc0',  -- Add-ons Internal Stage
+      '7377719276ad44ee',  -- Pocket mobile
+      '798de7affc08df8b',  -- MDN Plus App
+      '7ad9917f6c55fb77',  -- Firefox Reality
+      '7f368c6886429f19',  -- Notes
+      '85da77264642d6a1',  -- Firefox for Fire TV
+      '98adfa37698f255b',  -- Firefox Lockwise
+      'a3dbd8c5a6fd93e2',  -- Notes
+      'b8a3bdc3790a61f6',  -- Mozilla Support Stage
+      'b966b5f51190da9e',  -- Add-ons Internal Production
+      'c40f32fd2938f0b6',  -- Mozilla email preferences
+      'c87d36d7fd9a1bcf',  -- Pontoon Staging
+      'e7ce535d93522896',  -- Firefox Lockwise
+      'ea3ca969f8c6bb0d'   -- Firefox Accounts
+    )
     GROUP BY
       1, 2
     HAVING ARRAY_LENGTH(service_names) > 1;;

--- a/accounts_backend/views/mozilla_accounts_multi_service_dau.view.lkml
+++ b/accounts_backend/views/mozilla_accounts_multi_service_dau.view.lkml
@@ -14,6 +14,7 @@ view: mozilla_accounts_multi_service_dau {
     ON e.metrics.string.relying_party_oauth_client_id = c.id
     WHERE (e.metrics.string.event_name IN ('reg_complete', 'login_complete')
      OR e.metrics.string.event_name like r'access\_token%')
+    AND c.id NOT IN ('c87d36d7fd9a1bcf', '00efbcb5b2dbfa0e', '6cd7216e25bc0fc0', 'b8a3bdc3790a61f6', '2a54021236022573', '1e5a77cf09e5b4b5', '7377719276ad44ee', '2963d96620413b9f', 'c40f32fd2938f0b6', 'b966b5f51190da9e', '3c32bf6654542211', '6c6c2958595c38de', '7f368c6886429f19', 'a3dbd8c5a6fd93e2', '85da77264642d6a1', '7ad9917f6c55fb77', '0d1a8469632d0f61', '565585c1745a144d', '798de7affc08df8b', 'ea3ca969f8c6bb0d', 'e7ce535d93522896', '98adfa37698f255b', '3c49430b43dfba77', '59cceb6f8c32317c')
     GROUP BY
       1, 2
     HAVING ARRAY_LENGTH(service_names) > 1;;


### PR DESCRIPTION
@sean-rose I know we discussed earlier about not hard-coding services to include (i.e `WHERE oauth_client_id IN (..)` but there are a set of oauth client IDs we don't wish to track on dashboards because they are not relevant to product decisions, that I am instead excluding here. This way, any new oauth client ID that is added will still be tracked.