### PR TITLE
Google Search Console revisions (DENG-1733)

### DIFF
--- a/websites/explores/google_search_console_by_page.explore.lkml
+++ b/websites/explores/google_search_console_by_page.explore.lkml
@@ -8,8 +8,14 @@ explore: google_search_console_by_page {
 
   join: user_countries {
     from: countries
+    view_label: "User Regions"
     sql_on: ${google_search_console_by_page.user_country_code} = ${user_countries.code_3} ;;
     type: left_outer
     relationship: many_to_one
+    fields: [
+      region_name,
+      subregion_name,
+      intermediate_region_name
+    ]
   }
 }

--- a/websites/explores/google_search_console_by_page.explore.lkml
+++ b/websites/explores/google_search_console_by_page.explore.lkml
@@ -6,6 +6,19 @@ explore: google_search_console_by_page {
     filters: [google_search_console_by_page.date_date: "30 days"]
   }
 
+  join: localized_site_countries {
+    from: countries
+    view_label: "Localized Site Regions"
+    sql_on: ${google_search_console_by_page.localized_site_country_code} = ${localized_site_countries.code} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      region_name,
+      subregion_name,
+      intermediate_region_name
+    ]
+  }
+
   join: user_countries {
     from: countries
     view_label: "User Regions"

--- a/websites/explores/google_search_console_by_page.explore.lkml
+++ b/websites/explores/google_search_console_by_page.explore.lkml
@@ -6,8 +6,9 @@ explore: google_search_console_by_page {
     filters: [google_search_console_by_page.date_date: "30 days"]
   }
 
-  join: countries {
-    sql_on: ${google_search_console_by_page.country_code} = ${countries.code_3} ;;
+  join: user_countries {
+    from: countries
+    sql_on: ${google_search_console_by_page.user_country_code} = ${user_countries.code_3} ;;
     type: left_outer
     relationship: many_to_one
   }

--- a/websites/explores/google_search_console_by_site.explore.lkml
+++ b/websites/explores/google_search_console_by_site.explore.lkml
@@ -6,8 +6,9 @@ explore: google_search_console_by_site {
     filters: [google_search_console_by_site.date_date: "30 days"]
   }
 
-  join: countries {
-    sql_on: ${google_search_console_by_site.country_code} = ${countries.code_3} ;;
+  join: user_countries {
+    from: countries
+    sql_on: ${google_search_console_by_site.user_country_code} = ${user_countries.code_3} ;;
     type: left_outer
     relationship: many_to_one
   }

--- a/websites/explores/google_search_console_by_site.explore.lkml
+++ b/websites/explores/google_search_console_by_site.explore.lkml
@@ -8,8 +8,14 @@ explore: google_search_console_by_site {
 
   join: user_countries {
     from: countries
+    view_label: "User Regions"
     sql_on: ${google_search_console_by_site.user_country_code} = ${user_countries.code_3} ;;
     type: left_outer
     relationship: many_to_one
+    fields: [
+      region_name,
+      subregion_name,
+      intermediate_region_name
+    ]
   }
 }


### PR DESCRIPTION
## [DENG-1733](https://mozilla-hub.atlassian.net/browse/DENG-1733): Make Google Search Console data available for use

These updates depend on https://github.com/mozilla/bigquery-etl/pull/5424, and will be deployed in conjunction with that.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
