### PR TITLE
added retention metrics to the base explore

### DIFF
--- a/growth/views/android_app_campaign_stats.view.lkml
+++ b/growth/views/android_app_campaign_stats.view.lkml
@@ -70,6 +70,18 @@ view: android_app_campaign_stats {
     hidden: yes
   }
 
+  dimension: repeat_users_dim {
+    sql: COALESCE(${TABLE}.repeat_users, 0) ;;
+    type: number
+    hidden: yes
+  }
+
+  dimension: week_4_retained_users_dim {
+    sql: COALESCE(${TABLE}.week_4_retained_users, 0) ;;
+    type: number
+    hidden: yes
+  }
+
   dimension: spend_dim {
     sql: COALESCE(${TABLE}.spend, 0) ;;
     type: number
@@ -134,6 +146,18 @@ view: android_app_campaign_stats {
     description: "Estimated value, in US dollars, of the clients attributed to this campaign/ad group."
   }
 
+  measure: total_repeat_users {
+    type: sum
+    sql: ${repeat_users_dim} ;;
+    description: "Total number of attributed repeat new profiles for this campaign/ad group, as reported by Firefox Telemetry"
+  }
+
+  measure: total_week_4_retained_users {
+    type: sum
+    sql: ${week_4_retained_users_dim} ;;
+    description: "Total number of attributed week 4 retained new profiles for this campaign/ad group, as reported by Firefox Telemetry"
+  }
+
   measure: cost_per_impression {
     description: "Cost per ad impression"
     type: number
@@ -167,10 +191,35 @@ view: android_app_campaign_stats {
     sql: SUM(IF(${TABLE}.date < DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY), ${activated_profiles_dim}, 0)) ;;
   }
 
+  measure: filtered_retention_spend {
+    description: "Spend, but not including the last 28 days"
+    hidden: yes
+    sql: SUM(IF(${TABLE}.date < DATE_ADD(CURRENT_DATE(), INTERVAL -28 DAY), ${spend_dim}, 0)) ;;
+  }
+
+  measure: filtered_repeat_users {
+    description: "Filter repeat users using the same where clause as filtered_retention_spend"
+    hidden: yes
+    sql: SUM(IF(${TABLE}.date < DATE_ADD(CURRENT_DATE(), INTERVAL -28 DAY), ${repeat_users_dim}, 0)) ;;
+  }
+
+  measure: filtered_week_4_retained_users {
+    description: "Filter week 4 retained users using the same where clause as filtered_retention_spend"
+    hidden: yes
+    sql: SUM(IF(${TABLE}.date < DATE_ADD(CURRENT_DATE(), INTERVAL -28 DAY), ${week_4_retained_users_dim}, 0)) ;;
+  }
+
+
   measure: filtered_new_profiles {
     description: "Filter new profiles using the same where clause as filtered_activated_spend"
     hidden: yes
     sql: SUM(IF(${TABLE}.date < DATE_ADD(CURRENT_DATE(), INTERVAL -7 DAY), ${new_profiles_dim}, 0)) ;;
+  }
+
+  measure: filtered_ret_new_profiles {
+    description: "Filter new profiles using the same where clause as filtered_activated_spend"
+    hidden: yes
+    sql: SUM(IF(${TABLE}.date < DATE_ADD(CURRENT_DATE(), INTERVAL -28 DAY), ${new_profiles_dim}, 0)) ;;
   }
 
   measure: cost_per_activation {
@@ -179,6 +228,21 @@ view: android_app_campaign_stats {
     value_format_name: usd
     sql: SAFE_DIVIDE(${filtered_activated_spend}, ${filtered_activated}) ;;
   }
+
+  measure: cost_per_repeat_user {
+    description: "Cost per repeat user. Takes 28 days for this value to appear."
+    type: number
+    value_format_name: usd
+    sql: SAFE_DIVIDE(${filtered_retention_spend}, ${filtered_repeat_users}) ;;
+  }
+
+  measure: cost_per_week_4_retained_users {
+    description: "Cost per week 4 retained user. Takes 28 days for this value to appear."
+    type: number
+    value_format_name: usd
+    sql: SAFE_DIVIDE(${filtered_retention_spend}, ${filtered_week_4_retained_users}) ;;
+  }
+
 
   measure: ROAS {
     sql: SAFE_DIVIDE(${total_lifetime_value}, ${total_spend}) ;;
@@ -250,6 +314,22 @@ view: android_app_campaign_stats {
     type: number
     value_format_name: percent_2
     sql: SAFE_DIVIDE(${filtered_activated}, ${filtered_new_profiles}) ;;
+    hidden: yes
+  }
+
+  measure: repeat_user_rate {
+    label: "Repeat User Rate"
+    type: number
+    value_format_name: percent_2
+    sql: SAFE_DIVIDE(${filtered_repeat_users}, ${filtered_ret_new_profiles}) ;;
+    hidden: yes
+  }
+
+  measure: week_4_retention_rate {
+    label: "Week 4 Retention Rate"
+    type: number
+    value_format_name: percent_2
+    sql: SAFE_DIVIDE(${filtered_week_4_retained_users}, ${filtered_ret_new_profiles}) ;;
     hidden: yes
   }
 


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
