### PR TITLE
Fix "Retention by Cohort" chart on Monitor SaaSboard (DS-3009)

### DIFF
--- a/subscription_platform/dashboards/monitor_saasboard__retention.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__retention.dashboard.lookml
@@ -4,7 +4,7 @@
   layout: newspaper
   preferred_viewer: dashboards-next
   description: ''
-  preferred_slug: 4OLpCAQsglh1d434LNOjP5
+  preferred_slug: twy49L634gzYTaHbf0rQtX
   elements:
   - name: ''
     type: text
@@ -211,14 +211,14 @@
     model: subscription_platform
     explore: logical_subscriptions
     type: looker_column
-    fields: [retention_by_month.retained_subscription_count, logical_subscriptions.started_at_month,
+    fields: [logical_subscriptions.started_at_month, logical_subscriptions.active_logical_subscription_count,
       logical_subscriptions.logical_subscription_count]
     sorts: [logical_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${retention_by_month.retained_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${logical_subscriptions.active_logical_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_0
@@ -269,6 +269,7 @@
       retention_by_month.churned_subscription_count: "#FF7139"
       retention_by_month.retained_subscription_count: "#0060E0"
       retention_rate: "#000000"
+      logical_subscriptions.active_logical_subscription_count: "#0060E0"
     defaults_version: 1
     hidden_fields: [logical_subscriptions.logical_subscription_count]
     hidden_pivots: {}

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -121,6 +121,11 @@ view: +logical_subscriptions {
     type: count
   }
 
+  measure: active_logical_subscription_count {
+    type: count
+    filters: [is_active: "yes"]
+  }
+
   measure: provider_subscription_count {
     type: count_distinct
     sql: ${TABLE}.provider_subscription_id ;;


### PR DESCRIPTION
## [DS-3009](https://mozilla-hub.atlassian.net/browse/DS-3009): create dashboards for Monitor Premium's Q4 release

The "Retention by Cohort" chart was incorrectly using the Retention by Month > Retained Subscription Count measure without including the Retention by Month > Subscription Month Number dimension, resulting in it counting subscriptions that retained in their first month (or any other month) as "currently" retained.

This fixes the "Retention by Cohort" chart by only counting subscriptions that are currently active as currently retained.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
