### PR TITLE
More Google Search Console revisions (DENG-1733)

### DIFF
--- a/websites/explores/google_search_console_by_page.explore.lkml
+++ b/websites/explores/google_search_console_by_page.explore.lkml
@@ -5,17 +5,4 @@ explore: google_search_console_by_page {
   conditionally_filter: {
     filters: [google_search_console_by_page.date_date: "30 days"]
   }
-
-  join: user_countries {
-    from: countries
-    view_label: "User Regions"
-    sql_on: ${google_search_console_by_page.user_country_code} = ${user_countries.code_3} ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      region_name,
-      subregion_name,
-      intermediate_region_name
-    ]
-  }
 }

--- a/websites/explores/google_search_console_by_page.explore.lkml
+++ b/websites/explores/google_search_console_by_page.explore.lkml
@@ -6,7 +6,7 @@ explore: google_search_console_by_page {
     filters: [google_search_console_by_page.date_date: "30 days"]
   }
 
-  query: recent_popular_queries {
+  query: recent_popular_web_search_queries {
     dimensions: [query, site_domain_name]
     measures: [distinct_page_url_count, average_result_position, total_impressions, total_clicks, click_through_rate]
     filters: [
@@ -18,11 +18,12 @@ explore: google_search_console_by_page {
     limit: 100
   }
 
-  query: recent_popular_pages {
+  query: recent_popular_web_search_pages {
     dimensions: [page_url, site_domain_name]
     measures: [distinct_query_count, average_result_position, total_impressions, total_clicks, click_through_rate]
     filters: [
       google_search_console_by_page.date_date: "30 days",
+      google_search_console_by_page.is_anonymized: "No",
       google_search_console_by_page.search_type: "Web"
     ]
     sorts: [total_clicks: desc]

--- a/websites/explores/google_search_console_by_page.explore.lkml
+++ b/websites/explores/google_search_console_by_page.explore.lkml
@@ -5,4 +5,27 @@ explore: google_search_console_by_page {
   conditionally_filter: {
     filters: [google_search_console_by_page.date_date: "30 days"]
   }
+
+  query: recent_popular_queries {
+    dimensions: [query, site_domain_name]
+    measures: [distinct_page_url_count, average_result_position, total_impressions, total_clicks, click_through_rate]
+    filters: [
+      google_search_console_by_page.date_date: "30 days",
+      google_search_console_by_page.is_anonymized: "No",
+      google_search_console_by_page.search_type: "Web"
+    ]
+    sorts: [total_impressions: desc]
+    limit: 100
+  }
+
+  query: recent_popular_pages {
+    dimensions: [page_url, site_domain_name]
+    measures: [distinct_query_count, average_result_position, total_impressions, total_clicks, click_through_rate]
+    filters: [
+      google_search_console_by_page.date_date: "30 days",
+      google_search_console_by_page.search_type: "Web"
+    ]
+    sorts: [total_clicks: desc]
+    limit: 100
+  }
 }

--- a/websites/explores/google_search_console_by_page.explore.lkml
+++ b/websites/explores/google_search_console_by_page.explore.lkml
@@ -6,19 +6,6 @@ explore: google_search_console_by_page {
     filters: [google_search_console_by_page.date_date: "30 days"]
   }
 
-  join: localized_site_countries {
-    from: countries
-    view_label: "Localized Site Regions"
-    sql_on: ${google_search_console_by_page.localized_site_country_code} = ${localized_site_countries.code} ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      region_name,
-      subregion_name,
-      intermediate_region_name
-    ]
-  }
-
   join: user_countries {
     from: countries
     view_label: "User Regions"

--- a/websites/explores/google_search_console_by_site.explore.lkml
+++ b/websites/explores/google_search_console_by_site.explore.lkml
@@ -5,4 +5,16 @@ explore: google_search_console_by_site {
   conditionally_filter: {
     filters: [google_search_console_by_site.date_date: "30 days"]
   }
+
+  query: recent_popular_queries {
+    dimensions: [query, site_domain_name]
+    measures: [average_top_result_position, total_impressions, total_clicks, click_through_rate]
+    filters: [
+      google_search_console_by_site.date_date: "30 days",
+      google_search_console_by_site.is_anonymized: "No",
+      google_search_console_by_site.search_type: "Web"
+    ]
+    sorts: [total_impressions: desc]
+    limit: 100
+  }
 }

--- a/websites/explores/google_search_console_by_site.explore.lkml
+++ b/websites/explores/google_search_console_by_site.explore.lkml
@@ -6,7 +6,7 @@ explore: google_search_console_by_site {
     filters: [google_search_console_by_site.date_date: "30 days"]
   }
 
-  query: recent_popular_queries {
+  query: recent_popular_web_search_queries {
     dimensions: [query, site_domain_name]
     measures: [average_top_result_position, total_impressions, total_clicks, click_through_rate]
     filters: [

--- a/websites/explores/google_search_console_by_site.explore.lkml
+++ b/websites/explores/google_search_console_by_site.explore.lkml
@@ -5,17 +5,4 @@ explore: google_search_console_by_site {
   conditionally_filter: {
     filters: [google_search_console_by_site.date_date: "30 days"]
   }
-
-  join: user_countries {
-    from: countries
-    view_label: "User Regions"
-    sql_on: ${google_search_console_by_site.user_country_code} = ${user_countries.code_3} ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      region_name,
-      subregion_name,
-      intermediate_region_name
-    ]
-  }
 }

--- a/websites/views/google_search_console_by_page.view.lkml
+++ b/websites/views/google_search_console_by_page.view.lkml
@@ -48,6 +48,11 @@ view: +google_search_console_by_page {
     description: "The average position of the page in the search results, where `1` is the topmost position. This will be null for Discover and Google News search impressions."
   }
 
+  measure: distinct_page_url_count {
+    type: count_distinct
+    sql: ${page_url} ;;
+  }
+
   measure: distinct_query_count {
     type: count_distinct
     sql: ${query} ;;

--- a/websites/views/google_search_console_by_page.view.lkml
+++ b/websites/views/google_search_console_by_page.view.lkml
@@ -47,4 +47,9 @@ view: +google_search_console_by_page {
     value_format_name: decimal_2
     description: "The average position of the page in the search results, where `1` is the topmost position. This will be null for Discover and Google News search impressions."
   }
+
+  measure: distinct_query_count {
+    type: count_distinct
+    sql: ${query} ;;
+  }
 }

--- a/websites/views/google_search_console_by_site.view.lkml
+++ b/websites/views/google_search_console_by_site.view.lkml
@@ -41,4 +41,9 @@ view: +google_search_console_by_site {
     value_format_name: decimal_2
     description: "The average top position of the site in the search results, where `1` is the topmost position."
   }
+
+  measure: distinct_query_count {
+    type: count_distinct
+    sql: ${query} ;;
+  }
 }


### PR DESCRIPTION
## [DENG-1733](https://mozilla-hub.atlassian.net/browse/DENG-1733): Make Google Search Console data available for use

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
