### PR TITLE
Adding tiles dismissals measures to newtab_visits

### DIFF
--- a/firefox_desktop/explores/newtab_visits.explore.lkml
+++ b/firefox_desktop/explores/newtab_visits.explore.lkml
@@ -37,6 +37,7 @@ explore: newtab_visits {
       ]
       measures: [
         newtab_visits_table__topsite_tile_interactions.sum_sponsored_topsite_tile_impressions,
+        newtab_visits_table__topsite_tile_interactions.sum_sponsored_topsite_tile_dismissals,
         newtab_visits_table__topsite_tile_interactions.sum_sponsored_topsite_tile_clicks,
         newtab_visits.clients
       ]

--- a/firefox_desktop/views/newtab_visits.view.lkml
+++ b/firefox_desktop/views/newtab_visits.view.lkml
@@ -104,6 +104,15 @@ view: +newtab_visits_table__topsite_tile_interactions {
     type: sum
   }
 
+  dimension: organic_topsite_tile_dismissals {
+    hidden: yes
+  }
+
+  measure: sum_organic_topsite_tile_dismissals {
+    sql: ${TABLE}.organic_topsite_tile_dismissals ;;
+    type: sum
+  }
+
   dimension: sponsored_topsite_tile_clicks {
     hidden: yes
   }
@@ -122,6 +131,15 @@ view: +newtab_visits_table__topsite_tile_interactions {
     type: sum
   }
 
+  dimension: sponsored_topsite_tile_dismissals {
+    hidden: yes
+  }
+
+  measure: sum_sponsored_topsite_tile_dismissals {
+    sql: ${TABLE}.sponsored_topsite_tile_dismissals ;;
+    type: sum
+  }
+
   dimension: topsite_tile_clicks {
     hidden: yes
   }
@@ -137,6 +155,15 @@ view: +newtab_visits_table__topsite_tile_interactions {
 
   measure: sum_topsite_tile_impressions {
     sql: ${TABLE}.topsite_tile_impressions ;;
+    type: sum
+  }
+
+  dimension: topsite_tile_dismissals {
+    hidden: yes
+  }
+
+  measure: sum_topsite_tile_dismissals {
+    sql: ${TABLE}.topsite_tile_dismissals ;;
     type: sum
   }
 }


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
