### PR TITLE
Use source countries table for all suggests

### DIFF
--- a/shared/views/countries.view.lkml
+++ b/shared/views/countries.view.lkml
@@ -2,6 +2,11 @@ include: "//looker-hub/shared/views/countries.view"
 
 view: +countries {
 
+  # Almost unbelievelably, Looker throws a validation error when a suggest_dimension
+  # references the field itself, _even_ if coming from a different view.
+  # For that reason, we had to add the hidden "_suggest_*" fields, so Looker
+  # doesn't think the field is referencing itself.
+
   dimension: tier {
     type: string
     sql:
@@ -12,6 +17,14 @@ view: +countries {
       END ;;
 
     description: "Country tier, as used in relation to browser KPIs. The specific meaning of Tier 1 may vary across different products."
+    suggestable: yes
+    suggest_explore: countries_suggest_explore
+    suggest_dimension: countries_suggest_explore._suggest_tier
+  }
+  
+  dimension: _suggest_tier {
+    hidden: yes
+    sql: ${tier} ;;
   }
 
   dimension: name {
@@ -19,6 +32,14 @@ view: +countries {
     type: string
     description: "Official country name per ISO 3166"
     map_layer_name: countries
+    suggestable: yes
+    suggest_explore: countries_suggest_explore
+    suggest_dimension: countries_suggest_explore._suggest_name
+  }
+  
+  dimension: _suggest_name {
+    hidden: yes
+    sql: ${name} ;;
   }
 
   dimension: code {
@@ -26,7 +47,17 @@ view: +countries {
     type: string
     description: "ISO 3166 alpha-2 country code"
     map_layer_name: countries
+    suggestable: yes
+    suggest_explore: countries_suggest_explore
+    suggest_dimension: countries_suggest_explore._suggest_code
   }
+  
+  dimension: _suggest_code {
+    hidden: yes
+    sql: ${code} ;;
+  }
+}
 
-
+explore: countries_suggest_explore {
+  from: countries
 }


### PR DESCRIPTION
Currently, when trying to suggest on e.g. `countries.names`, Looker tries to query the entire source dataset for distinct field names. The problem is that the source datasets (e.g. `active_users_aggregates`) usually require a `submission_date` filter. Because the suggest doesn't filter, the suggest fails, and nothing shows.

This is visible in e.g. [this dashboard](https://mozilla.cloud.looker.com/dashboards/885?Country=).

This change will query _just_ the `countries` table for distinct country names and codes. This is a bit of a behavior change, but since suggests by and large were not working previously, I believe these are acceptable: Countries will present themselves in these results even if the underlying dataset doesn't have that country present.

Checklist for reviewer:

When adding a new derived dataset:
- [x] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [x] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [x] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [x] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
