### PR TITLE
Revert "Add missing first_seen_date for metrics views"

### DIFF
--- a/firefox_desktop/firefox_desktop.model.lkml
+++ b/firefox_desktop/firefox_desktop.model.lkml
@@ -161,19 +161,3 @@ view: +clients_daily_table__contextual_services_quicksuggest_impression_sum {
     type: number
   }
 }
-
-# todo: fix in generation
-view: +metric_definitions_clients_first_seen_v2 {
-  dimension: first_seen_date {
-    sql: ${TABLE}.first_seen_date ;;
-    type: date
-  }
-}
-
-# todo: fix in generation
-view: +metric_definitions_clients_first_seen_28_days_later {
-  dimension: first_seen_date {
-    sql: ${TABLE}.first_seen_date ;;
-    type: date
-  }
-}


### PR DESCRIPTION
Reverts mozilla/looker-spoke-default#849

Depends on https://github.com/mozilla/lookml-generator/pull/981/