### PR TITLE
Create placeholder search forecasting explore and view

### DIFF
--- a/search/explores/search_funnel_forecasts.explore.lkml
+++ b/search/explores/search_funnel_forecasts.explore.lkml
@@ -1,0 +1,6 @@
+include: "../views/search_funnel_forecasts.view.lkml"
+
+explore: search_funnel_forecasts {
+  label: "Search Funnel Metric Forecasts"
+  from: search_funnel_forecasts
+}

--- a/search/views/search_funnel_forecasts.view.lkml
+++ b/search/views/search_funnel_forecasts.view.lkml
@@ -1,0 +1,122 @@
+view: search_funnel_forecasts {
+  derived_table: {
+    sql:
+    -- Need to filter out forecast start dates with multiple forecasts; keeps the most recent
+    WITH cte AS (
+      SELECT
+        country,
+        channel,
+        device,
+        partner,
+        metric_alias,
+        forecast_start_date,
+        MAX(forecast_trained_at) AS forecast_trained_at,
+      FROM
+        `mozdata.analysis.search_funnel_forecasts`
+      GROUP BY 1, 2, 3, 4, 5, 6
+    )
+    SELECT
+      srf.*
+    FROM
+      `mozdata.analysis.search_funnel_forecasts` srf
+    WHERE
+      forecast_trained_at IN (SELECT forecast_trained_at FROM cte);;
+  }
+
+  dimension_group: submission {
+    sql: ${TABLE}.submission_date ;;
+    type: time
+    timeframes: [
+      date,
+      day_of_week,
+      week,
+      month,
+      month_name,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+
+  dimension: country {
+    sql: ${TABLE}.country ;;
+    type: string
+  }
+
+  dimension: channel {
+    sql: ${TABLE}.channel ;;
+    type: string
+  }
+
+  dimension: device {
+    sql: ${TABLE}.device ;;
+    type: string
+  }
+
+  dimension: partner {
+    sql: ${TABLE}.partner ;;
+    type: string
+  }
+
+  dimension: forecast_start_date {
+    sql:  ${TABLE}.forecast_start_date ;;
+    type: string
+    description: "First date of forecasted series as a string."
+  }
+
+  dimension: forecast_end_date {
+    sql:  ${TABLE}.forecast_start_date ;;
+    type: string
+    description: "Last date of forecasted series as a string."
+  }
+
+  dimension:  aggregation_period {
+    sql:  ${TABLE}.aggregation_period ;;
+    type: string
+    description: "Aggregation period of the value, either 'month' or 'day'."
+  }
+
+  dimension:  source {
+    sql:  ${TABLE}.source ;;
+    type: string
+    description: "Whether the value on this submission date is a forecasted or historical value."
+  }
+
+  dimension: metric_name {
+    sql: REPLACE(${TABLE}.metric_alias, "search_forecasting_", "") ;;
+    type:  string
+    description: "Name of forecasted metric."
+  }
+
+  dimension: metric_hub_app_name {
+    sql: ${TABLE}.metric_hub_app_name ;;
+    type:  string
+    description: "Name of the app in the `metric-hub` repo where this metric's definition can be found."
+  }
+
+  measure: value {
+    sql: ${TABLE}.value ;;
+    type: sum
+    description: "Value of the forecasted or actuals for the given metric."
+  }
+
+  measure: value_low {
+    sql:  ${TABLE}.value_low ;;
+    type:  sum
+    description: "On forecasted dates, the lower bound of the 90% credible interval."
+  }
+
+  measure: value_mid {
+    sql:  ${TABLE}.value_mid ;;
+    type:  sum
+    description: "On forecasted dates, the midpoint of the 90% credible interval."
+  }
+
+  measure: value_high {
+    sql:  ${TABLE}.value_high ;;
+    type:  sum
+    description: "On forecasted dates, the upper bound of the 90% credible interval."
+  }
+
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
