### PR TITLE
Revert "Auto-push from LookML generation"

### DIFF
--- a/fakespot/explores/product_analyses.explore.lkml
+++ b/fakespot/explores/product_analyses.explore.lkml
@@ -1,0 +1,5 @@
+include: "../views/unified_analyses.view.lkml"
+
+explore: product_analyses {
+  view_name: unified_analyses
+}

--- a/fakespot/fakespot.model.lkml
+++ b/fakespot/fakespot.model.lkml
@@ -1,0 +1,6 @@
+connection: "telemetry"
+
+label: "Fakespot"
+
+include: "views/*.view.lkml"
+include: "explores/*.explore.lkml"

--- a/fakespot/views/unified_analyses.view.lkml
+++ b/fakespot/views/unified_analyses.view.lkml
@@ -1,0 +1,150 @@
+view: unified_analyses {
+   # Or, you could make this view a derived table, like this:
+   derived_table: {
+     sql: SELECT
+        "amazon" as source,
+        product_id,
+        * except (id, exchange_review_words_detected, product_id),
+        RANK() OVER (partition by product_id ORDER BY updated_at) as analysis_rank,
+      FROM `mozdata.fakespot.amazon_analyses`
+      UNION ALL
+      SELECT
+        "bestbuy" as source,
+        bestbuy_product_id as product_id,
+        * except (id, bestbuy_product_id),
+        RANK() OVER (partition by bestbuy_product_id ORDER BY updated_at) as analysis_rank,
+      FROM `mozdata.fakespot.bestbuy_analyses`
+      UNION ALL
+      SELECT
+        "walmart" as source,
+        walmart_product_id as product_id,
+        * except (id, walmart_product_id),
+        RANK() OVER (partition by walmart_product_id ORDER BY updated_at) as analysis_rank,
+      FROM `mozdata.fakespot.walmart_analyses`
+      UNION ALL
+      SELECT
+        "home_depot" as source,
+        home_depot_product_id as product_id,
+        * except (id, home_depot_product_id),
+        RANK() OVER (partition by home_depot_product_id ORDER BY updated_at) as analysis_rank,
+      FROM `mozdata.fakespot.home_depot_analyses`
+      UNION ALL
+      SELECT
+        "flipkart" as source,
+        flipkart_product_id as product_id,
+        * except (id, flipkart_product_id),
+        RANK() OVER (partition by flipkart_product_id ORDER BY updated_at) as analysis_rank,
+      FROM `mozdata.fakespot.flipkart_analyses`
+       ;;
+  }
+
+  # Define your dimensions and measures here, like this:
+  dimension: source {
+    description: "Product Source"
+    type: string
+    sql: ${TABLE}.source ;;
+  }
+
+  dimension: product_id {
+    description: "Vendor specific product id"
+    type: number
+    sql: ${TABLE}.product_id ;;
+  }
+
+  dimension: url {
+    description: "Product Url"
+    type: string
+    sql: ${TABLE}.url ;;
+  }
+
+  dimension: name {
+    description: "Product name"
+    type: string
+    sql: ${TABLE}.name ;;
+  }
+
+  dimension: company {
+    description: "Product company"
+    type: string
+    sql: ${TABLE}.company ;;
+  }
+
+  dimension: category {
+    description: "Product category"
+    type: string
+    sql: ${TABLE}.category ;;
+  }
+
+  dimension: created_at {
+    description: "Analysis Created Time"
+    type: date_time
+    sql: TIMESTAMP(${TABLE}.created_at) ;;
+  }
+
+  dimension: updated_at {
+    description: "Analysis Updated Time"
+    type: date_time
+    sql: TIMESTAMP(${TABLE}.updated_at) ;;
+  }
+
+  dimension: status {
+    type: string
+    sql: ${TABLE}.status ;;
+  }
+
+  dimension: total_fake_reviews {
+    type: number
+    sql: ${TABLE}.total_fake_reviews ;;
+  }
+
+  dimension: total_legit_reviews {
+    type: number
+    sql: ${TABLE}.total_legit_reviews ;;
+  }
+
+  dimension: total_reviews {
+    type: number
+    sql: ${TABLE}.total_reviews ;;
+  }
+
+  dimension: percentage_fake {
+    type: number
+    sql: ${TABLE}.percentage_fake ;;
+  }
+
+  dimension: completed {
+    type: yesno
+    sql: ${TABLE}.completed ;;
+  }
+
+  dimension: rating {
+    type: number
+    sql: ${TABLE}.rating ;;
+  }
+
+  dimension: price {
+    type: string
+    sql: ${TABLE}.price ;;
+  }
+
+  dimension: percentage_fake_averaged {
+    type: number
+    sql: ${TABLE}.percentage_fake_averaged ;;
+  }
+
+  dimension: reviewers_count {
+    type: number
+    sql: ${TABLE}.reviewers_count ;;
+  }
+
+  dimension: analysis_rank {
+    type:  number
+    sql: ${TABLE}.analysis_rank ;;
+  }
+
+  measure: product_count {
+    type: count_distinct
+    sql: concat(${product_id}, ${source}) ;;
+  }
+
+}


### PR DESCRIPTION
This reverts commit 6281a9b0b99f5a98503e1660406b9c86cf2d8e34.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
