### PR TITLE
Country level browser metrics views

### DIFF
--- a/kpi/explores/country_level_yoy_metrics.explore.lkml
+++ b/kpi/explores/country_level_yoy_metrics.explore.lkml
@@ -1,0 +1,14 @@
+include: "../views/country_level_yoy_metrics.view.lkml"
+include: "/shared/views/countries.view.lkml"
+
+explore: country_level_yoy_metrics {
+  label: "Country-Level Year-over-Year Browser Metrics"
+  description: "Country-Level Year-over-Year Browser Metrics"
+  view_name: country_level_yoy_metrics
+
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${country_level_yoy_metrics.country} = ${countries.code} ;;
+  }
+}

--- a/kpi/views/country_level_yoy_metrics.view.lkml
+++ b/kpi/views/country_level_yoy_metrics.view.lkml
@@ -28,7 +28,13 @@ view: country_level_yoy_metrics {
       LAG(value) OVER (PARTITION BY country, app_name, metric ORDER BY submission_date ASC) as previous_value
       FROM metrics
     )
-    SELECT *
+    SELECT
+      submission_date,
+      country,
+      app_name,
+      CASE WHEN metric IN ('dau', 'wau', 'mau') THEN UPPER(metric) ELSE 'DAU 28-day Moving Average' END as metric,
+      value,
+      previous_value
     FROM yoy
     WHERE previous_value IS NOT NULL;;
   }
@@ -77,5 +83,13 @@ view: country_level_yoy_metrics {
     description: "The metric's value 365 days ago."
     value_format_name: decimal_0
     sql: ${TABLE}.previous_value ;;
+  }
+
+  measure: yoy_difference {
+    type: sum
+    label: "YoY Difference"
+    description: "The difference between the metric's value 365 days ago and its value on the target date."
+    value_format_name: decimal_0
+    sql:${TABLE}.value - ${TABLE}.previous_value;;
   }
 }

--- a/kpi/views/country_level_yoy_metrics.view.lkml
+++ b/kpi/views/country_level_yoy_metrics.view.lkml
@@ -1,0 +1,81 @@
+view: country_level_yoy_metrics {
+  derived_table: {
+    sql:
+    WITH base AS (
+      SELECT
+        submission_date,
+        country,
+        app_name,
+        SUM(COALESCE(dau, 0)) AS dau,
+        CAST(AVG(SUM(COALESCE(dau, 0))) OVER (PARTITION BY country, app_name ORDER BY submission_date ASC ROWS BETWEEN 27 PRECEDING AND CURRENT ROW) AS INT64) AS dau_28ma, -- only correct on user input date and previous year input date
+        SUM(COALESCE(wau, 0)) AS wau,
+        SUM(COALESCE(mau, 0)) AS mau,
+      FROM
+        `moz-fx-data-shared-prod.telemetry.active_users_aggregates` AS active_users_aggregates
+      WHERE
+        submission_date BETWEEN DATE_SUB(DATE({% date_start user_input_date %}), INTERVAL 27 DAY) AND DATE({% date_start user_input_date %})
+        OR submission_date BETWEEN DATE_SUB(DATE({% date_start user_input_date %}), INTERVAL 27+365 DAY) AND DATE_SUB(DATE({% date_start user_input_date %}), INTERVAL 365 DAY)
+      GROUP BY
+        ALL
+    ), metrics AS (
+      SELECT *
+      FROM base
+      UNPIVOT(value FOR metric IN (dau, dau_28ma, wau, mau))
+      WHERE submission_date = DATE({% date_start user_input_date %})
+      OR submission_date = DATE_SUB(DATE({% date_start user_input_date %}), INTERVAL 365 DAY)
+    ), yoy AS (
+      SELECT *,
+      LAG(value) OVER (PARTITION BY country, app_name, metric ORDER BY submission_date ASC) as previous_value
+      FROM metrics
+    )
+    SELECT *
+    FROM yoy
+    WHERE previous_value IS NOT NULL;;
+  }
+  filter: user_input_date {
+    type: date
+    label: "Target Date for YoY Comparison"
+  }
+
+  dimension: submission_date {
+    type: date
+    sql: ${TABLE}.submission_date ;;
+  }
+
+  dimension: app_name {
+    type: string
+    label: "Browser Name"
+    description: "The browser app name."
+    sql: ${TABLE}.app_name ;;
+  }
+
+  dimension: metric {
+    type: string
+    label: "Metric Name"
+    description: "The metric of interest."
+    sql: ${TABLE}.metric ;;
+  }
+
+  dimension: country {
+    type: string
+    label: "Country Code"
+    description: "Country Code"
+    sql: ${TABLE}.country ;;
+  }
+
+  measure: value {
+    type: sum
+    label: "Target Date's Value"
+    description: "The metric's value."
+    value_format_name: decimal_0
+    sql: ${TABLE}.value ;;
+  }
+
+  measure: previous_value {
+    type: sum
+    label: "Prior Year's Value"
+    description: "The metric's value 365 days ago."
+    value_format_name: decimal_0
+    sql: ${TABLE}.previous_value ;;
+  }
+}


### PR DESCRIPTION
Improved version of https://github.com/mozilla/looker-spoke-default/pull/875

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
