### PR TITLE
Removes columns no longer available and fixes PDT failure to update

### DIFF
--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -4,7 +4,7 @@ include: "/shared/views/countries.view.lkml"
 explore: active_users_aggregates {
   # persist_with: active_users_aggregates_v1_last_updated
   always_filter: {
-    filters: [active_users_aggregates.app_name: "Firefox Desktop,Firefox Desktop BrowserStack, Fenix, Fenix BrowserStack, Firefox iOS, Firefox iOS BrowserStack,
+    filters: [active_users_aggregates.app_name: "Firefox Desktop, Firefox Desktop BrowserStack, Fenix, Fenix BrowserStack, Firefox iOS, Firefox iOS BrowserStack,
       Focus Android,  Focus iOS, Focus iOS BrowserStack",
       active_users_aggregates.submission_date: "after 4 weeks ago"]
   }

--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -4,7 +4,7 @@ include: "/shared/views/countries.view.lkml"
 explore: active_users_aggregates {
   # persist_with: active_users_aggregates_v1_last_updated
   always_filter: {
-    filters: [active_users_aggregates.app_name: "Firefox Desktop, Fenix, Fenix BrowserStack, Firefox iOS, Firefox iOS BrowserStack,
+    filters: [active_users_aggregates.app_name: "Firefox Desktop,Firefox Desktop BrowserStack, Fenix, Fenix BrowserStack, Firefox iOS, Firefox iOS BrowserStack,
       Focus Android,  Focus iOS, Focus iOS BrowserStack",
       active_users_aggregates.submission_date: "after 4 weeks ago"]
   }
@@ -20,7 +20,7 @@ explore: active_users_aggregates {
   aggregate_table: rollup__period_over_period {
     query: {
       dimensions: [period_over_period_pivot, period_over_period_row, active_users_aggregates.app_name, active_users_aggregates.submission_date, active_users_aggregates.ytd_only]
-      measures: [daily_active_users, weekly_active_users, monthly_active_users, new_profile, uri_counts, active_hour]
+      measures: [daily_active_users, weekly_active_users, monthly_active_users]
       filters: [
         active_users_aggregates.choose_breakdown: "Month^_Day",
         active_users_aggregates.choose_comparison: "Year",

--- a/combined_browser_metrics/views/active_users_aggregates.view.lkml
+++ b/combined_browser_metrics/views/active_users_aggregates.view.lkml
@@ -203,20 +203,6 @@ view: +active_users_aggregates {
     sql: ${TABLE}.wau ;;
   }
 
-  dimension: new_profiles {
-    hidden: yes
-    sql: ${TABLE}.new_profiles ;;
-  }
-
-  dimension: uri_count {
-    hidden: yes
-    sql: ${TABLE}.uri_count ;;
-  }
-
-  dimension: active_hours {
-    hidden: yes
-    sql: ${TABLE}.active_hours ;;
-  }
 
   # Define measures
   measure: daily_active_users {
@@ -235,24 +221,6 @@ view: +active_users_aggregates {
     label: "MAU"
     type: sum
     sql:  ${TABLE}.mau ;;
-  }
-
-  measure: new_profile {
-    label: "New Profiles"
-    type: sum
-    sql:  ${TABLE}.new_profiles ;;
-  }
-
-  measure: uri_counts {
-    label: "URI Counts"
-    type: sum
-    sql:  ${TABLE}.uri_count ;;
-  }
-
-  measure: active_hour {
-    label: "Active Hours"
-    type: sum
-    sql:  ${TABLE}.active_hours ;;
   }
 
   dimension: is_default_browser {


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
