### PR TITLE
DENG-4225 Limit rows for External Referrer tile

### DIFF
--- a/websites/dashboards/web_sessions.dashboard.lookml
+++ b/websites/dashboards/web_sessions.dashboard.lookml
@@ -13,7 +13,7 @@
     type: looker_grid
     fields: [web_sessions.page_path, web_sessions.session_count, web_sessions.client_count]
     sorts: [web_sessions.session_count desc]
-    limit: 500
+    limit: 50
     column_limit: 50
     show_view_names: false
     show_row_numbers: true
@@ -240,7 +240,7 @@
     fields: [web_sessions.session_count, web_sessions.client_count, web_sessions.external_referrer]
     sorts: [web_sessions.session_count desc]
     filters:
-      web_sessions.external_referrer: -EMPTY
+      web_sessions.external_referrer: "-EMPTY"
     limit: 50
     column_limit: 50
     x_axis_gridlines: false
@@ -296,7 +296,6 @@
     defaults_version: 1
     listen:
       Country Name: countries.name
-      External Referrer: web_sessions.external_referrer
       App Channel: web_sessions.app_channel
       UA - Browser: web_sessions.metadata__user_agent__browser
       Submission Date: web_sessions.submission_date_filter

--- a/websites/dashboards/web_sessions.dashboard.lookml
+++ b/websites/dashboards/web_sessions.dashboard.lookml
@@ -239,7 +239,9 @@
     type: looker_bar
     fields: [web_sessions.session_count, web_sessions.client_count, web_sessions.external_referrer]
     sorts: [web_sessions.session_count desc]
-    limit: 500
+    filters:
+      web_sessions.external_referrer: -EMPTY
+    limit: 50
     column_limit: 50
     x_axis_gridlines: false
     y_axis_gridlines: true


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
