### PR TITLE
Bug 1906165 :  looker PDT build fail for search.model

### DIFF
--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -68,7 +68,8 @@ explore: business_development_core_search_users_monthly {
       measures: [bizdev_search_core_users.approx_clients]
       filters: [
         bizdev_search_core_users.country: "US",
-        bizdev_search_core_users.normalized_engine: "Google"
+        bizdev_search_core_users.normalized_engine: "Google",
+        bizdev_search_core_users.submission_month: "1 months ago for 1 months"
       ]
     }
 
@@ -83,7 +84,8 @@ explore: business_development_core_search_users_monthly {
       measures: [bizdev_search_core_users.approx_clients]
       filters: [
         bizdev_search_core_users.country: "US",
-        bizdev_search_core_users.normalized_engine: "Google"
+        bizdev_search_core_users.normalized_engine: "Google",
+        bizdev_search_core_users.submission_month: "1 months ago for 1 months"
       ]
     }
 

--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -69,7 +69,7 @@ explore: business_development_core_search_users_monthly {
       filters: [
         bizdev_search_core_users.country: "US",
         bizdev_search_core_users.normalized_engine: "Google",
-        bizdev_search_core_users.submission_month: "1 months ago for 1 months"
+        bizdev_search_core_users.submission_month: "3 months"
       ]
     }
 
@@ -85,7 +85,7 @@ explore: business_development_core_search_users_monthly {
       filters: [
         bizdev_search_core_users.country: "US",
         bizdev_search_core_users.normalized_engine: "Google",
-        bizdev_search_core_users.submission_month: "1 months ago for 1 months"
+        bizdev_search_core_users.submission_month: "3 months"
       ]
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1906165

Built failed was observed for the following PDT during airlfow triage:

* business_development_core_search_users_monthly::rollup__bizdev_search_core_users_ad_click_bucket
* business_development_core_search_users_monthly::rollup__bizdev_search_core_users_clients

The error suggested that a submission_month filter is required.  I do not have the context on what the filter should be but I've added one to match the `always_filter`.

When I tried to test the explore I keep seeing that the PDTs were not used with the following note:  
```query contained the following measures we cannot roll up: bizdev_search_core_users.approx_clients.  ```
Those with context on this explore should check if the PDTs are being used / set up correctly.


Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
