### PR TITLE
Add iOS address probes to mobile feature usage dashboards

### DIFF
--- a/firefox_ios/views/firefox_ios_feature_usage_events.view.lkml
+++ b/firefox_ios/views/firefox_ios_feature_usage_events.view.lkml
@@ -167,7 +167,29 @@ view: firefox_ios_feature_usage_events {
         SUM(notification_alert_setting_disabled) AS notification_alert_setting_disabled,
         --notification_alert_setting_enabled
         SUM(notification_alert_setting_enabled_users) AS notification_alert_setting_enabled_users,
-        SUM(notification_alert_setting_enabled) AS notification_alert_setting_enabled
+        SUM(notification_alert_setting_enabled) AS notification_alert_setting_enabled,
+        /*address*/
+        --address_autofill_prompt_dismissed
+        SUM(address_autofill_prompt_dismissed_users) AS address_autofill_prompt_dismissed_users,
+        SUM(address_autofill_prompt_dismissed) AS address_autofill_prompt_dismissed,
+        --address_autofill_prompt_expanded
+        SUM(address_autofill_prompt_expanded_users) AS address_autofill_prompt_expanded_users,
+        SUM(address_autofill_prompt_expanded) AS address_autofill_prompt_expanded,
+        --address_autofill_prompt_shown
+        SUM(address_autofill_prompt_shown_users) AS address_autofill_prompt_shown_users,
+        SUM(address_autofill_prompt_shown) AS address_autofill_prompt_shown,
+        --address_autofilled
+        SUM(address_autofilled_users) AS address_autofilled_users,
+        SUM(address_autofilled) AS address_autofilled,
+        --address_form_detected
+        SUM(address_form_detected_users) AS address_form_detected_users,
+        SUM(address_form_detected) AS address_form_detected,
+        --address_modified
+        SUM(address_modified_users) AS address_modified_users,
+        SUM(address_modified) AS address_modified,
+        --address_settings_autofill
+        SUM(address_settings_autofill_users) AS address_settings_autofill_users,
+        SUM(address_settings_autofill) AS address_settings_autofill
       FROM `moz-fx-data-shared-prod.firefox_ios.feature_usage_events`
       WHERE submission_date >= '2018-01-01'
       GROUP BY 1,2 ;;}
@@ -692,6 +714,64 @@ view: firefox_ios_feature_usage_events {
     sql: ${TABLE}.tabs_tray_new_private_tab_tapped_users ;;
     type: sum
   }
+
+  measure: sum_address_autofill_prompt_dismissed {
+    sql: ${TABLE}.address_autofill_prompt_dismissed ;;
+    type: sum
+    }
+
+  measure: sum_address_autofill_prompt_dismissed_users {
+    sql: ${TABLE}.address_autofill_prompt_dismissed_users ;;
+    type: sum
+    }
+  measure: sum_address_autofill_prompt_expanded {
+    sql: ${TABLE}.address_autofill_prompt_expanded ;;
+    type: sum
+    }
+  measure: sum_address_autofill_prompt_expanded_users {
+    sql: ${TABLE}.address_autofill_prompt_expanded_users ;;
+    type: sum
+    }
+  measure: sum_address_autofill_prompt_shown {
+    sql: ${TABLE}.address_autofill_prompt_shown ;;
+    type: sum
+    }
+  measure: sum_address_autofill_prompt_shown_users {
+    sql: ${TABLE}.address_autofill_prompt_shown_users ;;
+    type: sum
+    }
+  measure: sum_address_autofilled {
+    sql: ${TABLE}.address_autofilled ;;
+    type: sum
+    }
+  measure: sum_address_autofilled_users {
+    sql: ${TABLE}.address_autofilled_users ;;
+    type: sum
+    }
+  measure: sum_address_form_detected {
+    sql: ${TABLE}.address_form_detected ;;
+    type: sum
+    }
+  measure: sum_address_form_detected_users {
+    sql: ${TABLE}.address_form_detected_users ;;
+    type: sum
+    }
+  measure: sum_address_modified {
+    sql: ${TABLE}.address_modified ;;
+    type: sum
+    }
+  measure: sum_address_modified_users {
+    sql: ${TABLE}.address_modified_users ;;
+    type: sum
+    }
+  measure: sum_address_settings_autofill {
+    sql: ${TABLE}.address_settings_autofill ;;
+    type: sum
+    }
+  measure: sum_address_settings_autofill_users {
+    sql: ${TABLE}.address_settings_autofill_users ;;
+    type: sum
+    }
 
   dimension_group: ping {
     sql: ${TABLE}.ping_date ;;

--- a/firefox_ios/views/firefox_ios_feature_usage_metrics.view.lkml
+++ b/firefox_ios/views/firefox_ios_feature_usage_metrics.view.lkml
@@ -120,7 +120,11 @@ view: firefox_ios_feature_usage_metrics {
         SUM(app_menu_customize_homepage) AS app_menu_customize_homepage,
         -- Firefox Home Page Customize Homepage Button
         SUM(firefox_home_page_customize_homepage_button_users) AS firefox_home_page_customize_homepage_button_users,
-        SUM(firefox_home_page_customize_homepage_button) AS firefox_home_page_customize_homepage_button
+        SUM(firefox_home_page_customize_homepage_button) AS firefox_home_page_customize_homepage_button,
+        /*Address*/
+         --addresses_saved_all_users
+        SUM(addresses_saved_all_users) AS addresses_saved_all_users,
+        SUM(addresses_saved_all) AS addresses_saved_all
 
       FROM `moz-fx-data-shared-prod.firefox_ios.feature_usage_metrics`
       WHERE submission_date >= '2018-01-01'
@@ -479,5 +483,14 @@ view: firefox_ios_feature_usage_metrics {
     type: sum
     sql: ${TABLE}.firefox_home_page_customize_homepage_button ;;
   }
+
+  measure: sum_addresses_saved_all_users {
+    type: sum
+    sql: ${TABLE}.addresses_saved_all_users ;;
+    }
+  measure: sum_addresses_saved_all {
+    type: sum
+    sql: ${TABLE}.addresses_saved_all ;;
+    }
 
 }


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [x] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [x] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [x] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [x] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
