### PR TITLE
Add views and explores for MLOps cost tracking tables

### DIFF
--- a/monitoring/explores/mlops_flow_cost.explore.lkml
+++ b/monitoring/explores/mlops_flow_cost.explore.lkml
@@ -1,0 +1,6 @@
+include: "../views/mlops_flow_cost.view.lkml"
+
+explore: mlops_flow_cost {
+  label: "MLOPs Aggregated Flow Cost Across Runs"
+
+}

--- a/monitoring/explores/mlops_flow_run_cost.explore.lkml
+++ b/monitoring/explores/mlops_flow_run_cost.explore.lkml
@@ -1,0 +1,6 @@
+include: "../views/mlops_flow_run_cost.view.lkml"
+
+explore: mlops_flow_run_cost {
+  label: "MLOps cost tracking per flow run"
+
+}

--- a/monitoring/views/mlops_flow_cost.view.lkml
+++ b/monitoring/views/mlops_flow_cost.view.lkml
@@ -1,0 +1,27 @@
+view: mlops_flow_cost {
+  derived_table: {
+    sql: SELECT
+        *
+      FROM `moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_v1`
+      ;;
+  }
+
+  dimension: flow_name {
+    description: "The flow being run"
+    type: string
+    sql: ${TABLE}.flow_name ;;
+  }
+
+  dimension: num_runs {
+    description: "The number of times this flow has run"
+    type: number
+    sql: ${TABLE}.num_runs ;;
+  }
+
+  measure: total_cost_usd {
+    description: "How much this flow has cost in USD over its runs"
+    type: number
+    sql: ${TABLE}.total_cost_usd ;;
+  }
+
+}

--- a/monitoring/views/mlops_flow_run_cost.view.lkml
+++ b/monitoring/views/mlops_flow_run_cost.view.lkml
@@ -1,0 +1,34 @@
+view: mlops_flow_run_cost {
+  derived_table: {
+    sql: SELECT
+        *
+      FROM `moz-fx-data-shared-prod.monitoring_derived.outerbounds_cost_per_flow_run_v1`
+      ORDER BY invoice_day DESC
+      ;;
+  }
+
+  dimension: run_id {
+    description: "The ID for the run"
+    type: string
+    sql: ${TABLE}.lifetime_orders ;;
+  }
+
+  dimension: flow_name {
+    description: "Which flow was run in this job"
+    type: string
+    sql: ${TABLE}.flow_name ;;
+  }
+
+  dimension: invoice_day {
+    description: "Day this job was invoiced"
+    type: date_time
+    sql: ${TABLE}.invoice_day ;;
+  }
+
+  measure: cost_usd {
+    description: "How much the job cost in USD"
+    type: number
+    sql: ${TABLE}.cost_usd ;;
+  }
+
+}


### PR DESCRIPTION
In spoke rather than hub because these tables are for one specific dashboard; not something it's likely other teams are going to need to build on, as is the case for your 'core' datasets in looker-hub.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
