### PR TITLE
add csat survey id, plan tier, experiment branch, scan date to monitor events table

### DIFF
--- a/monitor_frontend/views/events_unnested_table.view.lkml
+++ b/monitor_frontend/views/events_unnested_table.view.lkml
@@ -163,7 +163,8 @@ view: +events_unnested_table {
 
   dimension: event_extra__last_scan_date {
     description: "Last scan date"
-    type: string
+    type: date
+    convert_tz: no
     sql:  SAFE.PARSE_DATE('%Y%m%d', `mozfun.map.get_key`(${TABLE}.event_extra, 'last_scan_date')) ;;
     group_label: "Event Extra"
     group_item_label: "Last Scan Date"

--- a/monitor_frontend/views/events_unnested_table.view.lkml
+++ b/monitor_frontend/views/events_unnested_table.view.lkml
@@ -140,7 +140,7 @@ view: +events_unnested_table {
   dimension: event_extra__survey_id {
     description: "CSAT survey ID"
     type: string
-    sql: SAFE_CAST(`mozfun.map.get_key`(${TABLE}.event_extra, 'survey_id') AS STRING) ;;
+    sql: `mozfun.map.get_key`(${TABLE}.event_extra, 'survey_id') ;;
     group_label: "Event Extra"
     group_item_label: "Survey ID"
   }
@@ -148,7 +148,7 @@ view: +events_unnested_table {
   dimension: event_extra__plan_tier {
     description: "Plan tier of user"
     type: string
-    sql: SAFE_CAST(`mozfun.map.get_key`(${TABLE}.event_extra, 'plan_tier') AS STRING) ;;
+    sql: `mozfun.map.get_key`(${TABLE}.event_extra, 'plan_tier') ;;
     group_label: "Event Extra"
     group_item_label: "Plan Tier"
   }
@@ -156,7 +156,7 @@ view: +events_unnested_table {
   dimension: event_extra__experiment_branch {
     description: "Experiment branch"
     type: string
-    sql: SAFE_CAST(`mozfun.map.get_key`(${TABLE}.event_extra, 'experiment_branch') AS STRING) ;;
+    sql: `mozfun.map.get_key`(${TABLE}.event_extra, 'experiment_branch') ;;
     group_label: "Event Extra"
     group_item_label: "Experiment Branch"
   }

--- a/monitor_frontend/views/events_unnested_table.view.lkml
+++ b/monitor_frontend/views/events_unnested_table.view.lkml
@@ -130,19 +130,19 @@ view: +events_unnested_table {
   }
 
   dimension: event_extra__response_id {
-    description: "Rating given by user for csat survey"
+    description: "Rating given by user for CSAT survey"
     type: string
-    sql: SAFE_CAST(`mozfun.map.get_key`(${TABLE}.event_extra, 'response_id') AS STRING) ;;
+    sql: `mozfun.map.get_key`(${TABLE}.event_extra, 'response_id') ;;
     group_label: "Event Extra"
-    group_item_label: "Response Id"
+    group_item_label: "Response ID"
   }
 
   dimension: event_extra__survey_id {
-    description: "Csat survey id"
+    description: "CSAT survey ID"
     type: string
     sql: SAFE_CAST(`mozfun.map.get_key`(${TABLE}.event_extra, 'survey_id') AS STRING) ;;
     group_label: "Event Extra"
-    group_item_label: "Survey Id"
+    group_item_label: "Survey ID"
   }
 
   dimension: event_extra__plan_tier {
@@ -164,7 +164,7 @@ view: +events_unnested_table {
   dimension: event_extra__last_scan_date {
     description: "Last scan date"
     type: string
-    sql: `mozfun.map.get_key`(${TABLE}.event_extra, 'last_scan_date');;
+    sql:  SAFE.PARSE_DATE('%Y%m%d', `mozfun.map.get_key`(${TABLE}.event_extra, 'last_scan_date')) ;;
     group_label: "Event Extra"
     group_item_label: "Last Scan Date"
   }

--- a/monitor_frontend/views/events_unnested_table.view.lkml
+++ b/monitor_frontend/views/events_unnested_table.view.lkml
@@ -129,6 +129,46 @@ view: +events_unnested_table {
     group_item_label: "Broker Count"
   }
 
+  dimension: event_extra__response_id {
+    description: "Rating given by user for csat survey"
+    type: string
+    sql: SAFE_CAST(`mozfun.map.get_key`(${TABLE}.event_extra, 'response_id') AS STRING) ;;
+    group_label: "Event Extra"
+    group_item_label: "Response Id"
+  }
+
+  dimension: event_extra__survey_id {
+    description: "Csat survey id"
+    type: string
+    sql: SAFE_CAST(`mozfun.map.get_key`(${TABLE}.event_extra, 'survey_id') AS STRING) ;;
+    group_label: "Event Extra"
+    group_item_label: "Survey Id"
+  }
+
+  dimension: event_extra__plan_tier {
+    description: "Plan tier of user"
+    type: string
+    sql: SAFE_CAST(`mozfun.map.get_key`(${TABLE}.event_extra, 'plan_tier') AS STRING) ;;
+    group_label: "Event Extra"
+    group_item_label: "Plan Tier"
+  }
+
+  dimension: event_extra__experiment_branch {
+    description: "Experiment branch"
+    type: string
+    sql: SAFE_CAST(`mozfun.map.get_key`(${TABLE}.event_extra, 'experiment_branch') AS STRING) ;;
+    group_label: "Event Extra"
+    group_item_label: "Experiment Branch"
+  }
+
+  dimension: event_extra__last_scan_date {
+    description: "Last scan date"
+    type: string
+    sql: `mozfun.map.get_key`(${TABLE}.event_extra, 'last_scan_date');;
+    group_label: "Event Extra"
+    group_item_label: "Last Scan Date"
+  }
+
   measure: user_count {
     description: "Use this for counting lifetime orders across many users"
     type: count_distinct


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
