### PR TITLE
Add accounts users_services_daily explore

### DIFF
--- a/accounts_backend/explores/mozilla_accounts_users_services_daily.explore.lkml
+++ b/accounts_backend/explores/mozilla_accounts_users_services_daily.explore.lkml
@@ -1,0 +1,11 @@
+include: "../views/mozilla_accounts_users_services_daily.view.lkml"
+
+explore: mozilla_accounts_users_services_daily {
+  label: "Mozilla Accounts Users/Services Daily"
+
+  conditionally_filter: {
+    filters: [date_date: "30 days ago for 30 days"]
+    unless: [date_week, date_month, date_quarter, date_year]
+  }
+
+}

--- a/accounts_backend/views/mozilla_accounts_multi_service_dau.view.lkml
+++ b/accounts_backend/views/mozilla_accounts_multi_service_dau.view.lkml
@@ -4,16 +4,14 @@ view: mozilla_accounts_multi_service_dau {
 
     sql:
     SELECT
-      DATE(e.submission_timestamp) as submission_date,
-      e.metrics.string.account_user_id_sha256 AS user_id,
+      submission_date,
+      user_id_sha256 AS user_id,
       ARRAY_AGG(DISTINCT c.name IGNORE NULLS ORDER BY c.name) as service_names,
     FROM
-      `mozdata.accounts_backend.accounts_events` AS e
+      `mozdata.accounts_backend.users_services_daily` AS e
     JOIN
       `mozdata.accounts_db.fxa_oauth_clients` AS c
-    ON e.metrics.string.relying_party_oauth_client_id = c.id
-    WHERE (e.metrics.string.event_name IN ('reg_complete', 'login_complete')
-     OR e.metrics.string.event_name like r'access\_token%')
+    ON service = c.id
     AND c.id NOT IN (
       '00efbcb5b2dbfa0e',  -- Mozilla.social invitation flow
       '0d1a8469632d0f61',  -- Hubs Reticulum

--- a/accounts_backend/views/mozilla_accounts_users_services_daily.view.lkml
+++ b/accounts_backend/views/mozilla_accounts_users_services_daily.view.lkml
@@ -1,0 +1,58 @@
+view: mozilla_accounts_users_services_daily {
+  derived_table: {
+
+    sql:
+    SELECT
+      submission_date,
+      user_id_sha256 AS user_id_sha256,
+      country,
+      service,
+      c.name AS service_name
+    FROM
+      `mozdata.accounts_backend.users_services_daily` AS e
+    JOIN
+      `mozdata.accounts_db.fxa_oauth_clients` AS c
+    ON service = c.id
+    ;;
+  }
+
+  measure: user_count {
+    type:  count_distinct
+    sql:  ${TABLE}.user_id_sha256 ;;
+  }
+
+  dimension_group: date {
+    type:  time
+    sql:  ${TABLE}.submission_date;;
+    datatype: date
+    convert_tz: no
+    timeframes:[
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+  }
+
+  dimension: user_id_sha256 {
+    type:  string
+    hidden: yes
+    sql:  ${TABLE}.user_id_sha256 ;;
+  }
+
+  dimension: country {
+    type: number
+    sql:  ${TABLE}.country ;;
+  }
+
+  dimension: service {
+    type: number
+    sql:  ${TABLE}.service ;;
+  }
+
+  dimension: service_name {
+    type: string
+    sql:  ${TABLE}.service_name ;;
+  }
+}


### PR DESCRIPTION
This PR:
* adds users_services_daily explore which can be used to speed up some tiles in Customer Journey Insights Dashboard
* switches multi-service DAU explore to use users_services_daily, which will speed up queries that use it

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
