### PR TITLE
Add limited historical Google Search Console explores (DENG-4329)

### DIFF
--- a/websites/explores/limited_historical_google_search_console_by_page.explore.lkml
+++ b/websites/explores/limited_historical_google_search_console_by_page.explore.lkml
@@ -1,0 +1,34 @@
+include: "../views/limited_historical_google_search_console_by_page.view.lkml"
+
+explore: limited_historical_google_search_console_by_page {
+  description: "The data has the following limitations:
+    * For each site only data for specific historical dates is included.
+    * For each site only the top ~50,000 rows of data per day per search type is included (prioritized by number of clicks).
+    * Anonymized search queries aren't included."
+
+  conditionally_filter: {
+    filters: [limited_historical_google_search_console_by_page.date_date: "2023"]
+  }
+
+  query: popular_web_search_queries_in_2022 {
+    dimensions: [query, site_domain_name]
+    measures: [distinct_page_url_count, average_result_position, total_impressions, total_clicks, click_through_rate]
+    filters: [
+      limited_historical_google_search_console_by_page.date_date: "2022",
+      limited_historical_google_search_console_by_page.search_type: "Web"
+    ]
+    sorts: [total_impressions: desc]
+    limit: 100
+  }
+
+  query: popular_web_search_pages_in_2022 {
+    dimensions: [page_url, site_domain_name]
+    measures: [distinct_query_count, average_result_position, total_impressions, total_clicks, click_through_rate]
+    filters: [
+      limited_historical_google_search_console_by_page.date_date: "2022",
+      limited_historical_google_search_console_by_page.search_type: "Web"
+    ]
+    sorts: [total_clicks: desc]
+    limit: 100
+  }
+}

--- a/websites/explores/limited_historical_google_search_console_by_site.explore.lkml
+++ b/websites/explores/limited_historical_google_search_console_by_site.explore.lkml
@@ -1,0 +1,23 @@
+include: "../views/limited_historical_google_search_console_by_site.view.lkml"
+
+explore: limited_historical_google_search_console_by_site {
+  description: "The data has the following limitations:
+    * For each site only data for specific historical dates is included.
+    * For each site only the top ~50,000 rows of data per day per search type is included (prioritized by number of clicks).
+    * Anonymized search queries aren't included."
+
+  conditionally_filter: {
+    filters: [limited_historical_google_search_console_by_site.date_date: "2023"]
+  }
+
+  query: popular_web_search_queries_in_2022 {
+    dimensions: [query, site_domain_name]
+    measures: [average_top_result_position, total_impressions, total_clicks, click_through_rate]
+    filters: [
+      limited_historical_google_search_console_by_site.date_date: "2022",
+      limited_historical_google_search_console_by_site.search_type: "Web"
+    ]
+    sorts: [total_impressions: desc]
+    limit: 100
+  }
+}

--- a/websites/views/limited_historical_google_search_console_by_page.view.lkml
+++ b/websites/views/limited_historical_google_search_console_by_page.view.lkml
@@ -1,0 +1,54 @@
+include: "//looker-hub/websites/views/limited_historical_google_search_console_by_page.view.lkml"
+
+view: +limited_historical_google_search_console_by_page {
+  dimension: impressions {
+    hidden: yes
+  }
+  measure: total_impressions {
+    type: sum
+    sql: ${TABLE}.impressions ;;
+    description: "The number of times that search results with a link to the page were shown to a user."
+  }
+
+  dimension: clicks {
+    hidden: yes
+  }
+  measure: total_clicks {
+    type: sum
+    sql: ${TABLE}.clicks ;;
+    description: "The number of times a user clicked a search result link to the page."
+  }
+
+  measure: click_through_rate {
+    type: number
+    sql: SAFE_DIVIDE(${total_clicks}, ${total_impressions}) ;;
+    value_format_name: percent_2
+    label: "Click-Through Rate"
+    description: "The total click count divided by the total impression count."
+  }
+
+  dimension: average_position {
+    hidden: yes
+  }
+  measure: total_average_position_times_impressions {
+    type: sum
+    sql: ${TABLE}.average_position * ${TABLE}.impressions ;;
+    hidden: yes
+  }
+  measure: average_result_position {
+    type: number
+    sql: SAFE_DIVIDE(${total_average_position_times_impressions}, ${total_impressions}) ;;
+    value_format_name: decimal_2
+    description: "The average position of the page in the search results, where `1` is the topmost position."
+  }
+
+  measure: distinct_page_url_count {
+    type: count_distinct
+    sql: ${page_url} ;;
+  }
+
+  measure: distinct_query_count {
+    type: count_distinct
+    sql: ${query} ;;
+  }
+}

--- a/websites/views/limited_historical_google_search_console_by_site.view.lkml
+++ b/websites/views/limited_historical_google_search_console_by_site.view.lkml
@@ -1,0 +1,49 @@
+include: "//looker-hub/websites/views/limited_historical_google_search_console_by_site.view.lkml"
+
+view: +limited_historical_google_search_console_by_site {
+  dimension: impressions {
+    hidden: yes
+  }
+  measure: total_impressions {
+    type: sum
+    sql: ${TABLE}.impressions ;;
+    description: "The number of times that search results with at least one link to the site were shown to a user."
+  }
+
+  dimension: clicks {
+    hidden: yes
+  }
+  measure: total_clicks {
+    type: sum
+    sql: ${TABLE}.clicks ;;
+    description: "The number of times a user clicked at least one search result link to the site."
+  }
+
+  measure: click_through_rate {
+    type: number
+    sql: SAFE_DIVIDE(${total_clicks}, ${total_impressions}) ;;
+    value_format_name: percent_2
+    label: "Click-Through Rate"
+    description: "The total click count divided by the total impression count."
+  }
+
+  dimension: average_top_position {
+    hidden: yes
+  }
+  measure: total_average_top_position_times_impressions {
+    type: sum
+    sql: ${TABLE}.average_top_position * ${TABLE}.impressions ;;
+    hidden: yes
+  }
+  measure: average_top_result_position {
+    type: number
+    sql: SAFE_DIVIDE(${total_average_top_position_times_impressions}, ${total_impressions}) ;;
+    value_format_name: decimal_2
+    description: "The average top position of the site in the search results, where `1` is the topmost position."
+  }
+
+  measure: distinct_query_count {
+    type: count_distinct
+    sql: ${query} ;;
+  }
+}


### PR DESCRIPTION
## [DENG-4329](https://mozilla-hub.atlassian.net/browse/DENG-4329): Google Search Console data synced by Fivetran is not comparable to the data exported by Google

Depends on mozilla/lookml-generator#1030.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
