### PR TITLE
Push lookml to main-validation for running spectacles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,83 +37,29 @@ jobs:
           fingerprints:
             - "SHA256:rVrow/3DEpsY1OTWFfA4PymfidEtdpLN37b8zb6lDQU"
       - run:
-          name: Early return if this is running on a branch
-          command: |
-            if [[ "$CIRCLE_BRANCH" != "main" ]]; then
-              echo "Don't push changes to main-validation as this is a PR" \
-                "so marking this step successful"
-              circleci-agent step halt
-            fi
-      - run:
           name: Push lookml to main-validation branch
           command: |
             ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
             git config --global user.name "CircleCI main-validation job"
             git config --global user.email "dataops+main-validation@mozilla.com"
-            git clone --single-branch --branch main-validation \
-              git@github.com:mozilla/looker-spoke-default \
-              /tmp/main-validation
-            cp -r * /tmp/main-validation/
-            cd /tmp/main-validation
-            git add .
-            git commit -m "Auto-push due to change on main branch [ci skip]" \
-              && git tag c-${CIRCLE_SHA1:0:9} \
-              && git push \
-              && git push origin c-${CIRCLE_SHA1:0:9} \
-              || echo "Skipping push since it looks like there were no changes"
-  validate-lookml:
-    executor: python/default
-    steps:
-      - checkout
-      - run:
-          name: Install spectacles
-          command: pip install spectacles==2.3.18
-      - run:
-          no_output_timeout: 10m
-          command: |
-            # for validation on PRs use the current branch;
-            # for validation on main use `main-validation` as spectacles cannot run
-            # validation on the production `main` branch successfully (defaults to dev branch)
-            export BRANCH="$CIRCLE_BRANCH"
-            if [ "$CIRCLE_BRANCH" = main ]; then
-              BRANCH="main-validation"
-            fi
-
-            spectacles lookml \
-              --base-url ${LOOKER_INSTANCE_URI} \
-              --client-id ${LOOKER_API_CLIENT_ID} \
-              --client-secret ${LOOKER_API_CLIENT_SECRET} \
-              --project spoke-default \
-              --branch $BRANCH \
-              --pin-imports looker-hub:760abdc0ba154f23efe8a7d765355b4940c6f222 \
-              --verbose
+            git push origin main:main-validation
 workflows:
   version: 2
   build:
     jobs:
-      - validate-lookml:
-          context: data-eng-looker
-          requires:
-            - push-lookml-for-validation
       - deploy-prod:
-          requires:
-            - validate-lookml
           filters:
             branches:
               only: main
             tags:
               only: /.*/
       - deploy-stage:
-          requires:
-            - validate-lookml
           filters:
             branches:
               only: main-stage
             tags:
               only: /.*/
       - deploy-dev:
-          requires:
-            - validate-lookml
           filters:
             branches:
               only: main-nonprod
@@ -128,4 +74,8 @@ workflows:
               only: main
             tags:
               only: /.*/
-      - push-lookml-for-validation
+      - push-lookml-for-validation:
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@
 version: 2.1
 orbs:
   python: circleci/python@1.4.0
+  docker: circleci/docker@2.2
 
 jobs:
   deploy-prod:
@@ -31,7 +32,7 @@ jobs:
             python ./src/sync_dashboards/main.py sync --config lookml_dashboards.yaml
           no_output_timeout: 15m
   push-lookml-for-validation:
-    executor: python/default
+    executor: docker/machine
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -42,6 +43,8 @@ jobs:
             ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
             git config --global user.name "CircleCI main-validation job"
             git config --global user.email "dataops+main-validation@mozilla.com"
+            git clone git@github.com:mozilla/looker-spoke-default /tmp/looker-spoke-default
+            cd /tmp/looker-spoke-default
             git push origin main:main-validation
 workflows:
   version: 2
@@ -74,8 +77,8 @@ workflows:
               only: main
             tags:
               only: /.*/
-      - push-lookml-for-validation:
-          filters:
-            branches:
-              only:
-                - main
+      - push-lookml-for-validation
+          # filters:
+          #   branches:
+          #     only:
+          #       - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 orbs:
   python: circleci/python@1.4.0
-  docker: circleci/docker@2.2
+  docker: circleci/docker@2.6.0
 
 jobs:
   deploy-prod:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,8 +77,8 @@ workflows:
               only: main
             tags:
               only: /.*/
-      - push-lookml-for-validation
-          # filters:
-          #   branches:
-          #     only:
-          #       - main
+      - push-lookml-for-validation:
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,23 +30,90 @@ jobs:
           command: |
             python ./src/sync_dashboards/main.py sync --config lookml_dashboards.yaml
           no_output_timeout: 15m
+  push-lookml-for-validation:
+    executor: python/default
+    steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "SHA256:rVrow/3DEpsY1OTWFfA4PymfidEtdpLN37b8zb6lDQU"
+      - run:
+          name: Early return if this is running on a branch
+          command: |
+            if [[ "$CIRCLE_BRANCH" != "main" ]]; then
+              echo "Don't push changes to main-validation as this is a PR" \
+                "so marking this step successful"
+              circleci-agent step halt
+            fi
+      - run:
+          name: Push lookml to main-validation branch
+          command: |
+            ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
+            git config --global user.name "CircleCI main-validation job"
+            git config --global user.email "dataops+main-validation@mozilla.com"
+            git clone --single-branch --branch main-validation \
+              git@github.com:mozilla/looker-spoke-default \
+              /tmp/main-validation
+            cp -r * /tmp/main-validation/
+            cd /tmp/main-validation
+            git add .
+            git commit -m "Auto-push due to change on main branch [ci skip]" \
+              && git tag c-${CIRCLE_SHA1:0:9} \
+              && git push \
+              && git push origin c-${CIRCLE_SHA1:0:9} \
+              || echo "Skipping push since it looks like there were no changes"
+  validate-lookml:
+    executor: python/default
+    steps:
+      - checkout
+      - run:
+          name: Install spectacles
+          command: pip install spectacles==2.3.18
+      - run:
+          no_output_timeout: 10m
+          command: |
+            # for validation on PRs use the current branch;
+            # for validation on main use `main-validation` as spectacles cannot run
+            # validation on the production `main` branch successfully (defaults to dev branch)
+            export BRANCH="$CIRCLE_BRANCH"
+            if [ "$CIRCLE_BRANCH" = main ]; then
+              BRANCH="main-validation"
+            fi
+
+            spectacles lookml \
+              --base-url ${LOOKER_INSTANCE_URI} \
+              --client-id ${LOOKER_API_CLIENT_ID} \
+              --client-secret ${LOOKER_API_CLIENT_SECRET} \
+              --project spoke-default \
+              --branch $BRANCH \
+              --pin-imports looker-hub:760abdc0ba154f23efe8a7d765355b4940c6f222 \
+              --verbose
 workflows:
   version: 2
   build:
     jobs:
+      - validate-lookml:
+          context: data-eng-looker
+          requires:
+            - push-lookml-for-validation
       - deploy-prod:
+          requires:
+            - validate-lookml
           filters:
             branches:
               only: main
             tags:
               only: /.*/
       - deploy-stage:
+          requires:
+            - validate-lookml
           filters:
             branches:
               only: main-stage
             tags:
               only: /.*/
       - deploy-dev:
+          requires:
+            - validate-lookml
           filters:
             branches:
               only: main-nonprod
@@ -61,3 +128,4 @@ workflows:
               only: main
             tags:
               only: /.*/
+      - push-lookml-for-validation


### PR DESCRIPTION
This change will have the CI replicate the `main` branch and push it to `main-validation`. This is needed to run LookML validation and content validation via [spectacles](https://docs.spectacles.dev/cli/tutorials/getting-started/). As it turns out spectacles cannot run the validation on the `main` branch and instead defaults to the development branch of the user running spectacles. This branch is usually not up-to-date. Looker generally doesn't allow selecting the production branch (which is `main` for this repo) in the development mode, so it's not possible to run validation on that branch. 

So as a workaround I created the `main-validation` branch which serves as a mirror of `main`. Write access will be restricted to the user used in CI. 

The plan is to use spectacles to run some Looker content validation via Airflow (after lookml-generator runs). The content validation can be set on a per folder level, so it finishes relatively quickly and validates dashboards and related explores. Hopefully, this way we can detect breakages faster.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
