### PR TITLE
redirect confidence intervals view to a derived table from forecast t…

### DIFF
--- a/kpi/explores/automated_KPI_confidence_intervals.explore.lkml
+++ b/kpi/explores/automated_KPI_confidence_intervals.explore.lkml
@@ -1,13 +1,13 @@
-include: "//looker-hub/kpi/views/automated_kpi_confidence_intervals.view.lkml"
+include: "../views/automated_kpi_forecasts_confidence_intervals.view.lkml"
 
 explore: automated_KPI_confidence_intervals {
   label: "Automated KPI Confidence Intervals: Aggregated Data"
-  view_name: automated_kpi_confidence_intervals
+  view_name: automated_kpi_forecasts_confidence_intervals
   description: "This calculates confidence intervals for the time interval noted in unit. Aggregations to other time intervals are not supported. If desired, the KPI forecasting job should be updated to output confidence intervals at additional temporal specifications."
 
   always_filter: {
-    filters: [automated_kpi_confidence_intervals.target: "-EMPTY",
-      automated_kpi_confidence_intervals.forecast_date: "-EMPTY",
-      automated_kpi_confidence_intervals.unit: "-EMPTY"]
+    filters: [automated_kpi_forecasts_confidence_intervals.target: "-EMPTY",
+      automated_kpi_forecasts_confidence_intervals.forecast_date: "-EMPTY",
+      automated_kpi_forecasts_confidence_intervals.unit: "-EMPTY"]
   }
 }

--- a/kpi/kpi.model.lkml
+++ b/kpi/kpi.model.lkml
@@ -1,11 +1,10 @@
 connection: "telemetry"
 
 include: "//looker-hub/kpi/explores/*"
-include: "//looker-hub/kpi/views/automated_kpi_confidence_intervals.view.lkml"
 include: "//looker-hub/kpi/views/automated_kpi_forecasts.view.lkml"
 include: "//looker-hub/kpi/views/unified_metrics.view.lkml"
 include: "./dashboards/*.dashboard"
-include: "views/Automated_KPI_Forecast_Confidence_Intervals.view.lkml"
+include: "views/automated_kpi_forecasts_confidence_intervals.view.lkml"
 include: "views/Automated_KPI_Forecasts.view.lkml"
 include: "views/browser_dau.view.lkml"
 include: "views/browser_kpis.view.lkml"


### PR DESCRIPTION
…able

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
