### PR TITLE
Recognize remaining revenue for non-renewing subscriptions

### DIFF
--- a/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
@@ -118,6 +118,46 @@ view: +daily_active_logical_subscriptions {
     group_item_label: "UTM Term"
   }
 
+  dimension: annual_recurring_revenue_usd {
+    label: "Annual Recurring Revenue (USD)"
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__plan_currency} IS DISTINCT FROM 'USD'
+          THEN NULL
+        WHEN ${subscription__is_active} IS NOT TRUE
+          THEN 0
+        ELSE
+          CASE ${subscription__plan_interval_type}
+            WHEN 'year'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
+                )
+            WHEN 'month'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
+                )
+            WHEN 'week'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
+                )
+            WHEN 'day'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
+                )
+          END
+      END ;;
+    value_format_name: usd
+  }
+
   measure: logical_subscription_count {
     type: count_distinct
     sql: ${TABLE}.subscription.id ;;
@@ -142,39 +182,7 @@ view: +daily_active_logical_subscriptions {
     label: "Total Annual Recurring Revenue (USD)"
     type: sum_distinct
     sql_distinct_key: ${subscription__id} ;;
-    sql:
-      CASE
-        WHEN ${subscription__is_active}
-          AND ${subscription__plan_currency} = 'USD'
-          THEN
-            CASE ${subscription__plan_interval_type}
-              WHEN 'year'
-                THEN (
-                    ${subscription__plan_amount}
-                    / ${subscription__plan_interval_count}
-                    * IF(${subscription__auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
-                  )
-              WHEN 'month'
-                THEN (
-                    ${subscription__plan_amount}
-                    / ${subscription__plan_interval_count}
-                    * IF(${subscription__auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
-                  )
-              WHEN 'week'
-                THEN (
-                    ${subscription__plan_amount}
-                    / ${subscription__plan_interval_count}
-                    * IF(${subscription__auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
-                  )
-              WHEN 'day'
-                THEN (
-                    ${subscription__plan_amount}
-                    / ${subscription__plan_interval_count}
-                    * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
-                  )
-            END
-        ELSE NULL
-      END ;;
+    sql: ${annual_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -125,6 +125,46 @@ view: +logical_subscriptions {
     group_item_label: "UTM Term"
   }
 
+  dimension: annual_recurring_revenue_usd {
+    label: "Annual Recurring Revenue (USD)"
+    type: number
+    sql:
+      CASE
+        WHEN ${plan_currency} IS DISTINCT FROM 'USD'
+          THEN NULL
+        WHEN ${is_active} IS NOT TRUE
+          THEN 0
+        ELSE
+          CASE ${plan_interval_type}
+            WHEN 'year'
+              THEN (
+                  ${plan_amount}
+                  / ${plan_interval_count}
+                  * IF(${auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
+                )
+            WHEN 'month'
+              THEN (
+                  ${plan_amount}
+                  / ${plan_interval_count}
+                  * IF(${auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
+                )
+            WHEN 'week'
+              THEN (
+                  ${plan_amount}
+                  / ${plan_interval_count}
+                  * IF(${auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
+                )
+            WHEN 'day'
+              THEN (
+                  ${plan_amount}
+                  / ${plan_interval_count}
+                  * IF(${auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
+                )
+          END
+      END ;;
+    value_format_name: usd
+  }
+
   measure: logical_subscription_count {
     type: count
   }
@@ -153,39 +193,7 @@ view: +logical_subscriptions {
     label: "Total Annual Recurring Revenue (USD)"
     type: sum_distinct
     sql_distinct_key: ${id} ;;
-    sql:
-      CASE
-        WHEN ${is_active}
-          AND ${plan_currency} = 'USD'
-          THEN
-            CASE ${plan_interval_type}
-              WHEN 'year'
-                THEN (
-                    ${plan_amount}
-                    / ${plan_interval_count}
-                    * IF(${auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
-                  )
-              WHEN 'month'
-                THEN (
-                    ${plan_amount}
-                    / ${plan_interval_count}
-                    * IF(${auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
-                  )
-              WHEN 'week'
-                THEN (
-                    ${plan_amount}
-                    / ${plan_interval_count}
-                    * IF(${auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
-                  )
-              WHEN 'day'
-                THEN (
-                    ${plan_amount}
-                    / ${plan_interval_count}
-                    * IF(${auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
-                  )
-            END
-        ELSE NULL
-      END ;;
+    sql: ${annual_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 }

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -130,6 +130,46 @@ view: +monthly_active_logical_subscriptions {
     group_item_label: "UTM Term"
   }
 
+  dimension: annual_recurring_revenue_usd {
+    label: "Annual Recurring Revenue (USD)"
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__plan_currency} IS DISTINCT FROM 'USD'
+          THEN NULL
+        WHEN ${subscription__is_active} IS NOT TRUE
+          THEN 0
+        ELSE
+          CASE ${subscription__plan_interval_type}
+            WHEN 'year'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
+                )
+            WHEN 'month'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
+                )
+            WHEN 'week'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
+                )
+            WHEN 'day'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
+                )
+          END
+      END ;;
+    value_format_name: usd
+  }
+
   measure: logical_subscription_count {
     type: count_distinct
     sql: ${TABLE}.subscription.id ;;
@@ -154,39 +194,7 @@ view: +monthly_active_logical_subscriptions {
     label: "Total Annual Recurring Revenue (USD)"
     type: sum_distinct
     sql_distinct_key: ${subscription__id} ;;
-    sql:
-      CASE
-        WHEN ${subscription__is_active}
-          AND ${subscription__plan_currency} = 'USD'
-          THEN
-            CASE ${subscription__plan_interval_type}
-              WHEN 'year'
-                THEN (
-                    ${subscription__plan_amount}
-                    / ${subscription__plan_interval_count}
-                    * IF(${subscription__auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
-                  )
-              WHEN 'month'
-                THEN (
-                    ${subscription__plan_amount}
-                    / ${subscription__plan_interval_count}
-                    * IF(${subscription__auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
-                  )
-              WHEN 'week'
-                THEN (
-                    ${subscription__plan_amount}
-                    / ${subscription__plan_interval_count}
-                    * IF(${subscription__auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
-                  )
-              WHEN 'day'
-                THEN (
-                    ${subscription__plan_amount}
-                    / ${subscription__plan_interval_count}
-                    * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
-                  )
-            END
-        ELSE NULL
-      END ;;
+    sql: ${annual_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -170,6 +170,38 @@ view: +monthly_active_logical_subscriptions {
     value_format_name: usd
   }
 
+  dimension: monthly_recurring_revenue_usd {
+    label: "Monthly Recurring Revenue (USD)"
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__plan_currency} IS DISTINCT FROM 'USD'
+          THEN NULL
+        WHEN ${subscription__is_active} IS NOT TRUE
+          THEN 0
+        ELSE
+          CASE ${subscription__plan_interval_type}
+            WHEN 'year'
+              THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} / 12
+            WHEN 'month'
+              THEN ${subscription__plan_amount} / ${subscription__plan_interval_count}
+            WHEN 'week'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, (52 / 12), LEAST((${weeks_until_current_period_ends} + 1), (52 / 12)))
+                )
+            WHEN 'day'
+              THEN (
+                  ${subscription__plan_amount}
+                  / ${subscription__plan_interval_count}
+                  * IF(${subscription__auto_renew}, (365 / 12), LEAST((${days_until_current_period_ends} + 1), (365 / 12)))
+                )
+          END
+      END ;;
+    value_format_name: usd
+  }
+
   measure: logical_subscription_count {
     type: count_distinct
     sql: ${TABLE}.subscription.id ;;
@@ -198,4 +230,11 @@ view: +monthly_active_logical_subscriptions {
     value_format_name: usd
   }
 
+  measure: total_monthly_recurring_revenue_usd {
+    label: "Total Monthly Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${subscription__id} ;;
+    sql: ${monthly_recurring_revenue_usd} ;;
+    value_format_name: usd
+  }
 }

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -85,6 +85,19 @@ view: +monthly_active_logical_subscriptions {
     intervals: [day, week, month, quarter, year]
   }
 
+  dimension_group: until_current_period_ends {
+    type: duration
+    sql_start:
+      LEAST(
+        TIMESTAMP_SUB(TIMESTAMP(${TABLE}.month_end_date + 1), INTERVAL 1 MICROSECOND),
+        TIMESTAMP(CURRENT_DATE()),
+        ${TABLE}.subscription.current_period_ends_at
+      ) ;;
+    sql_end: ${TABLE}.subscription.current_period_ends_at ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+
   dimension: subscription__first_touch_attribution__utm_campaign {
     group_item_label: "UTM Campaign"
   }
@@ -144,18 +157,33 @@ view: +monthly_active_logical_subscriptions {
     sql:
       CASE
         WHEN ${subscription__is_active}
-          AND ${subscription__auto_renew}
           AND ${subscription__plan_currency} = 'USD'
           THEN
             CASE ${subscription__plan_interval_type}
               WHEN 'year'
-                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count}
+                THEN (
+                    ${subscription__plan_amount}
+                    / ${subscription__plan_interval_count}
+                    * IF(${subscription__auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
+                  )
               WHEN 'month'
-                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} * 12
+                THEN (
+                    ${subscription__plan_amount}
+                    / ${subscription__plan_interval_count}
+                    * IF(${subscription__auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
+                  )
               WHEN 'week'
-                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} * 52
+                THEN (
+                    ${subscription__plan_amount}
+                    / ${subscription__plan_interval_count}
+                    * IF(${subscription__auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
+                  )
               WHEN 'day'
-                THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} * 365
+                THEN (
+                    ${subscription__plan_amount}
+                    / ${subscription__plan_interval_count}
+                    * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
+                  )
             END
         ELSE NULL
       END ;;


### PR DESCRIPTION
This PR:
- Changes the `total_annual_recurring_revenue_usd` measures in SubPlat logical subscription views so they include the revenue that should be recognized for the remainder of non-renewing subscriptions' final subscription periods, rather than considering non-renewing subscriptions to have zero recurring revenue.
- Adds `annual_recurring_revenue_usd` dimensions, so ARR for individual subscriptions can be more easily inspected and filtered on.
- Adds `monthly_recurring_revenue_usd` dimensions and `total_monthly_recurring_revenue_usd` measures, because with the revenue recognition approach now being used, MRR isn't always simply ARR divided by 12.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
