### PR TITLE
Fix www_site_metrics_summary view

### DIFF
--- a/duet/desktop_funnels/desktop_funnels_web.view.lkml
+++ b/duet/desktop_funnels/desktop_funnels_web.view.lkml
@@ -22,7 +22,7 @@ view: desktop_funnels_web {
             funnel_derived,
       sum(non_fx_sessions) AS non_fx_sessions,
       sum(non_fx_downloads) AS non_fx_downloads
-      FROM `moz-fx-data-marketing-prod.ga.www_site_metrics_summary`
+      FROM `moz-fx-data-shared-prod.mozilla_org.www_site_metrics_summary`
       WHERE date >= '2021-01-01'
       AND device_category = 'desktop'
       GROUP BY ALL

--- a/duet/mr1DEVELOPMENT/views/dev_desktop_session.view.lkml
+++ b/duet/mr1DEVELOPMENT/views/dev_desktop_session.view.lkml
@@ -40,7 +40,7 @@ WITH tbl AS (
          END AS funnel_derived,
          sum(non_fx_sessions) AS non_fx_sessions,
          sum(non_fx_downloads) AS non_fx_downloads
-  FROM `moz-fx-data-marketing-prod.ga.www_site_metrics_summary`
+  FROM `moz-fx-data-shared-prod.mozilla_org.www_site_metrics_summary`
   WHERE date >= '2021-01-01'
     AND DATE_DIFF(current_date(), date, DAY) > 1
     AND device_category = 'desktop'

--- a/duet/views/desktop_session.view.lkml
+++ b/duet/views/desktop_session.view.lkml
@@ -1,5 +1,5 @@
 view: desktop_session {
-  sql_table_name: `moz-fx-data-marketing-prod.ga.www_site_metrics_summary`
+  sql_table_name: `moz-fx-data-shared-prod.mozilla_org.www_site_metrics_summary`
     ;;
 
   dimension: browser {

--- a/websites/views/moz_org_metrics_summary.view.lkml
+++ b/websites/views/moz_org_metrics_summary.view.lkml
@@ -5,7 +5,7 @@ view: +moz_org_metrics_summary {
   derived_table: {
     sql:
       SELECT *
-      FROM `moz-fx-data-marketing-prod.ga.www_site_metrics_summary`
+      FROM `moz-fx-data-shared-prod.mozilla_org.www_site_metrics_summary`
       ;;
   }
 


### PR DESCRIPTION
These views moved.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
