### PR TITLE
DENG-3274 Add accounts_frontend explore to expose event extras

### DIFF
--- a/accounts_frontend/accounts_frontend.model.lkml
+++ b/accounts_frontend/accounts_frontend.model.lkml
@@ -1,3 +1,4 @@
 connection: "telemetry"
 label: "Firefox Accounts Frontend"
 include: "//looker-hub/accounts_frontend/explores/*"
+include: "explores/*"

--- a/accounts_frontend/explores/events_stream_with_extras.explore.lkml
+++ b/accounts_frontend/explores/events_stream_with_extras.explore.lkml
@@ -1,0 +1,13 @@
+include: "../views/events_stream_with_extras.view.lkml"
+
+explore: events_stream_with_extras {
+  hidden: yes
+
+  description: "Events stream with event_extras as dimensions"
+
+  always_filter: {
+    filters: [
+      submission_date: "28 days",
+    ]
+  }
+}

--- a/accounts_frontend/views/events_stream_with_extras.view.lkml
+++ b/accounts_frontend/views/events_stream_with_extras.view.lkml
@@ -1,0 +1,10 @@
+include: "//looker-hub/accounts_frontend/views/events_stream_table.view.lkml"
+
+view: events_stream_with_extras {
+  extends: [events_stream_table]
+
+  dimension: extra_reason {
+    type: string
+    sql: safe.string(${TABLE}.event_extra.reason) ;;
+  }
+}


### PR DESCRIPTION
We need to access one of the event extras in `events_stream` to migrate FxA dashboards to use event metrics.

Since it is rather temporary, not a general solution to this problem, I'm setting this explore to be hidden.