### PR TITLE
Include foreign subscriptions in revenue calculations (DS-3082)

### DIFF
--- a/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
@@ -2,6 +2,8 @@ include: "../views/daily_active_logical_subscriptions.view.lkml"
 include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
 
 explore: daily_active_logical_subscriptions {
 
@@ -37,6 +39,34 @@ explore: daily_active_logical_subscriptions {
     sql_on: ${table_metadata.table_name} = 'daily_active_logical_subscriptions_v1' ;;
     type: left_outer
     relationship: many_to_one
+  }
+
+  join: vat_rates {
+    view_label: "VAT Rates"
+    sql_on:
+      ${daily_active_logical_subscriptions.subscription__country_code} = ${vat_rates.country_code}
+      AND (
+        ${daily_active_logical_subscriptions.date_raw} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
+        OR (${daily_active_logical_subscriptions.date_raw} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
+      ) ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      vat
+    ]
+  }
+
+  join: exchange_rates_table {
+    view_label: "Exchange Rates"
+    sql_on:
+      ${daily_active_logical_subscriptions.subscription__plan_currency} = ${exchange_rates_table.base_currency}
+      AND ${exchange_rates_table.quote_currency} = 'USD'
+      AND ${daily_active_logical_subscriptions.date_raw} = ${exchange_rates_table.date_raw} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      price
+    ]
   }
 
 }

--- a/subscription_platform/explores/logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/logical_subscriptions.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
 
 explore: logical_subscriptions {
   join: countries {
@@ -31,5 +33,33 @@ explore: logical_subscriptions {
     sql_on: ${table_metadata.table_name} = 'logical_subscriptions_history_v1' ;;
     type: left_outer
     relationship: many_to_one
+  }
+
+  join: vat_rates {
+    view_label: "VAT Rates"
+    sql_on:
+      ${logical_subscriptions.country_code} = ${vat_rates.country_code}
+      AND (
+        ${logical_subscriptions.effective_date} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
+        OR (${logical_subscriptions.effective_date} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
+      ) ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      vat
+    ]
+  }
+
+  join: exchange_rates_table {
+    view_label: "Exchange Rates"
+    sql_on:
+      ${logical_subscriptions.plan_currency} = ${exchange_rates_table.base_currency}
+      AND ${exchange_rates_table.quote_currency} = 'USD'
+      AND ${logical_subscriptions.effective_date} = ${exchange_rates_table.date_raw} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      price
+    ]
   }
 }

--- a/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
@@ -2,6 +2,8 @@ include: "../views/monthly_active_logical_subscriptions.view.lkml"
 include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
 
 explore: monthly_active_logical_subscriptions {
 
@@ -51,6 +53,34 @@ explore: monthly_active_logical_subscriptions {
     sql_on: ${table_metadata.table_name} = 'monthly_active_logical_subscriptions_v1' ;;
     type: left_outer
     relationship: many_to_one
+  }
+
+  join: vat_rates {
+    view_label: "VAT Rates"
+    sql_on:
+      ${monthly_active_logical_subscriptions.subscription__country_code} = ${vat_rates.country_code}
+      AND (
+        ${monthly_active_logical_subscriptions.effective_date} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
+        OR (${monthly_active_logical_subscriptions.effective_date} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
+      ) ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      vat
+    ]
+  }
+
+  join: exchange_rates_table {
+    view_label: "Exchange Rates"
+    sql_on:
+      ${monthly_active_logical_subscriptions.subscription__plan_currency} = ${exchange_rates_table.base_currency}
+      AND ${exchange_rates_table.quote_currency} = 'USD'
+      AND ${monthly_active_logical_subscriptions.effective_date} = ${exchange_rates_table.date_raw} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      price
+    ]
   }
 
 }


### PR DESCRIPTION
## [DS-3082](https://mozilla-hub.atlassian.net/browse/DS-3082): SubPlat logical subscriptions Looker explores

To include foreign subscriptions in revenue calculations their revenue needs to be converted to USD and the portion for VAT needs to be excluded.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
