### PR TITLE
Add country-level Desktop LTV to Looker

### DIFF
--- a/growth/views/firefox_desktop_ltv.view.lkml
+++ b/growth/views/firefox_desktop_ltv.view.lkml
@@ -1,7 +1,25 @@
-include: "//looker-hub/revenue/views/firefox_desktop_ltv.view.lkml"
-
-view: +firefox_desktop_ltv {
+view: firefox_desktop_ltv {
   label: "Firefox Desktop Lifetime Value (LTV)"
+  derived_table: {
+    sql: with first_country AS
+(SELECT client_id, sample_id, country as first_reported_country
+FROM `mozdata.telemetry.clients_first_seen`
+)
+
+SELECT client_id,
+  sample_id,
+  first_reported_country,
+  total_historic_ad_clicks,
+  total_future_ad_clicks,
+  total_predicted_ad_clicks,
+  revenue_per_click,
+  historic_value,
+  future_value,
+  lifetime_value
+FROM `mozdata.ltv.firefox_desktop_client_ltv`
+LEFT JOIN first_country USING(client_id, sample_id)
+      ;;
+  }
 
   dimension: client_id {
     sql: ${TABLE}.client_id ;;
@@ -13,34 +31,28 @@ view: +firefox_desktop_ltv {
     hidden: yes
   }
 
-  dimension: total_future_ad_clicks {
-    sql: ${TABLE}.total_future_ad_clicks ;;
-    type: number
-    hidden: yes
+  dimension: first_reported_country {
+    sql: ${TABLE}.first_reported_country ;;
+    type: string
   }
 
-  dimension: total_historic_ad_clicks {
-    sql: ${TABLE}.total_historic_ad_clicks ;;
-    type: number
-    hidden: yes
-  }
-
-  dimension: total_predicted_ad_clicks {
-    sql: ${TABLE}.total_predicted_ad_clicks ;;
-    type: number
-    hidden: yes
-  }
-
-  dimension: lifetime_value {
-    sql: ${TABLE}.lifetime_value ;;
-    type: number
-    hidden: yes
+  measure: total_users {
+    type: count_distinct
+    sql: ${client_id} ;;
   }
 
   measure: lifetime_value_total  {
     type: sum
     sql:${TABLE}.lifetime_value ;;
-    description: "Total life time revenue"
+    description: "Total Value"
+  }
+
+  measure: average_ltv {
+    type: number
+    value_format: "$0.000"
+    label: "Average LTV"
+    sql: SAFE_DIVIDE(${lifetime_value_total},  ${total_users});;
+    description: "The predicted LTV of a single user, in US dollars."
   }
 
   measure: future_ad_clicks_total  {


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
