### PR TITLE
Correct subscription revenue calculations to ignore VAT for plans using USD or CAD currencies

### DIFF
--- a/mozilla_vpn/views/mobile_subscriptions.view.lkml
+++ b/mozilla_vpn/views/mobile_subscriptions.view.lkml
@@ -33,9 +33,12 @@ view: mobile_subscriptions {
   dimension: pricing_plan {
     hidden:  no
   }
-
   dimension: plan_id {
     hidden: no
+  }
+  # The `mobile_subscriptions` explore doesn't do a proper join to `vat_rates`.
+  dimension: plan_vat_rate {
+    sql: NULL ;;
   }
 
   measure: non_trial_sub_count{

--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -79,6 +79,21 @@ view: +subscriptions {
     sql: CONCAT(IF(${product_name} LIKE "%Relay%", CONCAT("bundle", "_"), ""), ${plan_interval_count}, "_", ${plan_interval});;
   }
 
+  dimension: plan_vat_rate {
+    hidden: yes
+    type: number
+    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
+    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
+    sql:
+      CASE
+        WHEN ${subscriptions__active.active_date} >= "2022-12-01"
+          AND ${provider} IN ("Stripe", "Paypal")
+          AND ${plan_currency} IN ("usd", "cad")
+          THEN 0
+        ELSE IFNULL(${vat_rates.vat}, 0)
+      END;;
+  }
+
   dimension: forecast_region {
     description: "Indicates region used in financial forecasting.  This is to primarily support finance forecasting work."
     type: string
@@ -249,7 +264,7 @@ view: +subscriptions {
       ${plan_interval} = "month"
     THEN
       12 / ${plan_interval_count}
-    END * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
+    END * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + ${plan_vat_rate}) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
     value_format: "$#,##0.00"
   }
 }

--- a/relay/views/active_subscriptions.view.lkml
+++ b/relay/views/active_subscriptions.view.lkml
@@ -52,6 +52,21 @@ view: +active_subscriptions {
             "_", ${plan_interval});;
   }
 
+  dimension: plan_vat_rate {
+    label: "Plan VAT Rate"
+    type: number
+    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
+    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
+    sql:
+      CASE
+        WHEN ${active_date} >= "2022-12-01"
+          AND ${provider} IN ("Stripe", "Paypal")
+          AND ${plan_currency} IN ("usd", "cad")
+          THEN 0
+        ELSE IFNULL(${vat_rates.vat}, 0)
+      END;;
+  }
+
   dimension: promotion_discounts_amount {
     group_label: "Coupon"
     description: "The discounted amount applied to a subscription."
@@ -107,7 +122,7 @@ view: +active_subscriptions {
           ${plan_interval} = "month"
         THEN
           1 / ${plan_interval_count}
-        END * ${count} * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
+        END * ${count} * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + ${plan_vat_rate}) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
     hidden: yes
   }
 

--- a/relay/views/subscriptions.view.lkml
+++ b/relay/views/subscriptions.view.lkml
@@ -52,6 +52,21 @@ view: +subscriptions {
           "_", ${plan_interval});;
   }
 
+  dimension: plan_vat_rate {
+    hidden: yes
+    type: number
+    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
+    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
+    sql:
+      CASE
+        WHEN ${subscriptions__active.active_date} >= "2022-12-01"
+          AND ${provider} IN ("Stripe", "Paypal")
+          AND ${plan_currency} IN ("usd", "cad")
+          THEN 0
+        ELSE IFNULL(${vat_rates.vat}, 0)
+      END;;
+  }
+
   dimension: promotion_discounts_amount {
     group_label: "Coupon"
     description: "The discounted amount applied to a subscription."
@@ -161,7 +176,7 @@ view: +subscriptions {
         ${plan_interval} = "month"
       THEN
         12 / ${plan_interval_count}
-      END * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
+      END * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + ${plan_vat_rate}) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
     value_format: "$#,##0.00"
   }
   }

--- a/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
@@ -66,6 +66,21 @@ view: +daily_active_logical_subscriptions {
   dimension: subscription__plan_amount {
     value_format_name: decimal_2
   }
+  dimension: subscription__plan_vat_rate {
+    group_label: "Subscription"
+    group_item_label: "Plan VAT Rate"
+    type: number
+    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
+    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
+    sql:
+      CASE
+        WHEN ${date_date} >= '2022-12-01'
+          AND ${subscription__provider} = 'Stripe'
+          AND ${subscription__plan_currency} IN ('USD', 'CAD')
+          THEN 0
+        ELSE COALESCE(${vat_rates.vat}, 0)
+      END ;;
+  }
 
   dimension_group: subscription_active {
     type: duration
@@ -153,7 +168,7 @@ view: +daily_active_logical_subscriptions {
                   * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
                 )
           END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
+          / (1 + ${subscription__plan_vat_rate})
           * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
         )
       ) ;;
@@ -187,7 +202,7 @@ view: +daily_active_logical_subscriptions {
                   * IF(${subscription__auto_renew}, (365 / 12), LEAST((${days_until_current_period_ends} + 1), (365 / 12)))
                 )
           END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
+          / (1 + ${subscription__plan_vat_rate})
           * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
         )
       ) ;;

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -51,6 +51,20 @@ view: +logical_subscriptions {
   dimension: plan_amount {
     value_format_name: decimal_2
   }
+  dimension: plan_vat_rate {
+    label: "Plan VAT Rate"
+    type: number
+    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
+    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
+    sql:
+      CASE
+        WHEN ${effective_date} >= '2022-12-01'
+          AND ${provider} = 'Stripe'
+          AND ${plan_currency} IN ('USD', 'CAD')
+          THEN 0
+        ELSE COALESCE(${vat_rates.vat}, 0)
+      END ;;
+  }
 
   dimension: effective_date {
     type: date_raw
@@ -165,7 +179,7 @@ view: +logical_subscriptions {
                   * IF(${auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
                 )
           END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
+          / (1 + ${plan_vat_rate})
           * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
         )
       ) ;;
@@ -198,7 +212,7 @@ view: +logical_subscriptions {
                   * IF(${auto_renew}, (365 / 12), LEAST((${days_until_current_period_ends} + 1), (365 / 12)))
                 )
           END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
+          / (1 + ${plan_vat_rate})
           * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
         )
       ) ;;

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -73,6 +73,21 @@ view: +monthly_active_logical_subscriptions {
   dimension: subscription__plan_amount {
     value_format_name: decimal_2
   }
+  dimension: subscription__plan_vat_rate {
+    group_label: "Subscription"
+    group_item_label: "Plan VAT Rate"
+    type: number
+    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
+    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
+    sql:
+      CASE
+        WHEN ${effective_date} >= '2022-12-01'
+          AND ${subscription__provider} = 'Stripe'
+          AND ${subscription__plan_currency} IN ('USD', 'CAD')
+          THEN 0
+        ELSE COALESCE(${vat_rates.vat}, 0)
+      END ;;
+  }
 
   dimension: effective_date {
     type: date_raw
@@ -175,7 +190,7 @@ view: +monthly_active_logical_subscriptions {
                   * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
                 )
           END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
+          / (1 + ${subscription__plan_vat_rate})
           * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
         )
       ) ;;
@@ -209,7 +224,7 @@ view: +monthly_active_logical_subscriptions {
                   * IF(${subscription__auto_renew}, (365 / 12), LEAST((${days_until_current_period_ends} + 1), (365 / 12)))
                 )
           END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
+          / (1 + ${subscription__plan_vat_rate})
           * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
         )
       ) ;;


### PR DESCRIPTION
The recent SubPlat tax incident ([FXA-10591](https://mozilla-hub.atlassian.net/browse/FXA-10591)) brought to light the fact that Stripe Tax only charges exclusive taxes on plans where the currency is USD or CAD ([docs](https://docs.stripe.com/tax/products-prices-tax-codes-tax-behavior#setting-a-default-tax-behavior-(recommended))), even incorrectly treating normally inclusive VAT as exclusive taxes.

To more accurately reflect that reality, this PR changes the subscription revenue calculations to ignore inclusive VAT for plans using USD or CAD currencies from when we started using Stripe Tax on 2022-12-01.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
