### PR TITLE
Revert "Correct subscription revenue calculations to ignore VAT for plans using USD or CAD currencies"

### DIFF
--- a/mozilla_vpn/views/active_subscriptions_table.view.lkml
+++ b/mozilla_vpn/views/active_subscriptions_table.view.lkml
@@ -44,21 +44,6 @@ view: +active_subscriptions_table {
     sql: CONCAT(IF(${product_name} LIKE "%Relay%", CONCAT("bundle", "_"), ""), ${plan_interval_count}, "_", ${plan_interval});;
   }
 
-  dimension: plan_vat_rate {
-    label: "Plan VAT Rate"
-    type: number
-    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
-    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
-    sql:
-      CASE
-        WHEN ${active_date} >= "2022-12-01"
-          AND ${provider} IN ("Stripe", "Paypal")
-          AND ${plan_currency} IN ("usd", "cad")
-          THEN 0
-        ELSE IFNULL(${vat_rates.vat}, 0)
-      END;;
-  }
-
   dimension: promotion_discounts_amount {
     group_label: "Coupon"
     description: "The discounted amount applied to a subscription."
@@ -114,7 +99,7 @@ view: +active_subscriptions_table {
             ${plan_interval} = "month"
           THEN
             1 / ${plan_interval_count}
-          END * ${count} * (${normalized_plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + ${plan_vat_rate}) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
+          END * ${count} * (${normalized_plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
     hidden: yes
   }
 

--- a/mozilla_vpn/views/mobile_subscriptions.view.lkml
+++ b/mozilla_vpn/views/mobile_subscriptions.view.lkml
@@ -33,12 +33,9 @@ view: mobile_subscriptions {
   dimension: pricing_plan {
     hidden:  no
   }
+
   dimension: plan_id {
     hidden: no
-  }
-  # The `mobile_subscriptions` explore doesn't do a proper join to `vat_rates`.
-  dimension: plan_vat_rate {
-    sql: NULL ;;
   }
 
   measure: non_trial_sub_count{

--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -79,21 +79,6 @@ view: +subscriptions {
     sql: CONCAT(IF(${product_name} LIKE "%Relay%", CONCAT("bundle", "_"), ""), ${plan_interval_count}, "_", ${plan_interval});;
   }
 
-  dimension: plan_vat_rate {
-    hidden: yes
-    type: number
-    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
-    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
-    sql:
-      CASE
-        WHEN ${subscriptions__active.active_date} >= "2022-12-01"
-          AND ${provider} IN ("Stripe", "Paypal")
-          AND ${plan_currency} IN ("usd", "cad")
-          THEN 0
-        ELSE IFNULL(${vat_rates.vat}, 0)
-      END;;
-  }
-
   dimension: forecast_region {
     description: "Indicates region used in financial forecasting.  This is to primarily support finance forecasting work."
     type: string
@@ -264,7 +249,7 @@ view: +subscriptions {
       ${plan_interval} = "month"
     THEN
       12 / ${plan_interval_count}
-    END * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + ${plan_vat_rate}) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
+    END * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
     value_format: "$#,##0.00"
   }
 }

--- a/relay/views/active_subscriptions.view.lkml
+++ b/relay/views/active_subscriptions.view.lkml
@@ -52,21 +52,6 @@ view: +active_subscriptions {
             "_", ${plan_interval});;
   }
 
-  dimension: plan_vat_rate {
-    label: "Plan VAT Rate"
-    type: number
-    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
-    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
-    sql:
-      CASE
-        WHEN ${active_date} >= "2022-12-01"
-          AND ${provider} IN ("Stripe", "Paypal")
-          AND ${plan_currency} IN ("usd", "cad")
-          THEN 0
-        ELSE IFNULL(${vat_rates.vat}, 0)
-      END;;
-  }
-
   dimension: promotion_discounts_amount {
     group_label: "Coupon"
     description: "The discounted amount applied to a subscription."
@@ -122,7 +107,7 @@ view: +active_subscriptions {
           ${plan_interval} = "month"
         THEN
           1 / ${plan_interval_count}
-        END * ${count} * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + ${plan_vat_rate}) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
+        END * ${count} * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
     hidden: yes
   }
 

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -73,21 +73,6 @@ view: +monthly_active_logical_subscriptions {
   dimension: subscription__plan_amount {
     value_format_name: decimal_2
   }
-  dimension: subscription__plan_vat_rate {
-    group_label: "Subscription"
-    group_item_label: "Plan VAT Rate"
-    type: number
-    # Stripe Tax doesn't charge inclusive taxes on plans where the currency is USD or CAD.
-    # We started using Stripe Tax on 2022-12-01 (FXA-5457).
-    sql:
-      CASE
-        WHEN ${effective_date} >= '2022-12-01'
-          AND ${subscription__provider} = 'Stripe'
-          AND ${subscription__plan_currency} IN ('USD', 'CAD')
-          THEN 0
-        ELSE COALESCE(${vat_rates.vat}, 0)
-      END ;;
-  }
 
   dimension: effective_date {
     type: date_raw
@@ -190,7 +175,7 @@ view: +monthly_active_logical_subscriptions {
                   * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
                 )
           END
-          / (1 + ${subscription__plan_vat_rate})
+          / (1 + COALESCE(${vat_rates.vat}, 0))
           * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
         )
       ) ;;
@@ -224,7 +209,7 @@ view: +monthly_active_logical_subscriptions {
                   * IF(${subscription__auto_renew}, (365 / 12), LEAST((${days_until_current_period_ends} + 1), (365 / 12)))
                 )
           END
-          / (1 + ${subscription__plan_vat_rate})
+          / (1 + COALESCE(${vat_rates.vat}, 0))
           * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
         )
       ) ;;


### PR DESCRIPTION
Reverts mozilla/looker-spoke-default#966

After speaking with Accounting I learned that we actually are paying UK VAT manually outside of Stripe Tax.