### PR TITLE
Add shredder and expiration monitoring explores

### DIFF
--- a/monitoring/explores/shredder_per_job_stats.explore.lkml
+++ b/monitoring/explores/shredder_per_job_stats.explore.lkml
@@ -1,0 +1,5 @@
+include: "../views/shredder_per_job_stats.view.lkml"
+
+explore: shredder_job_stats {
+  from: shredder_per_job_stats
+}

--- a/monitoring/explores/shredder_targets_new_mismatched_targets.explore.lkml
+++ b/monitoring/explores/shredder_targets_new_mismatched_targets.explore.lkml
@@ -1,0 +1,5 @@
+include: "../views/shredder_targets_new_mismatched_targets.view.lkml"
+
+explore: shredder_mismatched_targets {
+  from: shredder_targets_new_mismatched_targets
+}

--- a/monitoring/explores/table_partition_expirations.explore.lkml
+++ b/monitoring/explores/table_partition_expirations.explore.lkml
@@ -1,0 +1,4 @@
+include: "../views/table_partition_expirations.view.lkml"
+
+explore: table_partition_expirations {
+}

--- a/monitoring/views/shredder_per_job_stats.view.lkml
+++ b/monitoring/views/shredder_per_job_stats.view.lkml
@@ -1,0 +1,40 @@
+include: "//looker-hub/monitoring/views/shredder_per_job_stats.view.lkml"
+
+view: +shredder_per_job_stats {
+
+  measure: overall_start_time {
+    description: "Start time of the group of jobs"
+    sql: TIMESTAMP(MIN(${TABLE}.start_time)) ;;
+  }
+
+  measure: overall_end_time {
+    description: "End time of the group of jobs"
+    sql: TIMESTAMP(MAX(${TABLE}.end_time)) ;;
+  }
+
+  measure: total_run_time_hours {
+    description: "Runtime of the group of jobs in hours"
+    type: number
+    sql: TIMESTAMP_DIFF(${overall_end_time}, ${overall_start_time}, SECOND) / 60 / 60 ;;
+  }
+
+  measure: total_avg_slots {
+    description: "Average slot usage over the duration of the jobs"
+    type: number
+    sql: SUM(${slot_hours}) / ${total_run_time_hours} ;;
+  }
+
+  dimension: job_group {
+    description: "Type of table of the task, maps to airflow tasks"
+    sql: CASE
+      WHEN task_id LIKE 'moz-fx-data-shared-prod.telemetry_stable.main_v%'
+        THEN 'main'
+      WHEN task_id LIKE 'moz-fx-data-shared-prod.telemetry_stable.main_use_counter_v%'
+        THEN 'main_use_counters'
+      WHEN task_id LIKE 'moz-fx-data-experiments.%'
+        THEN 'experiments'
+      ELSE 'all'
+    END ;;
+  }
+
+}

--- a/monitoring/views/shredder_targets_new_mismatched_targets.view.lkml
+++ b/monitoring/views/shredder_targets_new_mismatched_targets.view.lkml
@@ -1,0 +1,4 @@
+include: "//looker-hub/monitoring/views/shredder_targets_new_mismatched_targets.view.lkml"
+
+view: +shredder_targets_new_mismatched_targets {
+}

--- a/monitoring/views/table_partition_expirations.view.lkml
+++ b/monitoring/views/table_partition_expirations.view.lkml
@@ -1,0 +1,4 @@
+include: "//looker-hub/monitoring/views/table_partition_expirations.view.lkml"
+
+view: +table_partition_expirations {
+}


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-6196

Uses views from https://github.com/mozilla/lookml-generator/pull/1097

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
