### PR TITLE
Incorporate discounts into the logical subscription recurring revenue calculations (DS-3082)

### DIFF
--- a/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
@@ -133,6 +133,7 @@ view: +daily_active_logical_subscriptions {
     sql:
       CASE
         WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__is_trial} IS TRUE
           THEN 0
         WHEN ${subscription__plan_interval_type} IN ('year', 'month')
           THEN (
@@ -324,6 +325,7 @@ view: +daily_active_logical_subscriptions {
     sql:
       CASE
         WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__is_trial} IS TRUE
           THEN 0
         WHEN ${subscription__plan_interval_type} IN ('year', 'month')
           THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})

--- a/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
@@ -118,79 +118,249 @@ view: +daily_active_logical_subscriptions {
     group_item_label: "UTM Term"
   }
 
+  dimension: current_period_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__current_period_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_revenue_months {
+    type: number
+    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${current_period_discounted_plan_amount}
+              / ${subscription__plan_interval_months}
+              * ${current_period_annual_recurring_revenue_months}
+            )
+        WHEN ${subscription__plan_interval_type} IN ('week', 'day')
+          THEN ${current_period_discounted_plan_amount}
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__ongoing_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension_group: after_current_period_before_ongoing_discount_ends {
+    type: duration
+    sql_start: ${subscription__current_period_ends_at_raw} ;;
+    sql_end: TIMESTAMP_SUB(${subscription__ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_months {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (12 - ${current_period_annual_recurring_revenue_months})
+        ELSE
+          LEAST(
+            (
+              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_months}) + 1)
+              * ${subscription__plan_interval_months}
+            ),
+            (12 - ${current_period_annual_recurring_revenue_months})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (52 - ${subscription__plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${subscription__plan_interval_count}) + 1)
+              * ${subscription__plan_interval_count}
+            ),
+            (52 - ${subscription__plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_days {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (365 - ${subscription__plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_count}) + 1)
+              * ${subscription__plan_interval_count}
+            ),
+            (365 - ${subscription__plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__auto_renew} IS NOT TRUE
+          OR COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_months}
+              * ${ongoing_discounted_annual_recurring_revenue_months}
+            )
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_weeks}
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_days}
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__auto_renew} IS NOT TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_months}
+              * GREATEST(
+                (
+                  12
+                  - ${current_period_annual_recurring_revenue_months}
+                  - ${ongoing_discounted_annual_recurring_revenue_months}
+                ),
+                0
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_count}
+              * GREATEST(
+                (
+                  52
+                  - ${subscription__plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
+                ),
+                0
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_count}
+              * GREATEST(
+                (
+                  365
+                  - ${subscription__plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_days}
+                ),
+                0
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: annual_recurring_gross_revenue {
+    type: number
+    sql:
+      ${current_period_annual_recurring_gross_revenue}
+      + ${ongoing_discounted_annual_recurring_gross_revenue}
+      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
+    hidden: yes
+  }
+  dimension: annual_recurring_net_revenue {
+    type: number
+    sql:
+      ${annual_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
   dimension: annual_recurring_revenue_usd {
-    group_label: "Subscription"
     label: "Annual Recurring Revenue (USD)"
     type: number
     sql:
-      IF(
-        ${subscription__is_active} IS NOT TRUE,
-        0,
-        (
-          CASE ${subscription__plan_interval_type}
-            WHEN 'year'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
-                )
-            WHEN 'month'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
-                )
-            WHEN 'week'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
-                )
-            WHEN 'day'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
-                )
-          END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
-          * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
-        )
-      ) ;;
+      ${annual_recurring_net_revenue}
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
     value_format_name: usd
   }
 
+  dimension: monthly_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${subscription__plan_interval_count}
+                * IF(${subscription__auto_renew}, GREATEST((4 - ${subscription__plan_interval_count}), 0), 0)
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${subscription__plan_interval_count}
+                * IF(${subscription__auto_renew}, GREATEST((30 - ${subscription__plan_interval_count}), 0), 0)
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+  dimension: monthly_recurring_net_revenue {
+    type: number
+    sql:
+      ${monthly_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
   dimension: monthly_recurring_revenue_usd {
-    group_label: "Subscription"
     label: "Monthly Recurring Revenue (USD)"
     type: number
     sql:
-      IF(
-        ${subscription__is_active} IS NOT TRUE,
-        0,
-        (
-          CASE ${subscription__plan_interval_type}
-            WHEN 'year'
-              THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} / 12
-            WHEN 'month'
-              THEN ${subscription__plan_amount} / ${subscription__plan_interval_count}
-            WHEN 'week'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, (52 / 12), LEAST((${weeks_until_current_period_ends} + 1), (52 / 12)))
-                )
-            WHEN 'day'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, (365 / 12), LEAST((${days_until_current_period_ends} + 1), (365 / 12)))
-                )
-          END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
-          * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
-        )
-      ) ;;
+      ${monthly_recurring_net_revenue}
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
@@ -312,6 +312,7 @@ view: +daily_active_logical_subscriptions {
     hidden: yes
   }
   dimension: annual_recurring_revenue_usd {
+    group_label: "Subscription"
     label: "Annual Recurring Revenue (USD)"
     type: number
     sql:
@@ -358,6 +359,7 @@ view: +daily_active_logical_subscriptions {
     hidden: yes
   }
   dimension: monthly_recurring_revenue_usd {
+    group_label: "Subscription"
     label: "Monthly Recurring Revenue (USD)"
     type: number
     sql:

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -131,77 +131,249 @@ view: +logical_subscriptions {
     group_item_label: "UTM Term"
   }
 
+  dimension: current_period_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${plan_amount} - COALESCE(${current_period_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_revenue_months {
+    type: number
+    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${is_active} IS NOT TRUE
+          THEN 0
+        WHEN ${plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${current_period_discounted_plan_amount}
+              / ${plan_interval_months}
+              * ${current_period_annual_recurring_revenue_months}
+            )
+        WHEN ${plan_interval_type} IN ('week', 'day')
+          THEN ${current_period_discounted_plan_amount}
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${plan_amount} - COALESCE(${ongoing_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension_group: after_current_period_before_ongoing_discount_ends {
+    type: duration
+    sql_start: ${current_period_ends_at_raw} ;;
+    sql_end: TIMESTAMP_SUB(${ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_months {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${ongoing_discount_ends_at_raw} IS NULL
+          THEN (12 - ${current_period_annual_recurring_revenue_months})
+        ELSE
+          LEAST(
+            (
+              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${plan_interval_months}) + 1)
+              * ${plan_interval_months}
+            ),
+            (12 - ${current_period_annual_recurring_revenue_months})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${ongoing_discount_ends_at_raw} IS NULL
+          THEN (52 - ${plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${plan_interval_count}) + 1)
+              * ${plan_interval_count}
+            ),
+            (52 - ${plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_days {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${ongoing_discount_ends_at_raw} IS NULL
+          THEN (365 - ${plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${plan_interval_count}) + 1)
+              * ${plan_interval_count}
+            ),
+            (365 - ${plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${is_active} IS NOT TRUE
+          OR ${auto_renew} IS NOT TRUE
+          OR COALESCE(${ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${plan_interval_months}
+              * ${ongoing_discounted_annual_recurring_revenue_months}
+            )
+        WHEN ${plan_interval_type} = 'week'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_weeks}
+            )
+        WHEN ${plan_interval_type} = 'day'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_days}
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${is_active} IS NOT TRUE
+          OR ${auto_renew} IS NOT TRUE
+          THEN 0
+        WHEN ${plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${plan_amount}
+              / ${plan_interval_months}
+              * GREATEST(
+                (
+                  12
+                  - ${current_period_annual_recurring_revenue_months}
+                  - ${ongoing_discounted_annual_recurring_revenue_months}
+                ),
+                0
+              )
+            )
+        WHEN ${plan_interval_type} = 'week'
+          THEN (
+              ${plan_amount}
+              / ${plan_interval_count}
+              * GREATEST(
+                (
+                  52
+                  - ${plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
+                ),
+                0
+              )
+            )
+        WHEN ${plan_interval_type} = 'day'
+          THEN (
+              ${plan_amount}
+              / ${plan_interval_count}
+              * GREATEST(
+                (
+                  365
+                  - ${plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_days}
+                ),
+                0
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: annual_recurring_gross_revenue {
+    type: number
+    sql:
+      ${current_period_annual_recurring_gross_revenue}
+      + ${ongoing_discounted_annual_recurring_gross_revenue}
+      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
+    hidden: yes
+  }
+  dimension: annual_recurring_net_revenue {
+    type: number
+    sql:
+      ${annual_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
   dimension: annual_recurring_revenue_usd {
     label: "Annual Recurring Revenue (USD)"
     type: number
     sql:
-      IF(
-        ${is_active} IS NOT TRUE,
-        0,
-        (
-          CASE ${plan_interval_type}
-            WHEN 'year'
-              THEN (
-                  ${plan_amount}
-                  / ${plan_interval_count}
-                  * IF(${auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
-                )
-            WHEN 'month'
-              THEN (
-                  ${plan_amount}
-                  / ${plan_interval_count}
-                  * IF(${auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
-                )
-            WHEN 'week'
-              THEN (
-                  ${plan_amount}
-                  / ${plan_interval_count}
-                  * IF(${auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
-                )
-            WHEN 'day'
-              THEN (
-                  ${plan_amount}
-                  / ${plan_interval_count}
-                  * IF(${auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
-                )
-          END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
-          * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
-        )
-      ) ;;
+      ${annual_recurring_net_revenue}
+      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
     value_format_name: usd
   }
 
+  dimension: monthly_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${is_active} IS NOT TRUE
+          THEN 0
+        WHEN ${plan_interval_type} IN ('year', 'month')
+          THEN (${current_period_discounted_plan_amount} / ${plan_interval_months})
+        WHEN ${plan_interval_type} = 'week'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${plan_interval_count}
+                * IF(${auto_renew}, GREATEST((4 - ${plan_interval_count}), 0), 0)
+              )
+            )
+        WHEN ${plan_interval_type} = 'day'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${plan_interval_count}
+                * IF(${auto_renew}, GREATEST((30 - ${plan_interval_count}), 0), 0)
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+  dimension: monthly_recurring_net_revenue {
+    type: number
+    sql:
+      ${monthly_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
   dimension: monthly_recurring_revenue_usd {
     label: "Monthly Recurring Revenue (USD)"
     type: number
     sql:
-      IF(
-        ${is_active} IS NOT TRUE,
-        0,
-        (
-          CASE ${plan_interval_type}
-            WHEN 'year'
-              THEN ${plan_amount} / ${plan_interval_count} / 12
-            WHEN 'month'
-              THEN ${plan_amount} / ${plan_interval_count}
-            WHEN 'week'
-              THEN (
-                  ${plan_amount}
-                  / ${plan_interval_count}
-                  * IF(${auto_renew}, (52 / 12), LEAST((${weeks_until_current_period_ends} + 1), (52 / 12)))
-                )
-            WHEN 'day'
-              THEN (
-                  ${plan_amount}
-                  / ${plan_interval_count}
-                  * IF(${auto_renew}, (365 / 12), LEAST((${days_until_current_period_ends} + 1), (365 / 12)))
-                )
-          END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
-          * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
-        )
-      ) ;;
+      ${monthly_recurring_net_revenue}
+      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -146,6 +146,7 @@ view: +logical_subscriptions {
     sql:
       CASE
         WHEN ${is_active} IS NOT TRUE
+          OR ${is_trial} IS TRUE
           THEN 0
         WHEN ${plan_interval_type} IN ('year', 'month')
           THEN (
@@ -337,6 +338,7 @@ view: +logical_subscriptions {
     sql:
       CASE
         WHEN ${is_active} IS NOT TRUE
+          OR ${is_trial} IS TRUE
           THEN 0
         WHEN ${plan_interval_type} IN ('year', 'month')
           THEN (${current_period_discounted_plan_amount} / ${plan_interval_months})

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -334,6 +334,7 @@ view: +monthly_active_logical_subscriptions {
     hidden: yes
   }
   dimension: annual_recurring_revenue_usd {
+    group_label: "Subscription"
     label: "Annual Recurring Revenue (USD)"
     type: number
     sql:
@@ -380,6 +381,7 @@ view: +monthly_active_logical_subscriptions {
     hidden: yes
   }
   dimension: monthly_recurring_revenue_usd {
+    group_label: "Subscription"
     label: "Monthly Recurring Revenue (USD)"
     type: number
     sql:

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -155,6 +155,7 @@ view: +monthly_active_logical_subscriptions {
     sql:
       CASE
         WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__is_trial} IS TRUE
           THEN 0
         WHEN ${subscription__plan_interval_type} IN ('year', 'month')
           THEN (
@@ -346,6 +347,7 @@ view: +monthly_active_logical_subscriptions {
     sql:
       CASE
         WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__is_trial} IS TRUE
           THEN 0
         WHEN ${subscription__plan_interval_type} IN ('year', 'month')
           THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -140,79 +140,249 @@ view: +monthly_active_logical_subscriptions {
     group_item_label: "UTM Term"
   }
 
+  dimension: current_period_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__current_period_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_revenue_months {
+    type: number
+    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${current_period_discounted_plan_amount}
+              / ${subscription__plan_interval_months}
+              * ${current_period_annual_recurring_revenue_months}
+            )
+        WHEN ${subscription__plan_interval_type} IN ('week', 'day')
+          THEN ${current_period_discounted_plan_amount}
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__ongoing_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension_group: after_current_period_before_ongoing_discount_ends {
+    type: duration
+    sql_start: ${subscription__current_period_ends_at_raw} ;;
+    sql_end: TIMESTAMP_SUB(${subscription__ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_months {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (12 - ${current_period_annual_recurring_revenue_months})
+        ELSE
+          LEAST(
+            (
+              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_months}) + 1)
+              * ${subscription__plan_interval_months}
+            ),
+            (12 - ${current_period_annual_recurring_revenue_months})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (52 - ${subscription__plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${subscription__plan_interval_count}) + 1)
+              * ${subscription__plan_interval_count}
+            ),
+            (52 - ${subscription__plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_days {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (365 - ${subscription__plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_count}) + 1)
+              * ${subscription__plan_interval_count}
+            ),
+            (365 - ${subscription__plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__auto_renew} IS NOT TRUE
+          OR COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_months}
+              * ${ongoing_discounted_annual_recurring_revenue_months}
+            )
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_weeks}
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_days}
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__auto_renew} IS NOT TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_months}
+              * GREATEST(
+                (
+                  12
+                  - ${current_period_annual_recurring_revenue_months}
+                  - ${ongoing_discounted_annual_recurring_revenue_months}
+                ),
+                0
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_count}
+              * GREATEST(
+                (
+                  52
+                  - ${subscription__plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
+                ),
+                0
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_count}
+              * GREATEST(
+                (
+                  365
+                  - ${subscription__plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_days}
+                ),
+                0
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: annual_recurring_gross_revenue {
+    type: number
+    sql:
+      ${current_period_annual_recurring_gross_revenue}
+      + ${ongoing_discounted_annual_recurring_gross_revenue}
+      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
+    hidden: yes
+  }
+  dimension: annual_recurring_net_revenue {
+    type: number
+    sql:
+      ${annual_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
   dimension: annual_recurring_revenue_usd {
-    group_label: "Subscription"
     label: "Annual Recurring Revenue (USD)"
     type: number
     sql:
-      IF(
-        ${subscription__is_active} IS NOT TRUE,
-        0,
-        (
-          CASE ${subscription__plan_interval_type}
-            WHEN 'year'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, 1, (LEAST((${months_until_current_period_ends} + 1), 12) / 12))
-                )
-            WHEN 'month'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, 12, LEAST((${months_until_current_period_ends} + 1), 12))
-                )
-            WHEN 'week'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, 52, LEAST((${weeks_until_current_period_ends} + 1), 52))
-                )
-            WHEN 'day'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, 365, LEAST((${days_until_current_period_ends} + 1), 365))
-                )
-          END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
-          * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
-        )
-      ) ;;
+      ${annual_recurring_net_revenue}
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
     value_format_name: usd
   }
 
+  dimension: monthly_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${subscription__plan_interval_count}
+                * IF(${subscription__auto_renew}, GREATEST((4 - ${subscription__plan_interval_count}), 0), 0)
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${subscription__plan_interval_count}
+                * IF(${subscription__auto_renew}, GREATEST((30 - ${subscription__plan_interval_count}), 0), 0)
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+  dimension: monthly_recurring_net_revenue {
+    type: number
+    sql:
+      ${monthly_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
   dimension: monthly_recurring_revenue_usd {
-    group_label: "Subscription"
     label: "Monthly Recurring Revenue (USD)"
     type: number
     sql:
-      IF(
-        ${subscription__is_active} IS NOT TRUE,
-        0,
-        (
-          CASE ${subscription__plan_interval_type}
-            WHEN 'year'
-              THEN ${subscription__plan_amount} / ${subscription__plan_interval_count} / 12
-            WHEN 'month'
-              THEN ${subscription__plan_amount} / ${subscription__plan_interval_count}
-            WHEN 'week'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, (52 / 12), LEAST((${weeks_until_current_period_ends} + 1), (52 / 12)))
-                )
-            WHEN 'day'
-              THEN (
-                  ${subscription__plan_amount}
-                  / ${subscription__plan_interval_count}
-                  * IF(${subscription__auto_renew}, (365 / 12), LEAST((${days_until_current_period_ends} + 1), (365 / 12)))
-                )
-          END
-          / (1 + COALESCE(${vat_rates.vat}, 0))
-          * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0))
-        )
-      ) ;;
+      ${monthly_recurring_net_revenue}
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
     value_format_name: usd
   }
 


### PR DESCRIPTION
## [DS-3082](https://mozilla-hub.atlassian.net/browse/DS-3082): SubPlat logical subscriptions Looker explores

Now that discounts data has been added to the underlying logical subscription tables (mozilla/bigquery-etl#6474) we can use that to more accurately project monthly/annual recurring subscription revenue.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
