### PR TITLE
Set caching to 4h for fenix and Firefox iOS

### DIFF
--- a/fenix/fenix.model.lkml
+++ b/fenix/fenix.model.lkml
@@ -7,6 +7,7 @@ include: "datagroups/*"
 include: "//looker-hub/fenix/views/metrics.view.lkml"
 include: "/fenix/views/android_store_performance.view.lkml"
 
+persist_for: "4 hours"
 
 explore: +topsites_impression {
   hidden: yes

--- a/firefox_ios/firefox_ios.model.lkml
+++ b/firefox_ios/firefox_ios.model.lkml
@@ -1,6 +1,8 @@
 connection: "telemetry"
 label: "Firefox for iOS"
 
+persist_for: "4 hours"
+
 # TODO: remove unnecessary view imports
 include: "//looker-hub/firefox_ios/views/active_users_aggregates_table.view.lkml"
 include: "//looker-hub/firefox_ios/views/active_users_table.view.lkml"


### PR DESCRIPTION
This is a follow-up to https://github.com/mozilla/looker-spoke-default/commit/cc02c31a19a99f1bdc90b8bf7f250d7650c25831

This increases the caching duration for FF iOS and Fenix to 4h. Previously, we only tested it on Focus iOS, but the explores there seem to be rarely used, so it wasn't possible to see much of a difference to before. Changing the caching on FF iOS and Fenix should give some better insight into whether this should be more widely used.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
