### PR TITLE
Remove experiment monitoring related views and explores

### DIFF
--- a/experimentation/dashboards/experiment_enrollments.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments.dashboard.lookml
@@ -1,7 +1,10 @@
+---
 - dashboard: experiment_enrollments
   title: Experiment Enrollments
   layout: newspaper
   preferred_viewer: dashboards-next
+  description: ''
+  preferred_slug: tvepcCRz7lG1J7fpxvCMzp
   elements:
   - title: Daily Active Population by Branch
     name: Daily Active Population by Branch
@@ -14,6 +17,7 @@
     filters: {}
     sorts: [experiment_enrollment_daily_active_population.time_time desc, experiment_enrollment_daily_active_population.branch]
     limit: 500
+    column_limit: 5000
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -44,8 +48,11 @@
         tickDensityCustom: 5, type: linear}]
     x_axis_label: Time [UTC]
     defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Updated daily
     listen:
-      Time Range: experiment_enrollment_daily_active_population.time_time
+      Time Range [UTC]: experiment_enrollment_daily_active_population.time_time
       Experiment: experiment_enrollment_daily_active_population.experiment
     row: 10
     col: 12
@@ -59,7 +66,8 @@
     fields: [experiment_enrollment_daily_active_population.Total, experiment_enrollment_daily_active_population.time_time]
     filters: {}
     sorts: [experiment_enrollment_daily_active_population.time_time desc]
-    limit: 500
+    limit: 5000
+    column_limit: 50
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -86,8 +94,12 @@
     interpolation: linear
     x_axis_label: Time [UTC]
     defaults_version: 1
+    y_axes: []
+    note_state: expanded
+    note_display: above
+    note_text: Updated daily
     listen:
-      Time Range: experiment_enrollment_daily_active_population.time_time
+      Time Range [UTC]: experiment_enrollment_daily_active_population.time_time
       Experiment: experiment_enrollment_daily_active_population.experiment
     row: 10
     col: 0
@@ -101,7 +113,8 @@
     fields: [experiment_enrollment_cumulative_population_estimate.Total, experiment_enrollment_cumulative_population_estimate.time_time]
     filters: {}
     sorts: [experiment_enrollment_cumulative_population_estimate.time_time desc]
-    limit: 500
+    limit: 5000
+    column_limit: 50
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -128,8 +141,12 @@
     interpolation: linear
     x_axis_label: Time [UTC]
     defaults_version: 1
+    y_axes: []
+    note_state: collapsed
+    note_display: above
+    note_text: Updated every 10 minutes
     listen:
-      Time Range: experiment_enrollment_cumulative_population_estimate.timeframe
+      Time Range [UTC]: experiment_enrollment_cumulative_population_estimate.timeframe
       Experiment: experiment_enrollment_cumulative_population_estimate.experiment
     row: 18
     col: 0
@@ -145,7 +162,8 @@
     pivots: [experiment_enrollment_cumulative_population_estimate.branch]
     filters: {}
     sorts: [experiment_enrollment_cumulative_population_estimate.time_time desc, experiment_enrollment_cumulative_population_estimate.branch]
-    limit: 500
+    limit: 5000
+    column_limit: 50
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -178,157 +196,13 @@
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Time [UTC]
     defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Updated every 10 minutes
     listen:
-      Time Range: experiment_enrollment_cumulative_population_estimate.timeframe
+      Time Range [UTC]: experiment_enrollment_cumulative_population_estimate.timeframe
       Experiment: experiment_enrollment_cumulative_population_estimate.experiment
     row: 18
-    col: 12
-    width: 12
-    height: 7
-  - title: Cumulative Ad Clicks by Branch
-    name: Cumulative Ad Clicks by Branch
-    model: experimentation
-    explore: experiment_cumulative_ad_clicks
-    type: looker_line
-    fields: [experiment_cumulative_ad_clicks.Total, experiment_cumulative_ad_clicks.time_time,
-      experiment_cumulative_ad_clicks.branch]
-    pivots: [experiment_cumulative_ad_clicks.branch]
-    filters: {}
-    sorts: [experiment_cumulative_ad_clicks.time_time desc, experiment_cumulative_ad_clicks.branch]
-    limit: 500
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    show_null_points: false
-    interpolation: linear
-    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_cumulative_ad_clicks.Total,
-            id: variant - experiment_cumulative_ad_clicks.Total, name: variant}],
-        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}]
-    x_axis_label: Time [UTC]
-    defaults_version: 1
-    listen:
-      Time Range: experiment_cumulative_ad_clicks.timeframe
-      Experiment: experiment_cumulative_ad_clicks.experiment
-    row: 61
-    col: 12
-    width: 12
-    height: 7
-  - title: Cumulative Search Count by Branch
-    name: Cumulative Search Count by Branch
-    model: experimentation
-    explore: experiment_cumulative_search_count
-    type: looker_line
-    fields: [experiment_cumulative_search_count.Total, experiment_cumulative_search_count.branch,
-      experiment_cumulative_search_count.time_time]
-    pivots: [experiment_cumulative_search_count.branch]
-    filters: {}
-    sorts: [experiment_cumulative_search_count.time_time desc, experiment_cumulative_search_count.branch]
-    limit: 500
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    show_null_points: false
-    interpolation: linear
-    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_cumulative_search_count.Total,
-            id: debugging-disabled - experiment_cumulative_search_count.Total, name: debugging-disabled},
-          {axisId: experiment_cumulative_search_count.Total, id: debugging-enabled
-              - experiment_cumulative_search_count.Total, name: debugging-enabled}],
-        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}]
-    x_axis_label: Time [UTC]
-    series_types: {}
-    defaults_version: 1
-    listen:
-      Time Range: experiment_cumulative_search_count.timeframe
-      Experiment: experiment_cumulative_search_count.experiment
-    row: 54
-    col: 12
-    width: 12
-    height: 7
-  - title: Cumulative Seach Count with Ads by Branch
-    name: Cumulative Seach Count with Ads by Branch
-    model: experimentation
-    explore: experiment_cumulative_search_with_ads_count
-    type: looker_line
-    fields: [experiment_cumulative_search_with_ads_count.Total, experiment_cumulative_search_with_ads_count.branch,
-      experiment_cumulative_search_with_ads_count.time_time]
-    pivots: [experiment_cumulative_search_with_ads_count.branch]
-    filters: {}
-    sorts: [experiment_cumulative_search_with_ads_count.time_time desc, experiment_cumulative_search_with_ads_count.branch]
-    limit: 500
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    show_null_points: false
-    interpolation: linear
-    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_cumulative_search_with_ads_count.Total,
-            id: only-branch - experiment_cumulative_search_with_ads_count.Total, name: only-branch}],
-        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}]
-    x_axis_label: Time [UTC]
-    defaults_version: 1
-    listen:
-      Time Range: experiment_cumulative_search_with_ads_count.timeframe
-      Experiment: experiment_cumulative_search_with_ads_count.experiment
-    row: 68
     col: 12
     width: 12
     height: 7
@@ -340,7 +214,8 @@
     fields: [experiment_unenrollment_overall.timestamp, experiment_unenrollment_overall.Total]
     filters: {}
     sorts: [experiment_unenrollment_overall.timestamp desc]
-    limit: 500
+    limit: 5000
+    column_limit: 50
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -369,14 +244,17 @@
     show_silhouette: false
     totals_color: "#808080"
     x_axis_label: Time [UTC]
-    series_types: {}
     show_null_points: true
     interpolation: linear
     defaults_version: 1
+    y_axes: []
+    note_state: collapsed
+    note_display: above
+    note_text: Updated every 10 minutes
     listen:
-      Time Range: experiment_unenrollment_overall.timeframe
+      Time Range [UTC]: experiment_unenrollment_overall.timeframe
       Experiment: experiment_unenrollment_overall.experiment
-    row: 32
+    row: 39
     col: 0
     width: 12
     height: 7
@@ -390,7 +268,8 @@
     pivots: [experiment_unenrollment_overall.branch]
     filters: {}
     sorts: [experiment_unenrollment_overall.timestamp desc, experiment_unenrollment_overall.branch]
-    limit: 500
+    limit: 5000
+    column_limit: 50
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -425,17 +304,19 @@
         showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
         tickDensityCustom: 5, type: linear}]
     x_axis_label: Time [UTC]
-    series_types: {}
     ordering: none
     show_null_labels: false
     show_totals_labels: false
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Updated every 10 minutes
     listen:
-      Time Range: experiment_unenrollment_overall.timeframe
+      Time Range [UTC]: experiment_unenrollment_overall.timeframe
       Experiment: experiment_unenrollment_overall.experiment
-    row: 32
+    row: 39
     col: 12
     width: 12
     height: 7
@@ -447,7 +328,8 @@
     fields: [experiment_enrollment_overall.timestamp, experiment_enrollment_overall.Total]
     filters: {}
     sorts: [experiment_enrollment_overall.timestamp desc]
-    limit: 500
+    limit: 5000
+    column_limit: 50
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -480,12 +362,14 @@
         showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
         type: linear}]
     x_axis_label: Time [UTC]
-    series_types: {}
     defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Updated every 10 minutes
     listen:
-      Time Range: experiment_enrollment_overall.timeframe
+      Time Range [UTC]: experiment_enrollment_overall.timeframe
       Experiment: experiment_enrollment_overall.experiment
-    row: 25
+    row: 32
     col: 0
     width: 12
     height: 7
@@ -499,7 +383,8 @@
     pivots: [experiment_enrollment_overall.branch]
     filters: {}
     sorts: [experiment_enrollment_overall.timestamp desc, experiment_enrollment_overall.branch]
-    limit: 500
+    limit: 5000
+    column_limit: 50
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -530,17 +415,19 @@
         type: linear}]
     x_axis_label: Time [UTC]
     hidden_series: [fission-disabled - experiment_enrollment_overall.Total]
-    series_types: {}
     ordering: none
     show_null_labels: false
     show_totals_labels: false
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
+    note_state: collapsed
+    note_display: above
+    note_text: Updated every 10 minutes
     listen:
-      Time Range: experiment_enrollment_overall.timeframe
+      Time Range [UTC]: experiment_enrollment_overall.timeframe
       Experiment: experiment_enrollment_overall.experiment
-    row: 25
+    row: 32
     col: 12
     width: 12
     height: 7
@@ -582,14 +469,17 @@
     show_silhouette: false
     totals_color: "#808080"
     x_axis_label: Time [UTC]
-    series_types: {}
     show_null_points: true
     interpolation: linear
     defaults_version: 1
+    y_axes: []
+    note_state: collapsed
+    note_display: above
+    note_text: Updated every 10 minutes
     listen:
-      Time Range: experiment_enrollment_other_events_overall.timeframe
+      Time Range [UTC]: experiment_enrollment_other_events_overall.timeframe
       Experiment: experiment_enrollment_other_events_overall.experiment
-    row: 39
+    row: 46
     col: 0
     width: 12
     height: 7
@@ -603,10 +493,16 @@
     pivots: [branch_event]
     filters: {}
     sorts: [experiment_enrollment_other_events_overall.timestamp desc, branch_event]
-    dynamic_fields: [{category: dimension, expression: 'concat(${experiment_enrollment_other_events_overall.branch},"
-          - ", ${experiment_enrollment_other_events_overall.event})', label: Branch
-          + Event, value_format: !!null '', value_format_name: !!null '', dimension: branch_event,
-        _kind_hint: dimension, _type_hint: string}]
+    dynamic_fields:
+    - category: dimension
+      expression: concat(${experiment_enrollment_other_events_overall.branch}," -
+        ", ${experiment_enrollment_other_events_overall.event})
+      label: Branch + Event
+      value_format:
+      value_format_name:
+      dimension: branch_event
+      _kind_hint: dimension
+      _type_hint: string
     x_axis_gridlines: false
     y_axis_gridlines: true
     show_view_names: false
@@ -635,14 +531,17 @@
     show_silhouette: false
     totals_color: "#808080"
     x_axis_label: Time [UTC]
-    series_types: {}
     show_null_points: true
     interpolation: linear
     defaults_version: 1
+    y_axes: []
+    note_state: collapsed
+    note_display: above
+    note_text: Updated every 10 minutes
     listen:
-      Time Range: experiment_enrollment_other_events_overall.timeframe
+      Time Range [UTC]: experiment_enrollment_other_events_overall.timeframe
       Experiment: experiment_enrollment_other_events_overall.experiment
-    row: 39
+    row: 46
     col: 12
     width: 12
     height: 7
@@ -652,9 +551,11 @@
     explore: unenrollment_reasons
     type: looker_grid
     fields: [events.reason, events.event_method, events.event_count]
-    filters: {}
+    filters:
+      events.sample_id: '0'
     sorts: [events.event_count desc]
     limit: 500
+    column_limit: 50
     show_view_names: false
     show_row_numbers: true
     transpose: false
@@ -696,185 +597,14 @@
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
-    series_types: {}
+    y_axes: []
     listen:
-      Time Range: events.submission_date
+      Time Range [UTC]: events.submission_date
       Experiment: events.event_string_value
-    row: 46
+    row: 53
     col: 0
     width: 24
     height: 6
-  - name: Search Metrics
-    type: text
-    title_text: Search Metrics
-    subtitle_text: ''
-    body_text: ''
-    row: 52
-    col: 0
-    width: 24
-    height: 2
-  - title: Search Count by Branch
-    name: Search Count by Branch
-    model: experimentation
-    explore: experiment_search_aggregates_live
-    type: looker_line
-    fields: [experiment_search_aggregates_live.timestamp, experiment_search_aggregates_live.total_search_count,
-      experiment_search_aggregates_live.branch]
-    pivots: [experiment_search_aggregates_live.branch]
-    filters: {}
-    sorts: [experiment_search_aggregates_live.timestamp desc, experiment_search_aggregates_live.branch]
-    limit: 500
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    show_null_points: true
-    interpolation: step
-    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_search_aggregates_live.total_search_count,
-            id: experiment_search_aggregates_live.total_search_count, name: Total
-              Search Count}], showLabels: true, showValues: true, unpinAxis: false,
-        tickDensity: default, tickDensityCustom: 5, type: linear}]
-    x_axis_label: Time [UTC]
-    series_types: {}
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    defaults_version: 1
-    listen:
-      Time Range: experiment_search_aggregates_live.timeframe
-      Experiment: experiment_search_aggregates_live.experiment
-    row: 54
-    col: 0
-    width: 12
-    height: 7
-  - title: Ad Clicks by Branch
-    name: Ad Clicks by Branch
-    model: experimentation
-    explore: experiment_search_aggregates_live
-    type: looker_line
-    fields: [experiment_search_aggregates_live.timestamp, experiment_search_aggregates_live.branch,
-      experiment_search_aggregates_live.total_ad_clicks]
-    pivots: [experiment_search_aggregates_live.branch]
-    filters: {}
-    sorts: [experiment_search_aggregates_live.timestamp desc, experiment_search_aggregates_live.branch]
-    limit: 500
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    show_null_points: true
-    interpolation: step
-    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_search_aggregates_live.total_search_count,
-            id: experiment_search_aggregates_live.total_search_count, name: Total
-              Search Count}], showLabels: true, showValues: true, unpinAxis: false,
-        tickDensity: default, tickDensityCustom: 5, type: linear}]
-    x_axis_label: Time [UTC]
-    series_types: {}
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    defaults_version: 1
-    listen:
-      Time Range: experiment_search_aggregates_live.timeframe
-      Experiment: experiment_search_aggregates_live.experiment
-    row: 61
-    col: 0
-    width: 12
-    height: 7
-  - title: Search Count with Ads by Branch
-    name: Search Count with Ads by Branch
-    model: experimentation
-    explore: experiment_search_aggregates_live
-    type: looker_line
-    fields: [experiment_search_aggregates_live.timestamp, experiment_search_aggregates_live.branch,
-      experiment_search_aggregates_live.total_searches_with_ads]
-    pivots: [experiment_search_aggregates_live.branch]
-    filters: {}
-    sorts: [experiment_search_aggregates_live.timestamp desc]
-    limit: 500
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    show_null_points: true
-    interpolation: step
-    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_search_aggregates_live.total_search_count,
-            id: experiment_search_aggregates_live.total_search_count, name: Total
-              Search Count}], showLabels: true, showValues: true, unpinAxis: false,
-        tickDensity: default, tickDensityCustom: 5, type: linear}]
-    x_axis_label: Time [UTC]
-    series_types: {}
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    defaults_version: 1
-    listen:
-      Time Range: experiment_search_aggregates_live.timeframe
-      Experiment: experiment_search_aggregates_live.experiment
-    row: 68
-    col: 0
-    width: 12
-    height: 7
   - title: Enrollment Status
     name: Enrollment Status
     model: experimentation
@@ -921,7 +651,7 @@
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
-    series_types: {}
+    y_axes: []
     listen:
       Experiment: enrollment_status.experiment
     row: 0
@@ -954,7 +684,7 @@
         bold: false, italic: false, strikethrough: false, fields: !!null ''}]
     show_view_names: false
     defaults_version: 1
-    series_types: {}
+    y_axes: []
     listen:
       Experiment: sample_ratio_mismatch.experiment
     row: 2
@@ -987,7 +717,7 @@
         bold: false, italic: false, strikethrough: false, fields: !!null ''}]
     show_view_names: false
     defaults_version: 1
-    series_types: {}
+    y_axes: []
     listen:
       Experiment: sample_ratio_mismatch.experiment
     row: 2
@@ -1020,7 +750,7 @@
         bold: false, italic: false, strikethrough: false, fields: !!null ''}]
     show_view_names: false
     defaults_version: 1
-    series_types: {}
+    y_axes: []
     listen:
       Experiment: sample_ratio_mismatch.experiment
     row: 2
@@ -1067,8 +797,15 @@
       logs.log_level: ERROR
       logs.message: "-%Error while computing statistic%"
     limit: 500
-    dynamic_fields: [{category: measure, expression: '', label: Error Count, based_on: logs.timestamp_time,
-        _kind_hint: measure, measure: error_count, type: count_distinct, _type_hint: number}]
+    dynamic_fields:
+    - category: measure
+      expression: ''
+      label: Error Count
+      based_on: logs.timestamp_time
+      _kind_hint: measure
+      measure: error_count
+      type: count_distinct
+      _type_hint: number
     custom_color_enabled: true
     show_single_value_title: true
     show_comparison: false
@@ -1079,12 +816,129 @@
     conditional_formatting_include_totals: false
     conditional_formatting_include_nulls: false
     defaults_version: 1
+    y_axes: []
     listen:
       Experiment: logs.experiment
     row: 6
     col: 0
     width: 8
     height: 2
+  - title: Daily Enrollments by Branch
+    name: Daily Enrollments by Branch
+    model: experimentation
+    explore: experiment_enrollment_overall
+    type: looker_line
+    fields: [experiment_enrollment_overall.Total, experiment_enrollment_overall.branch,
+      experiment_enrollment_overall.time_date]
+    pivots: [experiment_enrollment_overall.branch]
+    fill_fields: [experiment_enrollment_overall.time_date]
+    filters:
+      experiment_enrollment_overall.timeframe: 28 days
+    sorts: [experiment_enrollment_overall.branch, experiment_enrollment_overall.time_date
+        desc]
+    limit: 5000
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: false
+    interpolation: step
+    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_enrollment_overall.Total,
+            id: experiment_enrollment_overall.Total, name: Total}], showLabels: true,
+        showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
+        type: linear}]
+    x_axis_label: Time [UTC]
+    x_axis_zoom: true
+    y_axis_zoom: true
+    hidden_series: [fission-disabled - experiment_enrollment_overall.Total]
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    defaults_version: 1
+    note_state: expanded
+    note_display: above
+    note_text: Updated daily
+    listen:
+      Experiment: experiment_enrollment_overall.experiment
+    row: 25
+    col: 12
+    width: 12
+    height: 7
+  - title: Daily Enrollments
+    name: Daily Enrollments
+    model: experimentation
+    explore: experiment_enrollment_overall
+    type: looker_column
+    fields: [experiment_enrollment_overall.Total, experiment_enrollment_overall.time_date]
+    fill_fields: [experiment_enrollment_overall.time_date]
+    filters:
+      experiment_enrollment_overall.timeframe: 28 days
+    sorts: [experiment_enrollment_overall.time_date desc]
+    limit: 5000
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_enrollment_overall.Total,
+            id: experiment_enrollment_overall.Total, name: Total}], showLabels: true,
+        showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
+        type: linear}]
+    x_axis_label: Time [UTC]
+    defaults_version: 1
+    note_state: expanded
+    note_display: above
+    note_text: Updated daily
+    listen:
+      Experiment: experiment_enrollment_overall.experiment
+    row: 25
+    col: 0
+    width: 12
+    height: 7
   filters:
   - name: Experiment
     title: Experiment
@@ -1095,13 +949,12 @@
     ui_config:
       type: dropdown_menu
       display: inline
-      options: []
     model: experimentation
     explore: experiment_enrollment_daily_active_population
     listens_to_filters: []
     field: experiment_enrollment_daily_active_population.experiment
-  - name: Time Range
-    title: Time Range
+  - name: Time Range [UTC]
+    title: Time Range [UTC]
     type: field_filter
     default_value: 28 day
     allow_multiple_values: true

--- a/experimentation/experimentation.model.lkml
+++ b/experimentation/experimentation.model.lkml
@@ -1,13 +1,9 @@
 connection: "telemetry"
 label: "Experimentation"
-include: "//looker-hub/experimentation/views/experiment_cumulative_ad_clicks.view.lkml"
-include: "//looker-hub/experimentation/views/experiment_cumulative_search_count.view.lkml"
-include: "//looker-hub/experimentation/views/experiment_cumulative_search_with_ads_count.view.lkml"
 include: "//looker-hub/experimentation/views/experiment_enrollment_cumulative_population_estimate.view.lkml"
 include: "//looker-hub/experimentation/views/experiment_enrollment_daily_active_population.view.lkml"
 include: "//looker-hub/experimentation/views/experiment_enrollment_other_events_overall.view.lkml"
 include: "//looker-hub/experimentation/views/experiment_enrollment_overall.view.lkml"
-include: "//looker-hub/experimentation/views/experiment_search_aggregates_live.view.lkml"
 include: "//looker-hub/experimentation/views/experiment_unenrollment_overall.view.lkml"
 include: "//looker-hub/experimentation/views/experimenter_experiments.view.lkml"
 include: "//looker-hub/experimentation/views/logs.view.lkml"
@@ -47,54 +43,6 @@ view: +experiment_enrollment_cumulative_population_estimate {
   measure: Total {
     type: number
     sql: SUM(${value});;
-  }
-
-  filter: timeframe {
-    type: date
-  }
-}
-
-view: +experiment_cumulative_ad_clicks {
-  dimension: experiment {
-    suggest_explore: experimenter_experiments
-    suggest_dimension: experimenter_experiments.normandy_slug
-  }
-
-  measure: Total {
-    type: number
-    sql: SUM(${value}) ;;
-  }
-
-  filter: timeframe {
-    type: date
-  }
-}
-
-view: +experiment_cumulative_search_count {
-  dimension: experiment {
-    suggest_explore: experimenter_experiments
-    suggest_dimension: experimenter_experiments.normandy_slug
-  }
-
-  measure: Total {
-    type: number
-    sql: SUM(${value}) ;;
-  }
-
-  filter: timeframe {
-    type: date
-  }
-}
-
-view: +experiment_cumulative_search_with_ads_count {
-  dimension: experiment {
-    suggest_explore: experimenter_experiments
-    suggest_dimension: experimenter_experiments.normandy_slug
-  }
-
-  measure: Total {
-    type: number
-    sql: SUM(${value}) ;;
   }
 
   filter: timeframe {
@@ -177,79 +125,9 @@ view: +experiment_unenrollment_overall {
   }
 }
 
-view: +experiment_search_aggregates_live {
-  dimension: experiment {
-    suggest_explore: experimenter_experiments
-    suggest_dimension: experimenter_experiments.normandy_slug
-  }
-
-  dimension: timestamp {
-    type: date_time
-    sql: CASE
-        WHEN DATE_DIFF(DATE({% date_end timeframe %}), DATE({% date_start timeframe %}), DAY) BETWEEN 5 AND 30 THEN TIMESTAMP_TRUNC(TIMESTAMP(${window_start_time}), HOUR)
-        WHEN DATE_DIFF(DATE({% date_end timeframe %}), DATE({% date_start timeframe %}), DAY) >= 30 THEN TIMESTAMP_TRUNC(TIMESTAMP(${window_start_time}), DAY)
-        ELSE TIMESTAMP(${window_start_time})
-      END;;
-  }
-
-  measure: total_search_count {
-    type: number
-    sql: SUM(${search_count}) ;;
-  }
-
-  measure: total_ad_clicks {
-    type: number
-    sql: SUM(${ad_clicks_count}) ;;
-  }
-
-  measure: total_searches_with_ads {
-    type: number
-    sql: SUM(${search_with_ads_count}) ;;
-  }
-
-  filter: timeframe {
-    type: date
-  }
-}
 
 
 # Explores
-
-explore: experiment_cumulative_ad_clicks {
-  hidden: yes
-  sql_always_where:
-        ${branch} IS NOT NULL AND
-    {% condition experiment_cumulative_ad_clicks.timeframe %} TIMESTAMP(${time_time}) {% endcondition %} AND
-    ((EXTRACT(MINUTE FROM TIMESTAMP(${time_time})) = 0 AND
-     DATE_DIFF(DATE({% date_end experiment_cumulative_ad_clicks.timeframe %}), DATE({% date_start experiment_cumulative_ad_clicks.timeframe %}), DAY) BETWEEN 5 AND 30) OR
-     (EXTRACT(HOUR FROM TIMESTAMP(${time_time})) = 0 AND EXTRACT(MINUTE FROM TIMESTAMP(${time_time})) = 0 AND
-     DATE_DIFF(DATE({% date_end experiment_cumulative_ad_clicks.timeframe %}), DATE({% date_start experiment_cumulative_ad_clicks.timeframe %}), DAY) >= 30) OR
-     DATE_DIFF(DATE({% date_end experiment_cumulative_ad_clicks.timeframe %}), DATE({% date_start experiment_cumulative_ad_clicks.timeframe %}), DAY) < 5) ;;
-}
-
-explore: experiment_cumulative_search_count {
-  hidden: yes
-  sql_always_where:
-  ${branch} IS NOT NULL AND
-  {% condition experiment_cumulative_search_count.timeframe %} TIMESTAMP(${time_time}) {% endcondition %} AND
-  ((EXTRACT(MINUTE FROM TIMESTAMP(${time_time})) = 0 AND
-  DATE_DIFF(DATE({% date_end experiment_cumulative_search_count.timeframe %}), DATE({% date_start experiment_cumulative_search_count.timeframe %}), DAY) BETWEEN 5 AND 30) OR
-  (EXTRACT(HOUR FROM TIMESTAMP(${time_time})) = 0 AND EXTRACT(MINUTE FROM TIMESTAMP(${time_time})) = 0 AND
-  DATE_DIFF(DATE({% date_end experiment_cumulative_search_count.timeframe %}), DATE({% date_start experiment_cumulative_search_count.timeframe %}), DAY) >= 30) OR
-  DATE_DIFF(DATE({% date_end experiment_cumulative_search_count.timeframe %}), DATE({% date_start experiment_cumulative_search_count.timeframe %}), DAY) < 5) ;;
-}
-
-explore: experiment_cumulative_search_with_ads_count {
-  hidden: yes
-  sql_always_where:
-  ${branch} IS NOT NULL AND
-  {% condition experiment_cumulative_search_with_ads_count.timeframe %} TIMESTAMP(${time_time}) {% endcondition %} AND
-  ((EXTRACT(MINUTE FROM TIMESTAMP(${time_time})) = 0 AND
-  DATE_DIFF(DATE({% date_end experiment_cumulative_search_with_ads_count.timeframe %}), DATE({% date_start experiment_cumulative_search_with_ads_count.timeframe %}), DAY) BETWEEN 5 AND 30) OR
-  (EXTRACT(HOUR FROM TIMESTAMP(${time_time})) = 0 AND EXTRACT(MINUTE FROM TIMESTAMP(${time_time})) = 0 AND
-  DATE_DIFF(DATE({% date_end experiment_cumulative_search_with_ads_count.timeframe %}), DATE({% date_start experiment_cumulative_search_with_ads_count.timeframe %}), DAY) >= 30) OR
-  DATE_DIFF(DATE({% date_end experiment_cumulative_search_with_ads_count.timeframe %}), DATE({% date_start experiment_cumulative_search_with_ads_count.timeframe %}), DAY) < 5) ;;
-}
 
 explore: experiment_enrollment_cumulative_population_estimate {
   hidden: yes
@@ -298,13 +176,6 @@ explore: experiment_unenrollment_overall {
     sql_on: ${experiment_unenrollment_overall.experiment} = ${experimenter_experiments.normandy_slug} ;;
     relationship: many_to_one
   }
-}
-
-explore: experiment_search_aggregates_live {
-  hidden: yes
-  sql_always_where:
-    ${branch} IS NOT NULL AND
-    {% condition experiment_search_aggregates_live.timeframe %} TIMESTAMP(${window_start_time}) {% endcondition %};;
 }
 
 explore: experiment_enrollment_daily_active_population {


### PR DESCRIPTION
The experiment search monitoring related views are no longer needed as stakeholders generally don't check them (too spiky and inaccurate). So this PR removes them from Looker. 
The underlying tables and views will get deprecated in some follow-up PRs

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
