### PR TITLE
Fix crash rate number of result rows

### DIFF
--- a/experimentation/dashboards/experiment_enrollments.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments.dashboard.lookml
@@ -949,7 +949,7 @@
     filters: {}
     sorts: [experiment_crash_rates.branch, experiment_crash_rates.window_start_time
         desc]
-    limit: 500
+    limit: 5000
     column_limit: 50
     dynamic_fields:
     - _kind_hint: measure
@@ -1015,7 +1015,7 @@
     filters: {}
     sorts: [experiment_crash_rates.crash_process_type, experiment_crash_rates.window_start_time
         desc]
-    limit: 500
+    limit: 5000
     column_limit: 50
     dynamic_fields:
     - _kind_hint: measure
@@ -1090,7 +1090,7 @@
     fields: [sum_of_crash_count, experiment_crash_rates.window_start_time]
     filters: {}
     sorts: [experiment_crash_rates.window_start_time desc]
-    limit: 500
+    limit: 5000
     column_limit: 50
     dynamic_fields:
     - _kind_hint: measure


### PR DESCRIPTION
Increase result row limit for crash rate tiles on experimentation enrollment dashboard

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
