### PR TITLE
Fix DAU views used in Feature Metrics dashboard

### DIFF
--- a/fenix/views/fenix_dau.view.lkml
+++ b/fenix/views/fenix_dau.view.lkml
@@ -3,9 +3,10 @@ view: fenix_dau {
     sql:
       SELECT
         submission_date,
-        SUM(dau),
+        SUM(dau) as dau,
       FROM `moz-fx-data-shared-prod.fenix.active_users_aggregates`
       WHERE submission_date >= "2022-01-01"
+      AND app_name = 'Fenix'
       GROUP BY submission_date ;;
   }
 

--- a/firefox_ios/views/firefox_ios_dau.view.lkml
+++ b/firefox_ios/views/firefox_ios_dau.view.lkml
@@ -6,7 +6,7 @@ view: firefox_ios_dau {
       SELECT
         submission_date,
         SUM(dau) AS dau
-      FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
+      FROM `moz-fx-data-shared-prod.firefox_ios.active_users_aggregates`
       WHERE app_name = 'Firefox iOS'
       GROUP BY 1 ;;}
 

--- a/firefox_ios/views/firefox_ios_dau.view.lkml
+++ b/firefox_ios/views/firefox_ios_dau.view.lkml
@@ -8,7 +8,7 @@ view: firefox_ios_dau {
         SUM(dau) AS dau
       FROM `moz-fx-data-shared-prod.firefox_ios.active_users_aggregates`
       WHERE app_name = 'Firefox iOS'
-      GROUP BY 1 ;;}
+      GROUP BY submission_date ;;}
 
   dimension_group: submission {
     type: time


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
