### PR TITLE
Add experiment search views, explores, dashboards back

### DIFF
--- a/experimentation/dashboards/experiment_enrollments.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments.dashboard.lookml
@@ -52,8 +52,8 @@
     note_display: above
     note_text: Updated daily
     listen:
-      Experiment: experiment_enrollment_daily_active_population.experiment
       Time Range [UTC]: experiment_enrollment_daily_active_population.time_time
+      Experiment: experiment_enrollment_daily_active_population.experiment
     row: 10
     col: 12
     width: 12
@@ -99,8 +99,8 @@
     note_display: above
     note_text: Updated daily
     listen:
-      Experiment: experiment_enrollment_daily_active_population.experiment
       Time Range [UTC]: experiment_enrollment_daily_active_population.time_time
+      Experiment: experiment_enrollment_daily_active_population.experiment
     row: 10
     col: 0
     width: 12
@@ -146,8 +146,8 @@
     note_display: above
     note_text: Updated every 10 minutes
     listen:
-      Experiment: experiment_enrollment_cumulative_population_estimate.experiment
       Time Range [UTC]: experiment_enrollment_cumulative_population_estimate.timeframe
+      Experiment: experiment_enrollment_cumulative_population_estimate.experiment
     row: 18
     col: 0
     width: 12
@@ -200,8 +200,8 @@
     note_display: above
     note_text: Updated every 10 minutes
     listen:
-      Experiment: experiment_enrollment_cumulative_population_estimate.experiment
       Time Range [UTC]: experiment_enrollment_cumulative_population_estimate.timeframe
+      Experiment: experiment_enrollment_cumulative_population_estimate.experiment
     row: 18
     col: 12
     width: 12
@@ -252,8 +252,8 @@
     note_display: above
     note_text: Updated every 10 minutes
     listen:
-      Experiment: experiment_unenrollment_overall.experiment
       Time Range [UTC]: experiment_unenrollment_overall.timeframe
+      Experiment: experiment_unenrollment_overall.experiment
     row: 39
     col: 0
     width: 12
@@ -314,8 +314,8 @@
     note_display: above
     note_text: Updated every 10 minutes
     listen:
-      Experiment: experiment_unenrollment_overall.experiment
       Time Range [UTC]: experiment_unenrollment_overall.timeframe
+      Experiment: experiment_unenrollment_overall.experiment
     row: 39
     col: 12
     width: 12
@@ -367,8 +367,8 @@
     note_display: above
     note_text: Updated every 10 minutes
     listen:
-      Experiment: experiment_enrollment_overall.experiment
       Time Range [UTC]: experiment_enrollment_overall.timeframe
+      Experiment: experiment_enrollment_overall.experiment
     row: 32
     col: 0
     width: 12
@@ -425,8 +425,8 @@
     note_display: above
     note_text: Updated every 10 minutes
     listen:
-      Experiment: experiment_enrollment_overall.experiment
       Time Range [UTC]: experiment_enrollment_overall.timeframe
+      Experiment: experiment_enrollment_overall.experiment
     row: 32
     col: 12
     width: 12
@@ -477,8 +477,8 @@
     note_display: above
     note_text: Updated every 10 minutes
     listen:
-      Experiment: experiment_enrollment_other_events_overall.experiment
       Time Range [UTC]: experiment_enrollment_other_events_overall.timeframe
+      Experiment: experiment_enrollment_other_events_overall.experiment
     row: 46
     col: 0
     width: 12
@@ -539,8 +539,8 @@
     note_display: above
     note_text: Updated every 10 minutes
     listen:
-      Experiment: experiment_enrollment_other_events_overall.experiment
       Time Range [UTC]: experiment_enrollment_other_events_overall.timeframe
+      Experiment: experiment_enrollment_other_events_overall.experiment
     row: 46
     col: 12
     width: 12
@@ -599,8 +599,8 @@
     defaults_version: 1
     y_axes: []
     listen:
-      Experiment: events.event_string_value
       Time Range [UTC]: events.submission_date
+      Experiment: events.event_string_value
     row: 53
     col: 0
     width: 24
@@ -999,9 +999,9 @@
     interpolation: linear
     defaults_version: 1
     listen:
-      Experiment: experiment_crash_rates.experiment
       Time Range [UTC]: experiment_crash_rates.window_start_date
-    row: 61
+      Experiment: experiment_crash_rates.experiment
+    row: 84
     col: 12
     width: 12
     height: 7
@@ -1066,9 +1066,9 @@
     show_silhouette: false
     totals_color: "#808080"
     listen:
-      Experiment: experiment_crash_rates.experiment
       Time Range [UTC]: experiment_crash_rates.window_start_date
-    row: 68
+      Experiment: experiment_crash_rates.experiment
+    row: 91
     col: 0
     width: 12
     height: 7
@@ -1078,7 +1078,7 @@
     subtitle_text: ''
     body_text: '[{"type":"h1","children":[{"text":"Crash Counts"}],"align":"center"}]'
     rich_content_json: '{"format":"slate"}'
-    row: 59
+    row: 82
     col: 0
     width: 24
     height: 2
@@ -1139,10 +1139,332 @@
     interpolation: linear
     defaults_version: 1
     listen:
-      Experiment: experiment_crash_rates.experiment
       Time Range [UTC]: experiment_crash_rates.window_start_date
+      Experiment: experiment_crash_rates.experiment
+    row: 84
+    col: 0
+    width: 12
+    height: 7
+  - name: " (3)"
+    type: text
+    title_text: ''
+    subtitle_text: ''
+    body_text: '[{"type":"h1","children":[{"text":"Search Metrics"}],"align":"center"}]'
+    rich_content_json: '{"format":"slate"}'
+    row: 59
+    col: 0
+    width: 24
+    height: 2
+  - title: Search Count by Branch
+    name: Search Count by Branch
+    model: experimentation
+    explore: experiment_search_aggregates_live
+    type: looker_line
+    fields: [experiment_search_aggregates_live.timestamp, experiment_search_aggregates_live.total_search_count,
+      experiment_search_aggregates_live.branch]
+    pivots: [experiment_search_aggregates_live.branch]
+    filters: {}
+    sorts: [experiment_search_aggregates_live.timestamp desc, experiment_search_aggregates_live.branch]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: step
+    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_search_aggregates_live.total_search_count,
+            id: experiment_search_aggregates_live.total_search_count, name: Total
+              Search Count}], showLabels: true, showValues: true, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}]
+    x_axis_label: Time [UTC]
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    defaults_version: 1
+    listen:
+      Time Range [UTC]: experiment_search_aggregates_live.timeframe
+      Experiment: experiment_search_aggregates_live.experiment
     row: 61
     col: 0
+    width: 12
+    height: 7
+  - title: Ad Clicks by Branch
+    name: Ad Clicks by Branch
+    model: experimentation
+    explore: experiment_search_aggregates_live
+    type: looker_line
+    fields: [experiment_search_aggregates_live.timestamp, experiment_search_aggregates_live.branch,
+      experiment_search_aggregates_live.total_ad_clicks]
+    pivots: [experiment_search_aggregates_live.branch]
+    filters: {}
+    sorts: [experiment_search_aggregates_live.timestamp desc, experiment_search_aggregates_live.branch]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: step
+    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_search_aggregates_live.total_search_count,
+            id: experiment_search_aggregates_live.total_search_count, name: Total
+              Search Count}], showLabels: true, showValues: true, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}]
+    x_axis_label: Time [UTC]
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    defaults_version: 1
+    listen:
+      Time Range [UTC]: experiment_search_aggregates_live.timeframe
+      Experiment: experiment_search_aggregates_live.experiment
+    row: 68
+    col: 0
+    width: 12
+    height: 7
+  - title: Search Count with Ads by Branch
+    name: Search Count with Ads by Branch
+    model: experimentation
+    explore: experiment_search_aggregates_live
+    type: looker_line
+    fields: [experiment_search_aggregates_live.timestamp, experiment_search_aggregates_live.branch,
+      experiment_search_aggregates_live.total_searches_with_ads]
+    pivots: [experiment_search_aggregates_live.branch]
+    filters: {}
+    sorts: [experiment_search_aggregates_live.branch, experiment_search_aggregates_live.timestamp
+        desc]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: step
+    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_search_aggregates_live.total_search_count,
+            id: experiment_search_aggregates_live.total_search_count, name: Total
+              Search Count}], showLabels: true, showValues: true, unpinAxis: false,
+        tickDensity: default, tickDensityCustom: 5, type: linear}]
+    x_axis_label: Time [UTC]
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    defaults_version: 1
+    listen:
+      Time Range [UTC]: experiment_search_aggregates_live.timeframe
+      Experiment: experiment_search_aggregates_live.experiment
+    row: 75
+    col: 0
+    width: 12
+    height: 7
+  - title: Cumulative Search Count by Branch
+    name: Cumulative Search Count by Branch
+    model: experimentation
+    explore: experiment_cumulative_search_count
+    type: looker_line
+    fields: [experiment_cumulative_search_count.Total, experiment_cumulative_search_count.branch,
+      experiment_cumulative_search_count.time_time]
+    pivots: [experiment_cumulative_search_count.branch]
+    filters: {}
+    sorts: [experiment_cumulative_search_count.time_time desc, experiment_cumulative_search_count.branch]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: false
+    interpolation: linear
+    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_cumulative_search_count.Total,
+            id: debugging-disabled - experiment_cumulative_search_count.Total, name: debugging-disabled},
+          {axisId: experiment_cumulative_search_count.Total, id: debugging-enabled
+              - experiment_cumulative_search_count.Total, name: debugging-enabled}],
+        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    x_axis_label: Time [UTC]
+    defaults_version: 1
+    listen:
+      Time Range [UTC]: experiment_cumulative_search_count.timeframe
+      Experiment: experiment_cumulative_search_count.experiment
+    row: 61
+    col: 12
+    width: 12
+    height: 7
+  - title: Cumulative Ad Clicks by Branch
+    name: Cumulative Ad Clicks by Branch
+    model: experimentation
+    explore: experiment_cumulative_ad_clicks
+    type: looker_line
+    fields: [experiment_cumulative_ad_clicks.Total, experiment_cumulative_ad_clicks.time_time,
+      experiment_cumulative_ad_clicks.branch]
+    pivots: [experiment_cumulative_ad_clicks.branch]
+    filters: {}
+    sorts: [experiment_cumulative_ad_clicks.time_time desc, experiment_cumulative_ad_clicks.branch]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: false
+    interpolation: linear
+    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_cumulative_ad_clicks.Total,
+            id: variant - experiment_cumulative_ad_clicks.Total, name: variant}],
+        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    x_axis_label: Time [UTC]
+    defaults_version: 1
+    listen:
+      Time Range [UTC]: experiment_cumulative_ad_clicks.timeframe
+      Experiment: experiment_cumulative_ad_clicks.experiment
+    row: 68
+    col: 12
+    width: 12
+    height: 7
+  - title: Cumulative Seach Count with Ads by Branch
+    name: Cumulative Seach Count with Ads by Branch
+    model: experimentation
+    explore: experiment_cumulative_search_with_ads_count
+    type: looker_line
+    fields: [experiment_cumulative_search_with_ads_count.Total, experiment_cumulative_search_with_ads_count.branch,
+      experiment_cumulative_search_with_ads_count.time_time]
+    pivots: [experiment_cumulative_search_with_ads_count.branch]
+    filters: {}
+    sorts: [experiment_cumulative_search_with_ads_count.time_time desc, experiment_cumulative_search_with_ads_count.branch]
+    limit: 500
+    column_limit: 50
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: false
+    interpolation: linear
+    y_axes: [{label: Total, orientation: left, series: [{axisId: experiment_cumulative_search_with_ads_count.Total,
+            id: only-branch - experiment_cumulative_search_with_ads_count.Total, name: only-branch}],
+        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    x_axis_label: Time [UTC]
+    defaults_version: 1
+    listen:
+      Time Range [UTC]: experiment_cumulative_search_with_ads_count.timeframe
+      Experiment: experiment_cumulative_search_with_ads_count.experiment
+    row: 75
+    col: 12
     width: 12
     height: 7
   filters:


### PR DESCRIPTION
Reverts https://github.com/mozilla/looker-spoke-default/pull/989

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
