### PR TITLE
feat: approximate unenrollment reason counts

### DIFF
--- a/experimentation/dashboards/experiment_enrollments.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments.dashboard.lookml
@@ -554,6 +554,15 @@
     filters:
       events.sample_id: '0'
     sorts: [events.event_count desc]
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${events.event_count} * 100"
+      label: approx count
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: approx_count
+      _type_hint: number
     limit: 500
     column_limit: 50
     show_view_names: false
@@ -600,7 +609,7 @@
     y_axes: []
     note_state: expanded
     note_display: above
-    note_text: Event counts represent a 1% sample.
+    note_text: Event counts are **approximate** due to sampling (1% sample * 100).
     listen:
       Time Range [UTC]: events.submission_date
       Experiment: events.event_string_value


### PR DESCRIPTION
The current unenrollment event counts are sampled at 1%. Instead of a note about this we should approximate the actual counts by multiplying them by 100 and clarifying this in a note.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
