### PR TITLE
Update fxci explore + dashboard for new task tags schema

### DIFF
--- a/fxci/dashboards/tasks_overview.dashboard.lookml
+++ b/fxci/dashboards/tasks_overview.dashboard.lookml
@@ -1,6 +1,6 @@
 ---
-- dashboard: tasks_overview
-  title: Tasks Overview
+- dashboard: fxci_tasks_overview
+  title: Firefox-CI Tasks Overview
   layout: newspaper
   preferred_viewer: dashboards-next
   description: ''

--- a/fxci/dashboards/tasks_overview.dashboard.lookml
+++ b/fxci/dashboards/tasks_overview.dashboard.lookml
@@ -1,6 +1,6 @@
 ---
-- dashboard: fxci_tasks_overview
-  title: Firefox-CI Tasks Overview
+- dashboard: tasks_overview
+  title: Tasks Overview
   layout: newspaper
   preferred_viewer: dashboards-next
   description: ''
@@ -120,9 +120,8 @@
     model: fxci
     explore: tasks
     type: looker_grid
-    fields: [num_tasks, tasks__tags.value]
+    fields: [num_tasks, tasks.tags__trust_domain]
     filters:
-      tasks__tags.key: trust-domain
       tasks.submission_date: 6 months
     sorts: [num_tasks desc 0]
     limit: 500
@@ -193,10 +192,9 @@
     model: fxci
     explore: tasks
     type: looker_grid
-    fields: [num_tasks, tasks__tags.value]
+    fields: [num_tasks, tasks.tags__trust_domain, tasks.tags__kind]
     filters:
       tasks.submission_date: 6 months
-      tasks__tags.key: kind
     sorts: [num_tasks desc 0]
     limit: 500
     column_limit: 50
@@ -348,10 +346,9 @@
     model: fxci
     explore: tasks
     type: looker_grid
-    fields: [tasks__tags.value, sum_of_run_cost]
+    fields: [tasks.tags__trust_domain, tasks.tags__kind, sum_of_run_cost]
     filters:
       tasks.submission_date: 6 months
-      tasks__tags.key: kind
       task_run_costs.submission_date: 6 months
     limit: 500
     column_limit: 50
@@ -419,9 +416,8 @@
     model: fxci
     explore: tasks
     type: looker_grid
-    fields: [tasks__tags.value, sum_of_run_cost]
+    fields: [sum_of_run_cost, tasks.tags__trust_domain]
     filters:
-      tasks__tags.key: trust-domain
       tasks.submission_date: 6 months
       task_run_costs.submission_date: 6 months
     sorts: [sum_of_run_cost desc 0]

--- a/fxci/explores/tasks.explore.lkml
+++ b/fxci/explores/tasks.explore.lkml
@@ -13,11 +13,6 @@ explore:  tasks {
     sql_on: ${task_runs.task_id} = ${tasks.task_id};;
   }
 
-  join: tasks__tags {
-    relationship: many_to_many
-    sql: LEFT JOIN UNNEST(${tasks.tags}) AS tasks__tags ;;
-  }
-
   join: task_run_costs {
     type: inner
     relationship: one_to_one

--- a/fxci/views/tasks.view.lkml
+++ b/fxci/views/tasks.view.lkml
@@ -3,7 +3,3 @@ include: "//looker-hub/fxci/views/tasks_base.view.lkml"
 view: tasks {
   extends: [tasks_base]
 }
-
-view: tasks__tags {
-  extends: [tasks_base__tags]
-}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
