### PR TITLE
New view & explore for Fx desktop baseline_active_users_aggregates

### DIFF
--- a/combined_browser_metrics/explores/firefox_desktop_baseline_active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/firefox_desktop_baseline_active_users_aggregates.explore.lkml
@@ -1,0 +1,12 @@
+include: "../views/firefox_desktop_baseline_active_users_aggregates.view.lkml"
+include: "/shared/views/countries.view.lkml"
+
+explore: firefox_desktop_baseline_active_users_aggregates {
+  view_name: firefox_desktop_baseline_active_users_aggregates
+  
+  join: countries {
+    type: left_outer
+    relationship: one_to_one
+    sql_on: ${firefox_desktop_baseline_active_users_aggregates.country} = ${countries.code} ;;
+  }
+}

--- a/combined_browser_metrics/views/firefox_desktop_baseline_active_users_aggregates.view.lkml
+++ b/combined_browser_metrics/views/firefox_desktop_baseline_active_users_aggregates.view.lkml
@@ -1,0 +1,69 @@
+include: "//looker-hub/combined_browser_metrics/views/firefox_desktop_baseline_active_users_aggregates.view.lkml"
+
+
+view: +firefox_desktop_baseline_active_users_aggregates {
+
+  # Group OS dimensions in Explore
+  dimension: os {
+    sql: ${TABLE}.os ;;
+    group_label: "OS"
+  }
+  dimension: os_version {
+    sql: ${TABLE}.os_version ;;
+    group_label: "OS"
+  }
+  dimension: os_version_major {
+    sql: ${TABLE}.os_version_major ;;
+    group_label: "OS"
+  }
+  dimension: os_version_minor {
+    sql: ${TABLE}.os_version_minor ;;
+    group_label: "OS"
+  }
+  dimension: windows_build_number {
+    sql: ${TABLE}.windows_build_number ;;
+    group_label: "OS"
+  }
+
+  # Group app version dimensions in Explore
+  dimension: app_version {
+    sql: ${TABLE}.app_version ;;
+    group_label: "App Version"
+  }
+
+  dimension: app_version_major {
+    sql: ${TABLE}.app_version_major ;;
+    group_label: "App Version"
+  }
+
+  dimension: app_version_minor {
+    sql: ${TABLE}.app_version_minor ;;
+    group_label: "App Version"
+  }
+
+  dimension: app_version_patch_revision {
+    sql: ${TABLE}.app_version_patch_revision ;;
+    group_label: "App Version"
+  }
+
+  dimension: app_version_is_major_release {
+    sql: ${TABLE}.app_version_is_major_release ;;
+    group_label: "App Version"
+  }
+
+  # Group location data
+  dimension: country {
+    sql: ${TABLE}.country ;;
+    group_label: "Location"
+  }
+  dimension: city {
+    sql: ${TABLE}.city ;;
+    group_label: "Location"
+  }
+  dimension: locale {
+    sql: ${TABLE}.locale ;;
+    group_label: "Location"
+  }
+
+
+}

--- a/combined_browser_metrics/views/firefox_desktop_baseline_active_users_aggregates.view.lkml
+++ b/combined_browser_metrics/views/firefox_desktop_baseline_active_users_aggregates.view.lkml
@@ -3,6 +3,28 @@ include: "//looker-hub/combined_browser_metrics/views/firefox_desktop_baseline_a
 
 view: +firefox_desktop_baseline_active_users_aggregates {
 
+  #Hide is_default browser since always NULL
+  dimension: is_default_browser {
+    hidden: yes
+    sql: ${TABLE}.is_default_browser ;;
+  }
+
+  # Hide metric columns showing as dimensions
+  dimension: mau {
+    hidden: yes
+    sql: ${TABLE}.mau ;;
+  }
+
+  dimension: dau {
+    hidden: yes
+    sql: ${TABLE}.dau ;;
+  }
+
+  dimension: wau {
+    hidden: yes
+    sql: ${TABLE}.wau ;;
+  }
+
   # Group OS dimensions in Explore
   dimension: os {
     sql: ${TABLE}.os ;;
@@ -65,5 +87,23 @@ view: +firefox_desktop_baseline_active_users_aggregates {
     group_label: "Location"
   }
 
+  # Define measures for DAU, MAU, wau
+  measure: daily_active_users {
+    label: "DAU"
+    type:  sum
+    sql: (${TABLE}.dau) ;;
+  }
+
+  measure: weekly_active_users {
+    label: "WAU"
+    type: sum
+    sql:  ${TABLE}.wau ;;
+  }
+
+  measure: monthly_active_users {
+    label: "MAU"
+    type: sum
+    sql:  ${TABLE}.mau ;;
+  }
 
 }


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
