### PR TITLE
feat(fxci): Add worker data to the tasks explore

### DIFF
--- a/fxci/explores/tasks.explore.lkml
+++ b/fxci/explores/tasks.explore.lkml
@@ -1,6 +1,7 @@
 include: "../views/tasks.view.lkml"
 include: "../views/task_runs.view.lkml"
 include: "../views/task_run_costs.view.lkml"
+include: "../views/workers.view.lkml"
 
 explore:  tasks {
   label: "Firefox-CI Tasks"
@@ -14,8 +15,14 @@ explore:  tasks {
   }
 
   join: task_run_costs {
-    type: inner
+    type: left_outer
     relationship: one_to_one
     sql_on: ${task_runs.key} = ${task_run_costs.key};;
+  }
+
+  join: workers {
+    type: left_outer
+    relationship: one_to_one
+    sql_on:  ${task_runs.worker_group} = ${workers.zone} AND ${task_runs.worker_id} = ${workers.instance_id};;
   }
 }

--- a/fxci/views/workers.view.lkml
+++ b/fxci/views/workers.view.lkml
@@ -1,0 +1,75 @@
+view: workers {
+  derived_table: {
+    sql:
+      WITH metrics AS (
+        SELECT
+          project,
+          zone,
+          instance_id,
+          SUM(uptime) AS uptime
+        FROM `moz-fx-data-shared-prod.fxci.worker_metrics`
+        WHERE submission_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)
+        GROUP BY
+          project,
+          zone,
+          instance_id
+      ),
+      costs AS (
+        SELECT
+          project,
+          zone,
+          instance_id,
+          SUM(total_cost) AS total_cost
+        FROM `moz-fx-data-shared-prod.fxci.worker_costs`
+        WHERE usage_start_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 1 YEAR)
+        GROUP BY
+          project,
+          zone,
+          instance_id
+      )
+      SELECT
+        metrics.project AS project,
+        metrics.zone AS zone,
+        metrics.instance_id AS instance_id,
+        metrics.uptime AS uptime,
+        costs.total_cost AS cost
+      FROM
+        metrics
+      INNER JOIN
+        costs
+        ON metrics.project = costs.project
+        AND metrics.zone = costs.zone
+        AND metrics.instance_id = costs.instance_id
+      ;;
+    persist_for:  "24 hours"
+  }
+
+  dimension: key {
+    sql: CONCAT(${TABLE}.project, '-', ${TABLE}.zone, '-', ${TABLE}.instance_id) ;;
+  }
+
+  dimension: project {
+    type:  string
+    sql:  ${TABLE}.project ;;
+  }
+
+  dimension: zone {
+    type:  string
+    sql:  ${TABLE}.zone ;;
+  }
+
+  dimension: instance_id {
+    type:  string
+    sql:  ${TABLE}.instance_id ;;
+  }
+
+  dimension: uptime {
+    type: number
+    sql:  ${TABLE}.uptime ;;
+  }
+
+  dimension: cost {
+    type: number
+    sql:  ${TABLE}.cost ;;
+  }
+}


### PR DESCRIPTION
I'd appreciate a bit of validation in the review here, as I'm not 100% sure this is correct.

I have worker (aka cloud VM instance) data coming in from GCP. Because these VMs can be long lived (sometimes weeks), the data comes in as a timeseries. So both the underlying tables (worker_metrics and worker_costs) contain multiple records for each worker.

However, in Looker I want there to be a single record per worker that contains a somewhat accurate reflection of the worker's latest costs / metrics. I *think* this is a good use case for a PDT. So I believe this is what this PR is doing.

Please let me know if there's a better way to accomplish this, or if I'm mistaken in what the implementation is accomplishing!


Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
