### PR TITLE
Add view and explore for newtab_interactions_hourly_v1 table

### DIFF
--- a/firefox_desktop/explores/newtab_interactions_hourly_v1.explore.lkml
+++ b/firefox_desktop/explores/newtab_interactions_hourly_v1.explore.lkml
@@ -1,0 +1,6 @@
+include: "../views/newtab_interactions_hourly_v1.view.lkml"
+
+explore: newtab_interactions_hourly_v1 {
+  label: "New Tab Interactions (Merino, Glean, and Some Legacy Contribution)"
+
+}

--- a/firefox_desktop/views/newtab_interactions_hourly_v1.view.lkml
+++ b/firefox_desktop/views/newtab_interactions_hourly_v1.view.lkml
@@ -1,0 +1,49 @@
+view: newtab_interactions_hourly_v1 {
+  sql_table_name: `moz-fx-data-shared-prod.telemetry_derived.newtab_interactions_hourly_v1` ;;
+
+  dimension: click_count {
+    type: number
+    description: "The number of clicks on this piece of content on this day in this position."
+    sql: ${TABLE}.click_count ;;
+  }
+  dimension: dismiss_count {
+    type: number
+    description: "The number of dismisses of this piece of content on this day in this position via the \"...\" menu on the tile."
+    sql: ${TABLE}.dismiss_count ;;
+  }
+  dimension: impression_count {
+    type: number
+    description: "The number of impressions of this piece of content on this day in this position."
+    sql: ${TABLE}.impression_count ;;
+  }
+  dimension: position {
+    type: number
+    description: "0-indexed position of the content in the grid of content."
+    sql: ${TABLE}.position ;;
+  }
+  dimension: recommendation_id {
+    type: string
+    sql: ${TABLE}.recommendation_id ;;
+  }
+  dimension: save_count {
+    type: number
+    description: "The number of saves of this piece of content on this day in this position via the \"...\" menu on the tile."
+    sql: ${TABLE}.save_count ;;
+  }
+  dimension_group: submission {
+    type: time
+    description: "Client-side date in Firefox for when the indicated engagement happened."
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.submission_date ;;
+  }
+  dimension: tile_id {
+    type: number
+    description: "A content identifier specific to the Firefox Newtab. May not uniquely identify the same piece of content if it is run multiple times."
+    sql: ${TABLE}.tile_id ;;
+  }
+  measure: count {
+    type: count
+  }
+}


### PR DESCRIPTION
### We are adding an explore for this to make a Newtab Engagement dashboard in Looker.

We have one in Mode, but we're porting it over here, in accordance with [JIRA TICKET #8082](https://mozilla-hub.atlassian.net/browse/DENG-8082)

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
