### PR TITLE
fix: update daily enrollments charts to use dashboard date filter

### DIFF
--- a/experimentation/dashboards/experiment_enrollments.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments.dashboard.lookml
@@ -557,7 +557,7 @@
     dynamic_fields:
     - category: table_calculation
       expression: "${events.event_count} * 100"
-      label: Adjusted Event Count
+      label: Approximate Event Count
       value_format:
       value_format_name:
       _kind_hint: measure

--- a/experimentation/dashboards/experiment_enrollments.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments.dashboard.lookml
@@ -557,7 +557,7 @@
     dynamic_fields:
     - category: table_calculation
       expression: "${events.event_count} * 100"
-      label: approx count
+      label: Adjusted Event Count
       value_format:
       value_format_name:
       _kind_hint: measure
@@ -609,7 +609,7 @@
     y_axes: []
     note_state: expanded
     note_display: above
-    note_text: Event counts are **approximate** due to sampling (1% sample * 100).
+    note_text: Event counts are *approximate* due to sampling (1% sample).
     listen:
       Time Range [UTC]: events.submission_date
       Experiment: events.event_string_value
@@ -844,8 +844,7 @@
       experiment_enrollment_overall.time_date]
     pivots: [experiment_enrollment_overall.branch]
     fill_fields: [experiment_enrollment_overall.time_date]
-    filters:
-      experiment_enrollment_overall.timeframe: 28 days
+    filters: {}
     sorts: [experiment_enrollment_overall.branch, experiment_enrollment_overall.time_date
         desc]
     limit: 5000
@@ -892,6 +891,7 @@
     note_display: above
     note_text: Updated daily
     listen:
+      Time Range [UTC]: experiment_enrollment_overall.timeframe
       Experiment: experiment_enrollment_overall.experiment
     row: 25
     col: 12
@@ -904,8 +904,7 @@
     type: looker_column
     fields: [experiment_enrollment_overall.Total, experiment_enrollment_overall.time_date]
     fill_fields: [experiment_enrollment_overall.time_date]
-    filters:
-      experiment_enrollment_overall.timeframe: 28 days
+    filters: {}
     sorts: [experiment_enrollment_overall.time_date desc]
     limit: 5000
     column_limit: 50
@@ -946,6 +945,7 @@
     note_display: above
     note_text: Updated daily
     listen:
+      Time Range [UTC]: experiment_enrollment_overall.timeframe
       Experiment: experiment_enrollment_overall.experiment
     row: 25
     col: 0


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
