### PR TITLE
Add SubPlat service subscriptions explores (DS-3083)

### DIFF
--- a/subscription_platform/explores/daily_active_service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_service_subscriptions.explore.lkml
@@ -1,0 +1,71 @@
+include: "../views/daily_active_service_subscriptions.view.lkml"
+include: "../views/service_subscriptions.view.lkml"
+include: "../views/table_metadata.view.lkml"
+include: "/shared/views/countries.view.lkml"
+include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
+
+explore: daily_active_service_subscriptions {
+  join: countries {
+    sql_on: ${daily_active_service_subscriptions.subscription__country_code} = ${countries.code} ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+
+  join: current_subscription_state {
+    from: service_subscriptions
+    sql_on: ${daily_active_service_subscriptions.subscription__id} = ${current_subscription_state.id} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      is_trial,
+      is_active,
+      auto_renew,
+      has_refunds,
+      has_fraudulent_charges
+    ]
+  }
+
+  join: subscription_other_services {
+    from: daily_active_service_subscriptions__subscription__other_services
+    # This should use a dimension reference, but Looker currently has a problem resolving dimension references in `sql_table_name`.
+    sql_table_name: UNNEST(daily_active_service_subscriptions.subscription.other_services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: table_metadata {
+    sql_on: ${table_metadata.table_name} = 'daily_active_service_subscriptions_v1' ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+
+  join: vat_rates {
+    view_label: "VAT Rates"
+    sql_on:
+      ${daily_active_service_subscriptions.subscription__country_code} = ${vat_rates.country_code}
+      AND (
+        ${daily_active_service_subscriptions.date_raw} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
+        OR (${daily_active_service_subscriptions.date_raw} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
+      ) ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      vat
+    ]
+  }
+
+  join: exchange_rates_table {
+    view_label: "Exchange Rates"
+    sql_on:
+      ${daily_active_service_subscriptions.subscription__plan_currency} = ${exchange_rates_table.base_currency}
+      AND ${exchange_rates_table.quote_currency} = 'USD'
+      AND ${daily_active_service_subscriptions.date_raw} = ${exchange_rates_table.date_raw} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      price
+    ]
+  }
+}

--- a/subscription_platform/explores/monthly_active_service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_service_subscriptions.explore.lkml
@@ -1,0 +1,86 @@
+include: "../views/monthly_active_service_subscriptions.view.lkml"
+include: "../views/service_subscriptions.view.lkml"
+include: "../views/table_metadata.view.lkml"
+include: "/shared/views/countries.view.lkml"
+include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
+
+explore: monthly_active_service_subscriptions {
+  join: countries {
+    sql_on: ${monthly_active_service_subscriptions.subscription__country_code} = ${countries.code} ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+
+  join: current_subscription_state {
+    from: service_subscriptions
+    sql_on: ${monthly_active_service_subscriptions.subscription__id} = ${current_subscription_state.id} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      is_trial,
+      is_active,
+      auto_renew,
+      has_refunds,
+      has_fraudulent_charges
+    ]
+  }
+
+  join: next_month_still_active_subscriptions {
+    from: monthly_active_service_subscriptions
+    sql_on:
+      ${monthly_active_service_subscriptions.subscription__id} = ${next_month_still_active_subscriptions.subscription__id}
+      AND DATE_ADD(${monthly_active_service_subscriptions.month_start_date}, INTERVAL 1 MONTH) = ${next_month_still_active_subscriptions.month_start_date} ;;
+    type: left_outer
+    relationship: one_to_one
+    fields: [
+      service_subscription_count,
+      logical_subscription_count,
+      provider_subscription_count,
+      customer_count
+    ]
+  }
+
+  join: subscription_other_services {
+    from: monthly_active_service_subscriptions__subscription__other_services
+    # This should use a dimension reference, but Looker currently has a problem resolving dimension references in `sql_table_name`.
+    sql_table_name: UNNEST(monthly_active_service_subscriptions.subscription.other_services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: table_metadata {
+    sql_on: ${table_metadata.table_name} = 'monthly_active_service_subscriptions_v1' ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+
+  join: vat_rates {
+    view_label: "VAT Rates"
+    sql_on:
+      ${monthly_active_service_subscriptions.subscription__country_code} = ${vat_rates.country_code}
+      AND (
+        ${monthly_active_service_subscriptions.effective_date} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
+        OR (${monthly_active_service_subscriptions.effective_date} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
+      ) ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      vat
+    ]
+  }
+
+  join: exchange_rates_table {
+    view_label: "Exchange Rates"
+    sql_on:
+      ${monthly_active_service_subscriptions.subscription__plan_currency} = ${exchange_rates_table.base_currency}
+      AND ${exchange_rates_table.quote_currency} = 'USD'
+      AND ${monthly_active_service_subscriptions.effective_date} = ${exchange_rates_table.date_raw} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      price
+    ]
+  }
+}

--- a/subscription_platform/explores/service_subscription_events.explore.lkml
+++ b/subscription_platform/explores/service_subscription_events.explore.lkml
@@ -1,0 +1,50 @@
+include: "../views/service_subscription_events.view.lkml"
+include: "../views/service_subscriptions.view.lkml"
+include: "../views/table_metadata.view.lkml"
+include: "/shared/views/countries.view.lkml"
+
+explore: service_subscription_events {
+  join: countries {
+    sql_on: ${service_subscription_events.subscription__country_code} = ${countries.code} ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+
+  join: current_subscription_state {
+    from: service_subscriptions
+    sql_on: ${service_subscription_events.subscription__id} = ${current_subscription_state.id} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      is_trial,
+      is_active,
+      auto_renew,
+      has_refunds,
+      has_fraudulent_charges
+    ]
+  }
+
+  join: subscription_other_services {
+    from: service_subscription_events__subscription__other_services
+    # This should use a dimension reference, but Looker currently has a problem resolving dimension references in `sql_table_name`.
+    sql_table_name: UNNEST(service_subscription_events.subscription.other_services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: old_subscription_other_services {
+    from: service_subscription_events__old_subscription__other_services
+    # This should use a dimension reference, but Looker currently has a problem resolving dimension references in `sql_table_name`.
+    sql_table_name: UNNEST(service_subscription_events.old_subscription.other_services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: table_metadata {
+    sql_on: ${table_metadata.table_name} = 'service_subscription_events_v1' ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+}

--- a/subscription_platform/explores/service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/service_subscriptions.explore.lkml
@@ -1,0 +1,65 @@
+include: "../views/service_subscriptions.view.lkml"
+include: "../views/table_metadata.view.lkml"
+include: "/shared/views/countries.view.lkml"
+include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
+
+explore: service_subscriptions {
+  join: countries {
+    sql_on: ${service_subscriptions.country_code} = ${countries.code} ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+
+  join: retention_by_month {
+    from: service_subscriptions__retention_by_month
+    # The `sql` parameter was deprecated in Looker 3.12, so this should use `sql_table_name`,
+    # but Looker currently has a problem resolving dimension references in `sql_table_name`.
+    sql: LEFT JOIN UNNEST(${service_subscriptions.month_numbers}) AS retention_by_month ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: subscription_other_services {
+    from: service_subscriptions__other_services
+    # This should use a dimension reference, but Looker currently has a problem resolving dimension references in `sql_table_name`.
+    sql_table_name: UNNEST(service_subscriptions.other_services) ;;
+    sql_on: TRUE ;;
+    type: left_outer
+    relationship: one_to_many
+  }
+
+  join: table_metadata {
+    sql_on: ${table_metadata.table_name} = 'service_subscriptions_v1' ;;
+    type: left_outer
+    relationship: many_to_one
+  }
+
+  join: vat_rates {
+    view_label: "VAT Rates"
+    sql_on:
+      ${service_subscriptions.country_code} = ${vat_rates.country_code}
+      AND (
+        ${service_subscriptions.effective_date} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
+        OR (${service_subscriptions.effective_date} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
+      ) ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      vat
+    ]
+  }
+
+  join: exchange_rates_table {
+    view_label: "Exchange Rates"
+    sql_on:
+      ${service_subscriptions.plan_currency} = ${exchange_rates_table.base_currency}
+      AND ${exchange_rates_table.quote_currency} = 'USD'
+      AND ${service_subscriptions.effective_date} = ${exchange_rates_table.date_raw} ;;
+    type: left_outer
+    relationship: many_to_one
+    fields: [
+      price
+    ]
+  }
+}

--- a/subscription_platform/views/daily_active_service_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_service_subscriptions.view.lkml
@@ -1,0 +1,385 @@
+include: "//looker-hub/subscription_platform/views/daily_active_service_subscriptions.view.lkml"
+
+view: +daily_active_service_subscriptions {
+  dimension: id {
+    primary_key: yes
+    hidden: yes
+  }
+
+  dimension: service_subscriptions_history_id {
+    hidden: yes
+  }
+
+  dimension: subscription__provider_subscription_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Subscription ID"
+  }
+  dimension: subscription__provider_subscription_item_id {
+    hidden: yes
+  }
+  dimension: subscription__provider_customer_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Customer ID"
+  }
+
+  dimension: subscription__mozilla_account_id_sha256 {
+    hidden: yes
+  }
+
+  dimension: subscription__country_code {
+    map_layer_name: countries
+  }
+  dimension: subscription__country_name {
+    map_layer_name: countries
+  }
+
+  dimension: subscription__service__id {
+    sql: ${TABLE}.service_id ;;
+    group_label: "Subscription"
+    group_item_label: "Service ID"
+  }
+  dimension: subscription__service__name {
+    group_label: "Subscription"
+    group_item_label: "Service Name"
+  }
+  dimension: subscription__service__tier {
+    group_label: "Subscription"
+    group_item_label: "Service Tier"
+  }
+
+  dimension: subscription__other_services_quantity {
+    type: number
+    sql: ARRAY_LENGTH(${TABLE}.subscription.other_services) ;;
+    group_label: "Subscription"
+    group_item_label: "Other Services Quantity"
+  }
+
+  dimension: subscription__provider_product_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Product ID"
+  }
+
+  dimension: subscription__provider_plan_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Plan ID"
+  }
+  dimension: subscription__plan_interval_type {
+    hidden: yes
+  }
+  dimension: subscription__plan_interval_count {
+    hidden: yes
+  }
+  dimension: subscription__plan_amount {
+    value_format_name: decimal_2
+  }
+
+  dimension_group: subscription_active {
+    type: duration
+    sql_start: ${TABLE}.subscription.started_at ;;
+    sql_end: COALESCE(${TABLE}.subscription.ended_at, TIMESTAMP(${TABLE}.date + 1)) ;;
+    intervals: [day, week, month, quarter, year]
+  }
+
+  dimension_group: until_current_period_ends {
+    type: duration
+    sql_start:
+      LEAST(
+        TIMESTAMP_SUB(TIMESTAMP(${TABLE}.date + 1), INTERVAL 1 MICROSECOND),
+        ${TABLE}.subscription.current_period_ends_at
+      ) ;;
+    sql_end: ${TABLE}.subscription.current_period_ends_at ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+
+  dimension: current_period_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__current_period_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_revenue_months {
+    type: number
+    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__is_trial} IS TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${current_period_discounted_plan_amount}
+              / ${subscription__plan_interval_months}
+              * ${current_period_annual_recurring_revenue_months}
+            )
+        WHEN ${subscription__plan_interval_type} IN ('week', 'day')
+          THEN ${current_period_discounted_plan_amount}
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__ongoing_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension_group: after_current_period_before_ongoing_discount_ends {
+    type: duration
+    sql_start: ${subscription__current_period_ends_at_raw} ;;
+    sql_end: TIMESTAMP_SUB(${subscription__ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_months {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (12 - ${current_period_annual_recurring_revenue_months})
+        ELSE
+          LEAST(
+            (
+              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_months}) + 1)
+              * ${subscription__plan_interval_months}
+            ),
+            (12 - ${current_period_annual_recurring_revenue_months})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (52 - ${subscription__plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${subscription__plan_interval_count}) + 1)
+              * ${subscription__plan_interval_count}
+            ),
+            (52 - ${subscription__plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_days {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (365 - ${subscription__plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_count}) + 1)
+              * ${subscription__plan_interval_count}
+            ),
+            (365 - ${subscription__plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__auto_renew} IS NOT TRUE
+          OR COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_months}
+              * ${ongoing_discounted_annual_recurring_revenue_months}
+            )
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_weeks}
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_days}
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__auto_renew} IS NOT TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_months}
+              * GREATEST(
+                (
+                  12
+                  - ${current_period_annual_recurring_revenue_months}
+                  - ${ongoing_discounted_annual_recurring_revenue_months}
+                ),
+                0
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_count}
+              * GREATEST(
+                (
+                  52
+                  - ${subscription__plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
+                ),
+                0
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_count}
+              * GREATEST(
+                (
+                  365
+                  - ${subscription__plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_days}
+                ),
+                0
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: annual_recurring_gross_revenue {
+    type: number
+    sql:
+      ${current_period_annual_recurring_gross_revenue}
+      + ${ongoing_discounted_annual_recurring_gross_revenue}
+      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
+    hidden: yes
+  }
+  dimension: annual_recurring_net_revenue {
+    type: number
+    sql:
+      ${annual_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
+  dimension: annual_recurring_revenue_usd {
+    group_label: "Subscription"
+    label: "Annual Recurring Revenue (USD)"
+    type: number
+    sql:
+      ${annual_recurring_net_revenue}
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+    value_format_name: usd
+  }
+
+  dimension: monthly_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__is_trial} IS TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${subscription__plan_interval_count}
+                * IF(${subscription__auto_renew}, GREATEST((4 - ${subscription__plan_interval_count}), 0), 0)
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${subscription__plan_interval_count}
+                * IF(${subscription__auto_renew}, GREATEST((30 - ${subscription__plan_interval_count}), 0), 0)
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+  dimension: monthly_recurring_net_revenue {
+    type: number
+    sql:
+      ${monthly_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
+  dimension: monthly_recurring_revenue_usd {
+    group_label: "Subscription"
+    label: "Monthly Recurring Revenue (USD)"
+    type: number
+    sql:
+      ${monthly_recurring_net_revenue}
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+    value_format_name: usd
+  }
+
+  measure: service_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.subscription.id ;;
+  }
+
+  measure: logical_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.subscription.logical_subscription_id ;;
+  }
+
+  measure: provider_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.subscription.provider_subscription_id ;;
+  }
+
+  measure: customer_count {
+    type: count_distinct
+    sql:
+      COALESCE(
+        ${TABLE}.subscription.mozilla_account_id_sha256,
+        ${TABLE}.subscription.provider_customer_id,
+        ${TABLE}.subscription.provider_subscription_id
+      ) ;;
+  }
+
+  measure: total_annual_recurring_revenue_usd {
+    label: "Total Annual Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${subscription__id} ;;
+    sql: ${annual_recurring_revenue_usd} ;;
+    value_format_name: usd
+  }
+
+  measure: total_monthly_recurring_revenue_usd {
+    label: "Total Monthly Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${subscription__id} ;;
+    sql: ${monthly_recurring_revenue_usd} ;;
+    value_format_name: usd
+  }
+}

--- a/subscription_platform/views/monthly_active_service_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_service_subscriptions.view.lkml
@@ -1,0 +1,407 @@
+include: "//looker-hub/subscription_platform/views/monthly_active_service_subscriptions.view.lkml"
+
+view: +monthly_active_service_subscriptions {
+  dimension: id {
+    primary_key: yes
+    hidden: yes
+  }
+
+  dimension_group: month {
+    type: time
+    sql: ${TABLE}.month_start_date ;;
+    datatype: date
+    timeframes: [month, quarter, year]
+  }
+
+  dimension: service_subscriptions_history_id {
+    hidden: yes
+  }
+
+  dimension: subscription__provider_subscription_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Subscription ID"
+  }
+  dimension: subscription__provider_subscription_item_id {
+    hidden: yes
+  }
+  dimension: subscription__provider_customer_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Customer ID"
+  }
+
+  dimension: subscription__mozilla_account_id_sha256 {
+    hidden: yes
+  }
+
+  dimension: subscription__country_code {
+    map_layer_name: countries
+  }
+  dimension: subscription__country_name {
+    map_layer_name: countries
+  }
+
+  dimension: subscription__service__id {
+    sql: ${TABLE}.service_id ;;
+    group_label: "Subscription"
+    group_item_label: "Service ID"
+  }
+  dimension: subscription__service__name {
+    group_label: "Subscription"
+    group_item_label: "Service Name"
+  }
+  dimension: subscription__service__tier {
+    group_label: "Subscription"
+    group_item_label: "Service Tier"
+  }
+
+  dimension: subscription__other_services_quantity {
+    type: number
+    sql: ARRAY_LENGTH(${TABLE}.subscription.other_services) ;;
+    group_label: "Subscription"
+    group_item_label: "Other Services Quantity"
+  }
+
+  dimension: subscription__provider_product_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Product ID"
+  }
+
+  dimension: subscription__provider_plan_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Plan ID"
+  }
+  dimension: subscription__plan_interval_type {
+    hidden: yes
+  }
+  dimension: subscription__plan_interval_count {
+    hidden: yes
+  }
+  dimension: subscription__plan_amount {
+    value_format_name: decimal_2
+  }
+
+  dimension: effective_date {
+    type: date_raw
+    sql:
+      COALESCE(
+        DATE(${TABLE}.subscription.ended_at),
+        LEAST(${TABLE}.month_end_date, ${table_metadata.last_modified_date} - 1)
+      ) ;;
+    hidden: yes
+  }
+
+  dimension_group: subscription_active {
+    type: duration
+    sql_start: ${TABLE}.subscription.started_at ;;
+    sql_end:
+      COALESCE(
+        ${TABLE}.subscription.ended_at,
+        TIMESTAMP(LEAST((${TABLE}.month_end_date + 1), CURRENT_DATE()))
+      ) ;;
+    intervals: [day, week, month, quarter, year]
+  }
+
+  dimension_group: until_current_period_ends {
+    type: duration
+    sql_start:
+      LEAST(
+        TIMESTAMP_SUB(TIMESTAMP(${TABLE}.month_end_date + 1), INTERVAL 1 MICROSECOND),
+        TIMESTAMP(CURRENT_DATE()),
+        ${TABLE}.subscription.current_period_ends_at
+      ) ;;
+    sql_end: ${TABLE}.subscription.current_period_ends_at ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+
+  dimension: current_period_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__current_period_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_revenue_months {
+    type: number
+    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__is_trial} IS TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${current_period_discounted_plan_amount}
+              / ${subscription__plan_interval_months}
+              * ${current_period_annual_recurring_revenue_months}
+            )
+        WHEN ${subscription__plan_interval_type} IN ('week', 'day')
+          THEN ${current_period_discounted_plan_amount}
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__ongoing_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension_group: after_current_period_before_ongoing_discount_ends {
+    type: duration
+    sql_start: ${subscription__current_period_ends_at_raw} ;;
+    sql_end: TIMESTAMP_SUB(${subscription__ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_months {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (12 - ${current_period_annual_recurring_revenue_months})
+        ELSE
+          LEAST(
+            (
+              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_months}) + 1)
+              * ${subscription__plan_interval_months}
+            ),
+            (12 - ${current_period_annual_recurring_revenue_months})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (52 - ${subscription__plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${subscription__plan_interval_count}) + 1)
+              * ${subscription__plan_interval_count}
+            ),
+            (52 - ${subscription__plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_days {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
+          THEN (365 - ${subscription__plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_count}) + 1)
+              * ${subscription__plan_interval_count}
+            ),
+            (365 - ${subscription__plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__auto_renew} IS NOT TRUE
+          OR COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_months}
+              * ${ongoing_discounted_annual_recurring_revenue_months}
+            )
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_weeks}
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${subscription__plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_days}
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__auto_renew} IS NOT TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_months}
+              * GREATEST(
+                (
+                  12
+                  - ${current_period_annual_recurring_revenue_months}
+                  - ${ongoing_discounted_annual_recurring_revenue_months}
+                ),
+                0
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_count}
+              * GREATEST(
+                (
+                  52
+                  - ${subscription__plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
+                ),
+                0
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${subscription__plan_amount}
+              / ${subscription__plan_interval_count}
+              * GREATEST(
+                (
+                  365
+                  - ${subscription__plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_days}
+                ),
+                0
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: annual_recurring_gross_revenue {
+    type: number
+    sql:
+      ${current_period_annual_recurring_gross_revenue}
+      + ${ongoing_discounted_annual_recurring_gross_revenue}
+      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
+    hidden: yes
+  }
+  dimension: annual_recurring_net_revenue {
+    type: number
+    sql:
+      ${annual_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
+  dimension: annual_recurring_revenue_usd {
+    group_label: "Subscription"
+    label: "Annual Recurring Revenue (USD)"
+    type: number
+    sql:
+      ${annual_recurring_net_revenue}
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+    value_format_name: usd
+  }
+
+  dimension: monthly_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${subscription__is_active} IS NOT TRUE
+          OR ${subscription__is_trial} IS TRUE
+          THEN 0
+        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
+          THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})
+        WHEN ${subscription__plan_interval_type} = 'week'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${subscription__plan_interval_count}
+                * IF(${subscription__auto_renew}, GREATEST((4 - ${subscription__plan_interval_count}), 0), 0)
+              )
+            )
+        WHEN ${subscription__plan_interval_type} = 'day'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${subscription__plan_interval_count}
+                * IF(${subscription__auto_renew}, GREATEST((30 - ${subscription__plan_interval_count}), 0), 0)
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+  dimension: monthly_recurring_net_revenue {
+    type: number
+    sql:
+      ${monthly_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
+  dimension: monthly_recurring_revenue_usd {
+    group_label: "Subscription"
+    label: "Monthly Recurring Revenue (USD)"
+    type: number
+    sql:
+      ${monthly_recurring_net_revenue}
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+    value_format_name: usd
+  }
+
+  measure: service_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.subscription.id ;;
+  }
+
+  measure: logical_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.subscription.logical_subscription_id ;;
+  }
+
+  measure: provider_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.subscription.provider_subscription_id ;;
+  }
+
+  measure: customer_count {
+    type: count_distinct
+    sql:
+      COALESCE(
+        ${TABLE}.subscription.mozilla_account_id_sha256,
+        ${TABLE}.subscription.provider_customer_id,
+        ${TABLE}.subscription.provider_subscription_id
+      ) ;;
+  }
+
+  measure: total_annual_recurring_revenue_usd {
+    label: "Total Annual Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${subscription__id} ;;
+    sql: ${annual_recurring_revenue_usd} ;;
+    value_format_name: usd
+  }
+
+  measure: total_monthly_recurring_revenue_usd {
+    label: "Total Monthly Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${subscription__id} ;;
+    sql: ${monthly_recurring_revenue_usd} ;;
+    value_format_name: usd
+  }
+}

--- a/subscription_platform/views/service_subscription_events.view.lkml
+++ b/subscription_platform/views/service_subscription_events.view.lkml
@@ -1,0 +1,277 @@
+include: "//looker-hub/subscription_platform/views/service_subscription_events.view.lkml"
+
+view: +service_subscription_events {
+  dimension: id {
+    primary_key: yes
+    hidden: yes
+  }
+
+  dimension_group: timestamp {
+    label: "Event Timestamp"
+  }
+  dimension: type {
+    group_label: "Event"
+  }
+  dimension: reason {
+    group_label: "Event"
+  }
+
+  dimension: service_subscriptions_history_id {
+    hidden: yes
+  }
+
+  dimension: subscription__provider_subscription_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Subscription ID"
+  }
+  dimension: subscription__provider_subscription_item_id {
+    hidden: yes
+  }
+  dimension: subscription__provider_customer_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Customer ID"
+  }
+
+  dimension: subscription__mozilla_account_id_sha256 {
+    hidden: yes
+  }
+
+  dimension: subscription__country_code {
+    map_layer_name: countries
+  }
+  dimension: subscription__country_name {
+    map_layer_name: countries
+  }
+
+  dimension: subscription__service__id {
+    sql: ${TABLE}.service_id ;;
+    group_label: "Subscription"
+    group_item_label: "Service ID"
+  }
+  dimension: subscription__service__name {
+    group_label: "Subscription"
+    group_item_label: "Service Name"
+  }
+  dimension: subscription__service__tier {
+    group_label: "Subscription"
+    group_item_label: "Service Tier"
+  }
+
+  dimension: subscription__other_services_quantity {
+    type: number
+    sql: ARRAY_LENGTH(${TABLE}.subscription.other_services) ;;
+    group_label: "Subscription"
+    group_item_label: "Other Services Quantity"
+  }
+
+  dimension: subscription__provider_product_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Product ID"
+  }
+
+  dimension: subscription__provider_plan_id {
+    group_label: "Subscription Provider IDs"
+    group_item_label: "Plan ID"
+  }
+  dimension: subscription__plan_interval_type {
+    hidden: yes
+  }
+  dimension: subscription__plan_interval_count {
+    hidden: yes
+  }
+  dimension: subscription__plan_amount {
+    value_format_name: decimal_2
+  }
+
+  dimension_group: subscription_active {
+    type: duration
+    sql_start: ${TABLE}.subscription.started_at ;;
+    sql_end: COALESCE(${TABLE}.subscription.ended_at, ${TABLE}.timestamp) ;;
+    intervals: [day, week, month, quarter, year]
+  }
+
+  dimension: old_subscription__id {
+    hidden: yes
+  }
+  dimension: old_subscription__provider {
+    hidden: yes
+  }
+  dimension: old_subscription__payment_provider {
+    hidden: yes
+  }
+  dimension: old_subscription__logical_subscription_id {
+    hidden: yes
+  }
+  dimension: old_subscription__provider_subscription_id {
+    hidden: yes
+  }
+  dimension: old_subscription__provider_subscription_item_id {
+    hidden: yes
+  }
+  dimension_group: old_subscription__provider_subscription_created_at {
+    hidden: yes
+  }
+  dimension: old_subscription__provider_customer_id {
+    hidden: yes
+  }
+  dimension: old_subscription__mozilla_account_id_sha256 {
+    hidden: yes
+  }
+  dimension: old_subscription__customer_logical_subscription_number {
+    hidden: yes
+  }
+  dimension: old_subscription__customer_service_subscription_number {
+    hidden: yes
+  }
+
+  dimension: old_subscription__country_code {
+    map_layer_name: countries
+  }
+  dimension: old_subscription__country_name {
+    map_layer_name: countries
+  }
+
+  dimension: old_subscription__service__id {
+    group_label: "Old Subscription"
+    group_item_label: "Service ID"
+  }
+  dimension: old_subscription__service__name {
+    group_label: "Old Subscription"
+    group_item_label: "Service Name"
+  }
+  dimension: old_subscription__service__tier {
+    group_label: "Old Subscription"
+    group_item_label: "Service Tier"
+  }
+
+  dimension: old_subscription__other_services_quantity {
+    type: number
+    sql: ARRAY_LENGTH(${TABLE}.old_subscription.other_services) ;;
+    group_label: "Old Subscription"
+    group_item_label: "Other Services Quantity"
+  }
+
+  dimension: old_subscription__provider_product_id {
+    group_label: "Old Subscription Provider IDs"
+    group_item_label: "Product ID"
+  }
+
+  dimension: old_subscription__provider_plan_id {
+    group_label: "Old Subscription Provider IDs"
+    group_item_label: "Plan ID"
+  }
+  dimension: old_subscription__plan_interval_type {
+    hidden: yes
+  }
+  dimension: old_subscription__plan_interval_count {
+    hidden: yes
+  }
+  dimension: old_subscription__plan_amount {
+    value_format_name: decimal_2
+  }
+
+  dimension_group: old_subscription__logical_subscription_started_at {
+    hidden: yes
+  }
+  dimension_group: old_subscription__started_at {
+    hidden: yes
+  }
+  dimension_group: old_subscription__ended_at {
+    hidden: yes
+  }
+
+  dimension_group: old_subscription__first_touch_attribution__impression_at {
+    hidden: yes
+  }
+  dimension: old_subscription__first_touch_attribution__entrypoint {
+    hidden: yes
+  }
+  dimension: old_subscription__first_touch_attribution__entrypoint_experiment {
+    hidden: yes
+  }
+  dimension: old_subscription__first_touch_attribution__entrypoint_variation {
+    hidden: yes
+  }
+  dimension: old_subscription__first_touch_attribution__utm_campaign {
+    hidden: yes
+  }
+  dimension: old_subscription__first_touch_attribution__utm_content {
+    hidden: yes
+  }
+  dimension: old_subscription__first_touch_attribution__utm_medium {
+    hidden: yes
+  }
+  dimension: old_subscription__first_touch_attribution__utm_source {
+    hidden: yes
+  }
+  dimension: old_subscription__first_touch_attribution__utm_term {
+    hidden: yes
+  }
+
+  dimension_group: old_subscription__last_touch_attribution__impression_at {
+    hidden: yes
+  }
+  dimension: old_subscription__last_touch_attribution__entrypoint {
+    hidden: yes
+  }
+  dimension: old_subscription__last_touch_attribution__entrypoint_experiment {
+    hidden: yes
+  }
+  dimension: old_subscription__last_touch_attribution__entrypoint_variation {
+    hidden: yes
+  }
+  dimension: old_subscription__last_touch_attribution__utm_campaign {
+    hidden: yes
+  }
+  dimension: old_subscription__last_touch_attribution__utm_content {
+    hidden: yes
+  }
+  dimension: old_subscription__last_touch_attribution__utm_medium {
+    hidden: yes
+  }
+  dimension: old_subscription__last_touch_attribution__utm_source {
+    hidden: yes
+  }
+  dimension: old_subscription__last_touch_attribution__utm_term {
+    hidden: yes
+  }
+
+  measure: event_count {
+    type: count
+  }
+
+  measure: service_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.subscription.id ;;
+  }
+
+  measure: net_service_subscription_count {
+    type: sum
+    sql:
+      CASE ${TABLE}.type
+        WHEN 'Subscription Start' THEN 1
+        WHEN 'Subscription End' THEN -1
+        ELSE 0
+      END ;;
+  }
+
+  measure: logical_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.subscription.logical_subscription_id ;;
+  }
+
+  measure: provider_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.subscription.provider_subscription_id ;;
+  }
+
+  measure: customer_count {
+    type: count_distinct
+    sql:
+      COALESCE(
+        ${TABLE}.subscription.mozilla_account_id_sha256,
+        ${TABLE}.subscription.provider_customer_id,
+        ${TABLE}.subscription.provider_subscription_id
+      ) ;;
+  }
+}

--- a/subscription_platform/views/service_subscriptions.view.lkml
+++ b/subscription_platform/views/service_subscriptions.view.lkml
@@ -1,0 +1,447 @@
+include: "//looker-hub/subscription_platform/views/service_subscriptions.view.lkml"
+
+view: +service_subscriptions {
+  dimension: id {
+    primary_key: yes
+  }
+
+  dimension: service_id {
+    hidden: yes
+  }
+
+  dimension: provider_subscription_id {
+    group_label: "Provider IDs"
+    group_item_label: "Subscription ID"
+  }
+  dimension: provider_subscription_item_id {
+    hidden: yes
+  }
+  dimension: provider_customer_id {
+    group_label: "Provider IDs"
+    group_item_label: "Customer ID"
+  }
+
+  dimension: mozilla_account_id_sha256 {
+    hidden: yes
+  }
+
+  dimension: country_code {
+    map_layer_name: countries
+  }
+  dimension: country_name {
+    map_layer_name: countries
+  }
+
+  dimension: service__id {
+    sql: ${TABLE}.service_id ;;
+  }
+
+  dimension: other_services_quantity {
+    type: number
+    sql: ARRAY_LENGTH(${TABLE}.other_services) ;;
+  }
+
+  dimension: provider_product_id {
+    group_label: "Provider IDs"
+    group_item_label: "Product ID"
+  }
+
+  dimension: provider_plan_id {
+    group_label: "Provider IDs"
+    group_item_label: "Plan ID"
+  }
+  dimension: plan_interval_type {
+    hidden: yes
+  }
+  dimension: plan_interval_count {
+    hidden: yes
+  }
+  dimension: plan_amount {
+    value_format_name: decimal_2
+  }
+
+  dimension: effective_date {
+    type: date_raw
+    sql: COALESCE(DATE(${TABLE}.ended_at), ${table_metadata.last_modified_date} - 1) ;;
+    hidden: yes
+  }
+
+  dimension_group: active {
+    type: duration
+    sql_start: ${TABLE}.started_at ;;
+    sql_end: COALESCE(${TABLE}.ended_at, TIMESTAMP(CURRENT_DATE())) ;;
+    intervals: [day, week, month, quarter, year]
+  }
+
+  dimension_group: since_subscription_started {
+    type: duration
+    sql_start: ${TABLE}.started_at ;;
+    sql_end: TIMESTAMP(CURRENT_DATE()) ;;
+    intervals: [day, week, month, quarter, year]
+  }
+
+  dimension_group: until_current_period_ends {
+    type: duration
+    sql_start: LEAST(TIMESTAMP(CURRENT_DATE()), ${TABLE}.current_period_ends_at) ;;
+    sql_end: ${TABLE}.current_period_ends_at ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+
+  dimension: month_numbers {
+    sql: GENERATE_ARRAY(1, ${months_since_subscription_started} + 1) ;;
+    hidden: yes
+  }
+
+  dimension: months_since_start_month_ended {
+    type: duration_month
+    sql_start:
+      TIMESTAMP_SUB(
+        TIMESTAMP_ADD(
+          TIMESTAMP(LAST_DAY(DATE(${TABLE}.started_at), MONTH)),
+          INTERVAL 1 DAY
+        ),
+        INTERVAL 1 MICROSECOND
+      ) ;;
+    sql_end: TIMESTAMP(CURRENT_DATE()) ;;
+    hidden: yes
+  }
+
+  dimension: current_period_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${plan_amount} - COALESCE(${current_period_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_revenue_months {
+    type: number
+    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
+    hidden: yes
+  }
+  dimension: current_period_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${is_active} IS NOT TRUE
+          OR ${is_trial} IS TRUE
+          THEN 0
+        WHEN ${plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${current_period_discounted_plan_amount}
+              / ${plan_interval_months}
+              * ${current_period_annual_recurring_revenue_months}
+            )
+        WHEN ${plan_interval_type} IN ('week', 'day')
+          THEN ${current_period_discounted_plan_amount}
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_discounted_plan_amount {
+    type: number
+    sql: GREATEST((${plan_amount} - COALESCE(${ongoing_discount_amount}, 0)), 0) ;;
+    hidden: yes
+  }
+  dimension_group: after_current_period_before_ongoing_discount_ends {
+    type: duration
+    sql_start: ${current_period_ends_at_raw} ;;
+    sql_end: TIMESTAMP_SUB(${ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
+    intervals: [day, week, month]
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_months {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${ongoing_discount_ends_at_raw} IS NULL
+          THEN (12 - ${current_period_annual_recurring_revenue_months})
+        ELSE
+          LEAST(
+            (
+              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${plan_interval_months}) + 1)
+              * ${plan_interval_months}
+            ),
+            (12 - ${current_period_annual_recurring_revenue_months})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${ongoing_discount_ends_at_raw} IS NULL
+          THEN (52 - ${plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${plan_interval_count}) + 1)
+              * ${plan_interval_count}
+            ),
+            (52 - ${plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_revenue_days {
+    type: number
+    sql:
+      CASE
+        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${ongoing_discount_ends_at_raw} IS NULL
+          THEN (365 - ${plan_interval_count})
+        ELSE
+          LEAST(
+            (
+              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${plan_interval_count}) + 1)
+              * ${plan_interval_count}
+            ),
+            (365 - ${plan_interval_count})
+          )
+      END ;;
+    hidden: yes
+  }
+  dimension: ongoing_discounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${is_active} IS NOT TRUE
+          OR ${auto_renew} IS NOT TRUE
+          OR COALESCE(${ongoing_discount_amount}, 0) = 0
+          THEN 0
+        WHEN ${plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${plan_interval_months}
+              * ${ongoing_discounted_annual_recurring_revenue_months}
+            )
+        WHEN ${plan_interval_type} = 'week'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_weeks}
+            )
+        WHEN ${plan_interval_type} = 'day'
+          THEN (
+              ${ongoing_discounted_plan_amount}
+              / ${plan_interval_count}
+              * ${ongoing_discounted_annual_recurring_revenue_days}
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${is_active} IS NOT TRUE
+          OR ${auto_renew} IS NOT TRUE
+          THEN 0
+        WHEN ${plan_interval_type} IN ('year', 'month')
+          THEN (
+              ${plan_amount}
+              / ${plan_interval_months}
+              * GREATEST(
+                (
+                  12
+                  - ${current_period_annual_recurring_revenue_months}
+                  - ${ongoing_discounted_annual_recurring_revenue_months}
+                ),
+                0
+              )
+            )
+        WHEN ${plan_interval_type} = 'week'
+          THEN (
+              ${plan_amount}
+              / ${plan_interval_count}
+              * GREATEST(
+                (
+                  52
+                  - ${plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
+                ),
+                0
+              )
+            )
+        WHEN ${plan_interval_type} = 'day'
+          THEN (
+              ${plan_amount}
+              / ${plan_interval_count}
+              * GREATEST(
+                (
+                  365
+                  - ${plan_interval_count}
+                  - ${ongoing_discounted_annual_recurring_revenue_days}
+                ),
+                0
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+
+  dimension: annual_recurring_gross_revenue {
+    type: number
+    sql:
+      ${current_period_annual_recurring_gross_revenue}
+      + ${ongoing_discounted_annual_recurring_gross_revenue}
+      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
+    hidden: yes
+  }
+  dimension: annual_recurring_net_revenue {
+    type: number
+    sql:
+      ${annual_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
+  dimension: annual_recurring_revenue_usd {
+    label: "Annual Recurring Revenue (USD)"
+    type: number
+    sql:
+      ${annual_recurring_net_revenue}
+      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+    value_format_name: usd
+  }
+
+  dimension: monthly_recurring_gross_revenue {
+    type: number
+    sql:
+      CASE
+        WHEN ${is_active} IS NOT TRUE
+          OR ${is_trial} IS TRUE
+          THEN 0
+        WHEN ${plan_interval_type} IN ('year', 'month')
+          THEN (${current_period_discounted_plan_amount} / ${plan_interval_months})
+        WHEN ${plan_interval_type} = 'week'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${plan_interval_count}
+                * IF(${auto_renew}, GREATEST((4 - ${plan_interval_count}), 0), 0)
+              )
+            )
+        WHEN ${plan_interval_type} = 'day'
+          THEN (
+              ${current_period_discounted_plan_amount}
+              + (
+                ${ongoing_discounted_plan_amount}
+                / ${plan_interval_count}
+                * IF(${auto_renew}, GREATEST((30 - ${plan_interval_count}), 0), 0)
+              )
+            )
+      END ;;
+    hidden: yes
+  }
+  dimension: monthly_recurring_net_revenue {
+    type: number
+    sql:
+      ${monthly_recurring_gross_revenue}
+      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
+    hidden: yes
+  }
+  dimension: monthly_recurring_revenue_usd {
+    label: "Monthly Recurring Revenue (USD)"
+    type: number
+    sql:
+      ${monthly_recurring_net_revenue}
+      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+    value_format_name: usd
+  }
+
+  measure: service_subscription_count {
+    type: count
+  }
+
+  measure: active_service_subscription_count {
+    type: count
+    filters: [is_active: "yes"]
+  }
+
+  measure: logical_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.logical_subscription_id ;;
+  }
+
+  measure: provider_subscription_count {
+    type: count_distinct
+    sql: ${TABLE}.provider_subscription_id ;;
+  }
+
+  measure: customer_count {
+    type: count_distinct
+    sql:
+      COALESCE(
+        ${TABLE}.mozilla_account_id_sha256,
+        ${TABLE}.provider_customer_id,
+        ${TABLE}.provider_subscription_id
+      ) ;;
+  }
+
+  measure: total_annual_recurring_revenue_usd {
+    label: "Total Annual Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${id} ;;
+    sql: ${annual_recurring_revenue_usd} ;;
+    value_format_name: usd
+  }
+
+  measure: total_monthly_recurring_revenue_usd {
+    label: "Total Monthly Recurring Revenue (USD)"
+    type: sum_distinct
+    sql_distinct_key: ${id} ;;
+    sql: ${monthly_recurring_revenue_usd} ;;
+    value_format_name: usd
+  }
+}
+
+view: service_subscriptions__retention_by_month {
+  dimension: subscription_month_number {
+    type: number
+    sql: ${TABLE} ;;
+  }
+
+  dimension: is_start_month_cohort_complete {
+    type: yesno
+    sql: ${subscription_month_number} <= ${service_subscriptions.months_since_start_month_ended} ;;
+  }
+
+  measure: churned_subscription_count {
+    type: count_distinct
+    sql:
+      CASE
+        WHEN NOT ${service_subscriptions.is_active}
+          AND ${subscription_month_number} = ${service_subscriptions.months_active} + 1
+          THEN ${service_subscriptions.id}
+        ELSE NULL
+      END ;;
+  }
+
+  measure: retained_subscription_count {
+    type: count_distinct
+    sql:
+      CASE
+        WHEN ${service_subscriptions.is_active}
+          OR ${subscription_month_number} <= ${service_subscriptions.months_active}
+          THEN ${service_subscriptions.id}
+        ELSE NULL
+      END ;;
+  }
+
+  measure: previously_retained_subscription_count {
+    type: count_distinct
+    sql:
+      CASE
+        WHEN ${service_subscriptions.is_active}
+          OR ${subscription_month_number} <= ${service_subscriptions.months_active} + 1
+          THEN ${service_subscriptions.id}
+        ELSE NULL
+      END ;;
+  }
+}


### PR DESCRIPTION
## [DS-3083](https://mozilla-hub.atlassian.net/browse/DS-3083): SubPlat service subscriptions Looker explores

These views and explores are very similar to the existing "logical subscriptions" views/explores.

The point of this extra "service subscriptions" layer is to handle upgrades/downgrades to/from bundle subscriptions.  For example, if a customer subscribes to Relay and later upgrades their subscription to the Relay+VPN bundle then they will be considered to have a "service subscription" to Relay from the original start of the subscription, but a "service subscription" to VPN which only started at the point they upgraded to the bundle.

See [SubPlat consolidated reporting ETL design](https://docs.google.com/document/d/13TgTN7UJ_89dhh0S64eh0oDsYNHPdeJyEmLk0uScoGI/edit) (especially the diagram at the end) for how this fits into the overall design.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
