### PR TITLE
[DENG-8141] Update datagroups

### DIFF
--- a/firefox_desktop/explores/clients_daily_search.explore.lkml
+++ b/firefox_desktop/explores/clients_daily_search.explore.lkml
@@ -1,8 +1,8 @@
 include: "../views/clients_daily_search.view.lkml"
-include: "//looker-hub/firefox_desktop/datagroups/clients_daily_joined_v1_last_updated.datagroup.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/clients_daily_joined_table_last_updated.datagroup.lkml"
 
 explore: clients_daily_search {
-  persist_with: clients_daily_joined_v1_last_updated
+  persist_with: clients_daily_joined_table_last_updated
   sql_always_where: ${clients_daily_search.submission_date} >= '2010-01-01' ;;
   view_name: clients_daily_search
   description: "Daily search aggregates for desktop clients."

--- a/firefox_desktop/explores/crashes.explore.lkml
+++ b/firefox_desktop/explores/crashes.explore.lkml
@@ -1,11 +1,11 @@
 include: "../views/crash_usage.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "//looker-hub/firefox_desktop/datagroups/clients_daily_joined_v1_last_updated.datagroup.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/clients_daily_joined_table_last_updated.datagroup.lkml"
 
 explore: crash_usage {
   label: "Crashes Daily"
   description: "Crash counts for Desktop Firefox, derived from the crash ping."
-  persist_with: clients_daily_joined_v1_last_updated
+  persist_with: clients_daily_joined_table_last_updated
 
   join: buildhub {
     sql_on: ${crash_usage.version} = ${buildhub.version} AND ${crash_usage.channel} = ${buildhub.channel} ;;
@@ -71,7 +71,7 @@ explore: crash_usage {
       ]
     }
     materialization: {
-      datagroup_trigger: clients_daily_joined_v1_last_updated
+      datagroup_trigger: clients_daily_joined_table_last_updated
       increment_key: "submission_date"
     }
   }
@@ -153,7 +153,7 @@ explore: crash_usage {
       ]
     }
     materialization: {
-      datagroup_trigger: clients_daily_joined_v1_last_updated
+      datagroup_trigger: clients_daily_joined_table_last_updated
       increment_key: "submission_date"
     }
   }
@@ -186,7 +186,7 @@ explore: crash_usage {
     }
 
     materialization: {
-      datagroup_trigger: clients_daily_joined_v1_last_updated
+      datagroup_trigger: clients_daily_joined_table_last_updated
     }
   }
 
@@ -234,7 +234,7 @@ explore: crash_usage {
       ]
     }
     materialization: {
-      datagroup_trigger: clients_daily_joined_v1_last_updated
+      datagroup_trigger: clients_daily_joined_table_last_updated
       increment_key: "submission_date"
     }
   }
@@ -267,7 +267,7 @@ explore: crash_usage {
     }
 
     materialization: {
-      datagroup_trigger: clients_daily_joined_v1_last_updated
+      datagroup_trigger: clients_daily_joined_table_last_updated
     }
   }
 }

--- a/firefox_desktop/explores/newtab_interactions.explore.lkml
+++ b/firefox_desktop/explores/newtab_interactions.explore.lkml
@@ -1,10 +1,10 @@
 include: "../views/newtab_interactions.view.lkml"
 include: "../../shared/views/countries.view.lkml"
-include: "//looker-hub/firefox_desktop/datagroups/newtab_interactions_v1_last_updated.datagroup"
+include: "//looker-hub/firefox_desktop/datagroups/newtab_interactions_table_last_updated.datagroup"
 include: "/firefox_desktop/views/key_tentpole_dates.view.lkml"
 
 explore: newtab_interactions {
-  persist_with: newtab_interactions_v1_last_updated
+  persist_with: newtab_interactions_table_last_updated
   sql_always_where: ${newtab_interactions.submission_date} >= '2022-07-01' ;;
   label: "New Tab Interactions"
   from: newtab_interactions
@@ -49,7 +49,7 @@ explore: newtab_interactions {
     }
 
     materialization: {
-      datagroup_trigger: newtab_interactions_v1_last_updated
+      datagroup_trigger: newtab_interactions_table_last_updated
       increment_key: newtab_interactions.submission_date
       increment_offset: 1
     }
@@ -79,7 +79,7 @@ explore: newtab_interactions {
     }
 
     materialization: {
-      datagroup_trigger: newtab_interactions_v1_last_updated
+      datagroup_trigger: newtab_interactions_table_last_updated
       increment_key: newtab_interactions.submission_date
       increment_offset: 1
     }
@@ -108,7 +108,7 @@ explore: newtab_interactions {
     }
 
     materialization: {
-      datagroup_trigger: newtab_interactions_v1_last_updated
+      datagroup_trigger: newtab_interactions_table_last_updated
       increment_key: newtab_interactions.submission_date
       increment_offset: 1
     }

--- a/firefox_desktop/explores/newtab_visits.explore.lkml
+++ b/firefox_desktop/explores/newtab_visits.explore.lkml
@@ -1,10 +1,10 @@
 include: "../views/newtab_visits.view.lkml"
 include: "../../shared/views/countries.view.lkml"
-include: "//looker-hub/firefox_desktop/datagroups/newtab_visits_v1_last_updated.datagroup"
+include: "//looker-hub/firefox_desktop/datagroups/newtab_visits_table_last_updated.datagroup"
 include: "/firefox_desktop/views/key_tentpole_dates.view.lkml"
 
 explore: newtab_visits {
-  persist_with: newtab_visits_v1_last_updated
+  persist_with: newtab_visits_table_last_updated
   sql_always_where: ${newtab_visits.submission_date} >= '2022-07-01' ;;
   label: "New Tab Visits"
   from: newtab_visits

--- a/fivetran/explores/connector_costs.explore.lkml
+++ b/fivetran/explores/connector_costs.explore.lkml
@@ -1,7 +1,7 @@
 include: "../views/daily_connector_costs.view.lkml"
 
 explore: connector_costs {
-  persist_with: daily_connector_costs_v1_last_updated
+  persist_with: daily_connector_costs_last_updated
   from:  daily_connector_costs
 
 
@@ -12,7 +12,7 @@ explore: connector_costs {
     }
 
     materialization: {
-      datagroup_trigger: daily_connector_costs_v1_last_updated
+      datagroup_trigger: daily_connector_costs_last_updated
     }
   }
 }

--- a/fivetran/fivetran.model.lkml
+++ b/fivetran/fivetran.model.lkml
@@ -3,4 +3,4 @@ label: "Fivetran"
 
 include: "explores/connector_costs.explore"
 include: "dashboards/fivetran_connector_costs.dashboard"
-include: "//looker-hub/fivetran/datagroups/daily_connector_costs_v1_last_updated.datagroup.lkml"
+include: "//looker-hub/fivetran/datagroups/daily_connector_costs_last_updated.datagroup.lkml"

--- a/reference/reference.model.lkml
+++ b/reference/reference.model.lkml
@@ -2,4 +2,4 @@ connection: "telemetry"
 label: "Reference"
 
 include: "explores/*"
-include: "//looker-hub/reference/datagroups/macroeconomic_indices_v1_last_updated.datagroup.lkml"
+include: "//looker-hub/reference/datagroups/macroeconomic_indices_last_updated.datagroup.lkml"

--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -9,7 +9,7 @@ include: "views/search_aggregates.view.lkml"
 include: "views/search_clients_engine_sources_daily.view.lkml"
 include: "explores/*"
 include: "/shared/views/countries.view.lkml"
-include: "//looker-hub/search/datagroups/search_clients_daily_v8_last_updated.datagroup.lkml"
+include: "//looker-hub/search/datagroups/search_clients_engines_sources_daily_last_updated.datagroup.lkml"
 
 explore: search_aggregates {
   description: " Includes aggregated search metrics per day "
@@ -43,7 +43,7 @@ explore: +desktop_search_counts {
   like the URL bar and newtab page. Follow-on searches are those that are after entry from a
   SAP, and organic searches are those that occur directly on a search webpage (e.g. www.google.com)."
 
-  persist_with: search_clients_daily_v8_last_updated
+  persist_with: search_clients_engines_sources_daily_last_updated
 }
 
 explore: desktop_search_alert_latest_daily {}

--- a/user_journey/user_journey.model.lkml
+++ b/user_journey/user_journey.model.lkml
@@ -12,7 +12,7 @@ include: "views/funnel_analysis/event_types.view.lkml"
 include: "views/funnel_analysis/funnel_analysis.view.lkml"
 include: "views/event_type.view.lkml"
 include: "views/raw_event_types.view.lkml"
-include: "//looker-hub/firefox_desktop/datagroups/onboarding_v2_last_updated.datagroup.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/onboarding_table_last_updated.datagroup.lkml"
 
 explore: funnel_analysis {
   view_label: " User-Day Funnels"
@@ -190,7 +190,7 @@ explore: cohort_analysis {
 
 explore: event_counts {
   from: onboarding_v1
-  persist_with: onboarding_v2_last_updated
+  persist_with: onboarding_table_last_updated
 
   join: onboarding_v1__experiments {
     type: cross


### PR DESCRIPTION
Depends on https://github.com/mozilla/lookml-generator/pull/1180

The datagroup generation logic changed to generating datagroups per Looker view instead of per BigQuery table. Some references need to be updated for that

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
