### PR TITLE
Fix workers relationship; Switch duration to seconds.

### DIFF
--- a/fxci/explores/tasks.explore.lkml
+++ b/fxci/explores/tasks.explore.lkml
@@ -22,7 +22,7 @@ explore:  tasks {
 
   join: workers {
     type: left_outer
-    relationship: one_to_one
+    relationship: many_to_one
     sql_on:  ${task_runs.worker_group} = ${workers.zone} AND ${task_runs.worker_id} = ${workers.instance_id};;
   }
 }

--- a/fxci/views/task_runs.view.lkml
+++ b/fxci/views/task_runs.view.lkml
@@ -30,11 +30,11 @@ view: task_runs {
   }
 
   dimension: duration {
-    type: duration_minute
+    type: duration_second
     sql_start: ${started_raw} ;;
     sql_end:  ${resolved_raw} ;;
-    label: "Duration (minutes)"
-    description: "Task duration in minutes"
+    label: "Duration"
+    description: "Task duration in seconds"
   }
 
   measure: task_run_count {
@@ -45,7 +45,7 @@ view: task_runs {
   measure: average_duration {
     type: average
     sql: ${duration} ;;
-    label: "Average Duration (minutes)"
-    description: "Average duration in minutes"
+    label: "Average Duration"
+    description: "Average duration in seconds"
   }
 }

--- a/fxci/views/workers.view.lkml
+++ b/fxci/views/workers.view.lkml
@@ -45,6 +45,7 @@ view: workers {
   }
 
   dimension: key {
+    primary_key: yes
     sql: CONCAT(${TABLE}.project, '-', ${TABLE}.zone, '-', ${TABLE}.instance_id) ;;
   }
 


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
