### PR TITLE
Persist frequently used explores with datagroups

### DIFF
--- a/accounts_backend/explores/events_stream_with_extras.explore.lkml
+++ b/accounts_backend/explores/events_stream_with_extras.explore.lkml
@@ -1,4 +1,5 @@
 include: "../views/events_stream_with_extras.view.lkml"
+include: "//looker-hub/accounts_backend/datagroups/events_stream_table_last_updated.datagroup.lkml"
 
 explore: events_stream_with_extras {
   hidden: no
@@ -10,4 +11,6 @@ explore: events_stream_with_extras {
       submission_date: "28 days",
     ]
   }
+
+  persist_with: events_stream_table_last_updated
 }

--- a/accounts_frontend/explores/events_stream_with_extras.explore.lkml
+++ b/accounts_frontend/explores/events_stream_with_extras.explore.lkml
@@ -1,4 +1,5 @@
 include: "../views/events_stream_with_extras.view.lkml"
+include: "//looker-hub/accounts_frontend/datagroups/events_stream_table_last_updated.datagroup.lkml"
 
 explore: events_stream_with_extras {
   hidden: no
@@ -10,4 +11,6 @@ explore: events_stream_with_extras {
       submission_date: "28 days",
     ]
   }
+
+  persist_with: events_stream_table_last_updated
 }

--- a/activity_stream/explores/pocket_tile_impressions.explore.lkml
+++ b/activity_stream/explores/pocket_tile_impressions.explore.lkml
@@ -1,5 +1,6 @@
 include: "//looker-hub/activity_stream/explores/pocket_tile_impressions.explore.lkml"
 include: "../views/impression_stats_flat.view.lkml"
+include: "//looker-hub/activity_stream/datagroups/impression_stats_flat_last_updated.datagroup.lkml"
 
 explore: +pocket_tile_impressions {
 
@@ -16,5 +17,7 @@ explore: +pocket_tile_impressions {
       increment_offset: 1
     }
   }
+
+  persist_with: impression_stats_flat_last_updated
 
 }

--- a/activity_stream/explores/session_counts.explore.lkml
+++ b/activity_stream/explores/session_counts.explore.lkml
@@ -1,6 +1,6 @@
 include: "//looker-hub/activity_stream/explores/session_counts.explore.lkml"
 include: "../views/sessions.view.lkml"
-
+include: "//looker-hub/activity_stream/datagroups/sessions_last_updated.datagroup.lkml"
 
 explore: +session_counts {
 
@@ -17,4 +17,6 @@ explore: +session_counts {
       increment_offset: 1
     }
   }
+
+  persist_with: sessions_last_updated
 }

--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -1,6 +1,7 @@
 include: "../views//active_users_aggregates.view.lkml"
 include: "/shared/views/countries.view.lkml"
 include: "/firefox_desktop/views/key_tentpole_dates.view.lkml"
+include: "//looker-hub/combined_browser_metrics/datagroups/active_users_aggregates_last_updated.datagroup.lkml"
 
 explore: active_users_aggregates {
   # persist_with: active_users_aggregates_v1_last_updated
@@ -35,5 +36,7 @@ explore: active_users_aggregates {
       increment_offset: 1
     }
   }
+
+  persist_with: active_users_aggregates_last_updated
 
 }

--- a/combined_browser_metrics/explores/active_users_aggregates_device.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates_device.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views//active_users_aggregates_device.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/combined_browser_metrics/datagroups/active_users_aggregates_device_last_updated.datagroup.lkml"
 
 explore: active_users_aggregates_device {
   always_filter: {
@@ -14,4 +15,5 @@ explore: active_users_aggregates_device {
     sql_on: ${active_users_aggregates_device.country} = ${countries.code} ;;
   }
 
+  persist_with: active_users_aggregates_device_last_updated
 }

--- a/combined_browser_metrics/explores/use_counters.explore.lkml
+++ b/combined_browser_metrics/explores/use_counters.explore.lkml
@@ -1,5 +1,7 @@
 include: "../views/use_counters.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/combined_browser_metrics/datagroups/fenix_and_firefox_use_counters_last_updated.datagroup.lkml"
+
 
 explore: fenix_and_firefox_use_counters {
   view_name: fenix_and_firefox_use_counters
@@ -10,4 +12,5 @@ explore: fenix_and_firefox_use_counters {
     sql_on: ${fenix_and_firefox_use_counters.country} = ${countries.code} ;;
   }
 
+  persist_with: fenix_and_firefox_use_counters_last_updated
 }

--- a/combined_browser_metrics/explores/user_retention.explore.lkml
+++ b/combined_browser_metrics/explores/user_retention.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views//cohort_daily_statistics.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/combined_browser_metrics/datagroups/cohort_daily_statistics_last_updated.datagroup.lkml"
 
 explore: user_retention {
   view_name: cohort_daily_statistics
@@ -14,4 +15,5 @@ explore: user_retention {
     sql_on: ${cohort_daily_statistics.country} = ${countries.code} ;;
   }
 
+  persist_with: cohort_daily_statistics_last_updated
 }

--- a/combined_browser_metrics/explores/user_retention_weekly.explore.lkml
+++ b/combined_browser_metrics/explores/user_retention_weekly.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/cohort_weekly_statistics.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/combined_browser_metrics/datagroups/cohort_weekly_statistics_last_updated.datagroup.lkml"
 
 explore: user_retention_weekly {
   view_name: cohort_weekly_statistics
@@ -9,4 +10,6 @@ explore: user_retention_weekly {
     relationship: one_to_one
     sql_on: ${cohort_weekly_statistics.country} = ${countries.code} ;;
   }
+
+  persist_with: cohort_weekly_statistics_last_updated
 }

--- a/contextual_services/explores/sponsored_tiles_ad_request_fill.explore.lkml
+++ b/contextual_services/explores/sponsored_tiles_ad_request_fill.explore.lkml
@@ -1,4 +1,5 @@
 include: "/contextual_services/views/sponsored_tiles_ad_request_fill.view.lkml"
+include: "//looker-hub/contextual_services/datagroups/sponsored_tiles_ad_request_fill_last_updated.datagroup.lkml"
 
 explore: sponsored_tiles_ad_request_fill {
 
@@ -12,4 +13,5 @@ explore: sponsored_tiles_ad_request_fill {
   #   ]
   # }
 
+  persist_with: sponsored_tiles_ad_request_fill_last_updated
 }

--- a/fenix/explores/android_awesomebar_location_metrics.explore.lkml
+++ b/fenix/explores/android_awesomebar_location_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_awesomebar_location_metrics.view.lkml"
+include: "//looker-hub/fenix/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: fenix_android_awesomebar_location_metrics {
   label: "Awesomebar Location Metric for Android"
   view_name: android_awesomebar_location_metrics
+  persist_with: metrics_last_updated
 }

--- a/fenix/explores/android_bookmark_events.explore.lkml
+++ b/fenix/explores/android_bookmark_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_bookmark_events.view.lkml"
+include: "//looker-hub/fenix/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: fenix_android_bookmark_events {
   label: "Bookmark Event for Android"
   view_name: android_bookmark_events
+  persist_with: events_unnested_last_updated
 }

--- a/fenix/explores/android_bookmark_metrics.explore.lkml
+++ b/fenix/explores/android_bookmark_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_bookmark_metrics.view.lkml"
+include: "//looker-hub/fenix/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: fenix_android_bookmark_metrics {
   label: "Bookmark Metric for Android"
   view_name: android_bookmark_metrics
+  persist_with: metrics_last_updated
 }

--- a/fenix/explores/android_credential_management_events.explore.lkml
+++ b/fenix/explores/android_credential_management_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_credential_management_events.view.lkml"
+include: "//looker-hub/fenix/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: fenix_android_credential_management_events {
   label: "Credential Management Event for Android"
   view_name: android_credential_management_events
+  persist_with: events_unnested_last_updated
 }

--- a/fenix/explores/android_credential_management_metric.explore.lkml
+++ b/fenix/explores/android_credential_management_metric.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_credential_management_metrics.view.lkml"
+include: "//looker-hub/fenix/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: fenix_android_credential_management_metrics {
   label: "Credential Management Metric for Android"
   view_name: android_credential_management_metrics
+  persist_with: metrics_last_updated
 }

--- a/fenix/explores/android_customize_home_events.explore.lkml
+++ b/fenix/explores/android_customize_home_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_customize_home_events.view.lkml"
+include: "//looker-hub/fenix/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: fenix_android_customize_home_events {
   label: "Customize Home Event for Android"
   view_name: android_customize_home_events
+  persist_with: events_unnested_last_updated
 }

--- a/fenix/explores/android_customize_home_metrics.explore.lkml
+++ b/fenix/explores/android_customize_home_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_customize_home_metrics.view.lkml"
+include: "//looker-hub/fenix/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: fenix_android_customize_home_metrics {
   label: "Customize Home Metric for Android"
   view_name: android_customize_home_metrics
+  persist_with: metrics_last_updated
 }

--- a/fenix/explores/android_default_browser_events.explore.lkml
+++ b/fenix/explores/android_default_browser_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_default_browser_events.view.lkml"
+include: "//looker-hub/fenix/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: fenix_android_default_browser_events {
   label: "Default Browser Event for Android"
   view_name: android_default_browser_events
+  persist_with: events_unnested_last_updated
 }

--- a/fenix/explores/android_default_browser_metrics.explore.lkml
+++ b/fenix/explores/android_default_browser_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_default_browser_metrics.view.lkml"
+include: "//looker-hub/fenix/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: fenix_android_default_browser_metrics {
   label: "Default Browser Metric for Android"
   view_name: android_default_browser_metrics
+  persist_with: metrics_last_updated
 }

--- a/fenix/explores/android_fxa_events.explore.lkml
+++ b/fenix/explores/android_fxa_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_fxa_events.view.lkml"
+include: "//looker-hub/fenix/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: fenix_android_fxa_events {
   label: "Fxa Event for Android"
   view_name: android_fxa_events
+  persist_with: events_unnested_last_updated
 }

--- a/fenix/explores/android_history_events.explore.lkml
+++ b/fenix/explores/android_history_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_history_events.view.lkml"
+include: "//looker-hub/fenix/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: fenix_android_history_events {
   label: "History Event for Android"
   view_name: android_history_events
+  persist_with: events_unnested_last_updated
 }

--- a/fenix/explores/android_notification_events.explore.lkml
+++ b/fenix/explores/android_notification_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_notification_events.view.lkml"
+include: "//looker-hub/fenix/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: fenix_android_notification_events {
   label: "Notification Event for Android"
   view_name: android_notification_events
+  persist_with: events_unnested_last_updated
 }

--- a/fenix/explores/android_notification_metrics.explore.lkml
+++ b/fenix/explores/android_notification_metrics.explore.lkml
@@ -1,6 +1,9 @@
 include: "../views/android_notification_metrics.view.lkml"
+include: "//looker-hub/fenix/datagroups/metrics_last_updated.datagroup.lkml"
+
 
 explore: fenix_android_notification_metrics {
   label: "Notification Metric for Android"
   view_name: android_notification_metrics
+  persist_with: metrics_last_updated
 }

--- a/fenix/explores/android_onboarding.explore.lkml
+++ b/fenix/explores/android_onboarding.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_onboarding.view.lkml"
+include: "//looker-hub/fenix/datagroups/android_onboarding_last_updated.datagroup.lkml"
 
 explore: android_onboarding {
   label: "Android Onboarding Funnel"
   view_name: android_onboarding
+  persist_with: android_onboarding_last_updated
 }

--- a/fenix/explores/android_privacy_events.explore.lkml
+++ b/fenix/explores/android_privacy_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_privacy_events.view.lkml"
+include: "//looker-hub/fenix/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: fenix_android_privacy_metric {
   label: "Privacy Event for Android"
   view_name: android_privacy_events
+  persist_with: events_unnested_last_updated
 }

--- a/fenix/explores/android_tab_count_metrics.explore.lkml
+++ b/fenix/explores/android_tab_count_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/android_tab_count_metrics.view.lkml"
+include: "//looker-hub/fenix/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: fenix_android_tab_count_metrics {
   label: "Tab Count Metric for Android"
   view_name: android_tab_count_metrics
+  persist_with: metrics_last_updated
 }

--- a/fenix/explores/feature_usage_events.explore.lkml
+++ b/fenix/explores/feature_usage_events.explore.lkml
@@ -1,5 +1,6 @@
 include: "//looker-hub/fenix/explores/feature_usage_events.explore.lkml"
 include: "../views/feature_usage_events.view.lkml"
+include: "//looker-hub/fenix/datagroups/feature_usage_events_last_updated.datagroup.lkml"
 
 explore: +feature_usage_events {
   from: feature_usage_events
@@ -13,4 +14,5 @@ explore: +feature_usage_events {
     ]
   }
 
+  persist_with: feature_usage_events_last_updated
 }

--- a/fenix/explores/fenix_feature_usage_events.explore.lkml
+++ b/fenix/explores/fenix_feature_usage_events.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/fenix_feature_usage_events.view.lkml"
 include: "../views/fenix_dau.view.lkml"
+include: "//looker-hub/fenix/datagroups/feature_usage_events_last_updated.datagroup.lkml"
 
 explore: fenix_feature_usage_events {
 
@@ -18,4 +19,6 @@ explore: fenix_feature_usage_events {
       submission_date: "28 days",
     ]
   }
+
+  persist_with: feature_usage_events_last_updated
 }

--- a/fenix/explores/fenix_feature_usage_metrics.explore.lkml
+++ b/fenix/explores/fenix_feature_usage_metrics.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/fenix_feature_usage_metrics.view.lkml"
 include: "../views/fenix_dau.view.lkml"
+include: "//looker-hub/fenix/datagroups/feature_usage_metrics_last_updated.datagroup.lkml"
 
 explore: fenix_feature_usage_metrics {
 
@@ -12,4 +13,6 @@ explore: fenix_feature_usage_metrics {
     relationship: one_to_one
     sql_on: ${fenix_feature_usage_metrics.ping_date} = ${fenix_dau.submission_date} ;;
   }
+
+  persist_with: feature_usage_metrics_last_updated
 }

--- a/fenix/explores/firefox_android_clients.explore.lkml
+++ b/fenix/explores/firefox_android_clients.explore.lkml
@@ -1,4 +1,5 @@
 include: "../views/firefox_android_clients.view.lkml"
+include: "//looker-hub/fenix/datagroups/firefox_android_clients_last_updated.datagroup.lkml"
 
 explore: firefox_android_clients {
   sql_always_where: ${firefox_android_clients.first_seen_date} >= '2010-01-01' ;;
@@ -18,4 +19,6 @@ explore: firefox_android_clients {
     filters: [firefox_android_clients.first_seen_month: "6 month ago for 6 month", firefox_android_clients.channel: "release"]
     limit: 100
   }
+
+  persist_with: firefox_android_clients_last_updated
 }

--- a/fenix/explores/funnel_retention_week_4.explore.lkml
+++ b/fenix/explores/funnel_retention_week_4.explore.lkml
@@ -1,5 +1,7 @@
 include: "../views/new_retention_view_for_acquisition_funnel.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/fenix/datagroups/funnel_retention_week_4_table_last_updated.datagroup.lkml"
+
 
 explore: funnel_retention_week_4 {
   label: "Acquisition Funnel for Firefox Android"
@@ -16,4 +18,6 @@ explore: funnel_retention_week_4 {
     relationship: one_to_one
     sql_on: ${new_retention_view_for_acquisition_funnel.country} = ${countries.code} ;;
   }
+
+  persist_with: funnel_retention_week_4_table_last_updated
 }

--- a/fenix/explores/new_profile_activation.explore.lkml
+++ b/fenix/explores/new_profile_activation.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/new_profile_activation_table.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/fenix/datagroups/new_profile_activation_table_last_updated.datagroup.lkml"
 
 explore: fenix_new_profile_activation {
   label: "Activation Metric for Firefox for Android (Fenix)"
@@ -14,4 +15,6 @@ explore: fenix_new_profile_activation {
     relationship: one_to_one
     sql_on: ${new_profile_activation_table.country} = ${countries.code} ;;
   }
+
+  persist_with: new_profile_activation_table_last_updated
 }

--- a/firefox_desktop/explores/sponsored_tiles_clients_daily.explore.lkml
+++ b/firefox_desktop/explores/sponsored_tiles_clients_daily.explore.lkml
@@ -1,4 +1,5 @@
 include: "/firefox_desktop/views/sponsored_tiles_clients_daily.view.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/sponsored_tiles_clients_daily_last_updated.datagroup.lkml"
 
 explore: sponsored_tiles_clients_daily {
   view_name: sponsored_tiles_clients_daily
@@ -7,4 +8,6 @@ explore: sponsored_tiles_clients_daily {
     filters: [sponsored_tiles_clients_daily.submission_date: "28 days"
       ]
   }
+
+  persist_with: sponsored_tiles_clients_daily_last_updated
 }

--- a/firefox_desktop/explores/suggest_clients_daily.explore.lkml
+++ b/firefox_desktop/explores/suggest_clients_daily.explore.lkml
@@ -1,4 +1,5 @@
 include: "/firefox_desktop/views/suggest_clients_daily.view.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/suggest_clients_daily_last_updated.datagroup.lkml"
 
 explore: suggest_clients_daily {
   view_name: suggest_clients_daily
@@ -7,4 +8,6 @@ explore: suggest_clients_daily {
     filters: [suggest_clients_daily.submission_date: "28 days"
       ]
   }
+
+  persist_with: suggest_clients_daily_last_updated
 }

--- a/firefox_ios/explores/firefox_ios_clients.explore.lkml
+++ b/firefox_ios/explores/firefox_ios_clients.explore.lkml
@@ -1,4 +1,5 @@
 include: "../views/firefox_ios_clients.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/firefox_ios_clients_last_updated.datagroup.lkml"
 
 explore: firefox_ios_clients {
   sql_always_where: ${firefox_ios_clients.first_seen_date} >= '2010-01-01' ;;
@@ -18,4 +19,6 @@ explore: firefox_ios_clients {
     filters: [firefox_ios_clients.first_seen_month: "6 month ago for 6 month", firefox_ios_clients.channel: "release"]
     limit: 100
   }
+
+  persist_with: firefox_ios_clients_last_updated
 }

--- a/firefox_ios/explores/firefox_ios_feature_usage_events.explore.lkml
+++ b/firefox_ios/explores/firefox_ios_feature_usage_events.explore.lkml
@@ -1,6 +1,6 @@
 include: "../views/firefox_ios_feature_usage_events.view.lkml"
 include: "../views/firefox_ios_dau.view.lkml"
-
+include: "//looker-hub/firefox_ios/datagroups/feature_usage_events_last_updated.datagroup.lkml"
 
 explore: firefox_ios_feature_usage_events {
 
@@ -15,4 +15,6 @@ explore: firefox_ios_feature_usage_events {
     relationship: one_to_one
     sql_on: ${firefox_ios_feature_usage_events.ping_date} = ${firefox_ios_dau.submission_date};;
   }
+
+  persist_with: feature_usage_events_last_updated
 }

--- a/firefox_ios/explores/firefox_ios_feature_usage_events_not_added.explore.lkml
+++ b/firefox_ios/explores/firefox_ios_feature_usage_events_not_added.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/firefox_ios_feature_usage_events_not_added.view.lkml"
 include: "../views/firefox_ios_dau.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: firefox_ios_feature_usage_events_not_added {
   sql_always_where: ${firefox_ios_dau.submission_date} >= '2023-06-01'
@@ -18,4 +19,6 @@ explore: firefox_ios_feature_usage_events_not_added {
     relationship: one_to_one
     sql_on: ${firefox_ios_feature_usage_events_not_added.submission_date} = ${firefox_ios_dau.submission_date} ;;
   }
+
+  persist_with: events_unnested_last_updated
 }

--- a/firefox_ios/explores/firefox_ios_feature_usage_metrics.explore.lkml
+++ b/firefox_ios/explores/firefox_ios_feature_usage_metrics.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/firefox_ios_feature_usage_metrics.view.lkml"
 include: "../views/firefox_ios_dau.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/feature_usage_metrics_last_updated.datagroup.lkml"
 
 explore: firefox_ios_feature_usage_metrics {
 
@@ -13,4 +14,6 @@ explore: firefox_ios_feature_usage_metrics {
     relationship: one_to_one
     sql_on: ${firefox_ios_feature_usage_metrics.ping_date} = ${firefox_ios_dau.submission_date};;
   }
+
+  persist_with: feature_usage_metrics_last_updated
 }

--- a/firefox_ios/explores/firefox_ios_feature_usage_metrics_not_added.explore.lkml
+++ b/firefox_ios/explores/firefox_ios_feature_usage_metrics_not_added.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/firefox_ios_feature_usage_metrics_not_added.view.lkml"
 include: "../views/firefox_ios_dau.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: firefox_ios_feature_usage_metrics_not_added {
   sql_always_where: ${firefox_ios_dau.submission_date} >= '2023-06-01'
@@ -18,4 +19,6 @@ explore: firefox_ios_feature_usage_metrics_not_added {
     relationship: one_to_one
     sql_on: ${firefox_ios_feature_usage_metrics_not_added.submission_date} = ${firefox_ios_dau.submission_date} ;;
   }
+
+  persist_with: metrics_last_updated
 }

--- a/firefox_ios/explores/funnel_retention_week_4.explore.lkml
+++ b/firefox_ios/explores/funnel_retention_week_4.explore.lkml
@@ -1,5 +1,6 @@
 include: "/fenix/views/new_retention_view_for_acquisition_funnel.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/funnel_retention_week_4_table_last_updated.datagroup.lkml"
 
 explore: funnel_retention_week_4 {
   label: "Acquisition Funnel for Firefox iOS"
@@ -15,4 +16,6 @@ explore: funnel_retention_week_4 {
       relationship: one_to_one
       sql_on: ${new_retention_view_for_acquisition_funnel.country} = ${countries.code} ;;
     }
+
+    persist_with: funnel_retention_week_4_table_last_updated
   }

--- a/firefox_ios/explores/ios_awesomebar_location_events.explore.lkml
+++ b/firefox_ios/explores/ios_awesomebar_location_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_awesomebar_location_events.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: ios_awesomebar_location_events {
   label: "Awesomebar Location Event for iOS"
   view_name: ios_awesomebar_location_events
+  persist_with: events_unnested_last_updated
 }

--- a/firefox_ios/explores/ios_bookmark_metrics.explore.lkml
+++ b/firefox_ios/explores/ios_bookmark_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_bookmark_metrics.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: ios_bookmark_metrics {
   label: "Bookmark Metric for iOS"
   view_name: ios_bookmark_metrics
+  persist_with: metrics_last_updated
 }

--- a/firefox_ios/explores/ios_credit_card_events.explore.lkml
+++ b/firefox_ios/explores/ios_credit_card_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_credit_card_events.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: ios_credit_card_events {
   label: "Credit Card Event for iOS"
   view_name: ios_credit_card_events
+  persist_with: events_unnested_last_updated
 }

--- a/firefox_ios/explores/ios_credit_card_metrics.explore.lkml
+++ b/firefox_ios/explores/ios_credit_card_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_credit_card_metrics.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: ios_credit_card_metrics {
   label: "Credit Card Metric for iOS"
   view_name: ios_credit_card_metrics
+  persist_with: metrics_last_updated
 }

--- a/firefox_ios/explores/ios_customize_home_metrics.explore.lkml
+++ b/firefox_ios/explores/ios_customize_home_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_customize_home_metrics.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: ios_customize_home_metrics {
   label: "Customize Home Metric for iOS"
   view_name: ios_customize_home_metrics
+  persist_with: metrics_last_updated
 }

--- a/firefox_ios/explores/ios_default_browser_metrics.explore.lkml
+++ b/firefox_ios/explores/ios_default_browser_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_default_browser_metrics.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: ios_default_browser_metrics {
   label: "Default Browser Metric for iOS"
   view_name: ios_default_browser_metrics
+  persist_with: metrics_last_updated
 }

--- a/firefox_ios/explores/ios_fxa_events.explore.lkml
+++ b/firefox_ios/explores/ios_fxa_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_fxa_events.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: ios_fxa_events {
   label: "FxA Event for iOS"
   view_name: ios_fxa_events
+  persist_with: events_unnested_last_updated
 }

--- a/firefox_ios/explores/ios_fxa_metrics.explore.lkml
+++ b/firefox_ios/explores/ios_fxa_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_fxa_metrics.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: ios_fxa_metrics {
   label: "FxA Metric for iOS"
   view_name: ios_fxa_metrics
+  persist_with: metrics_last_updated
 }

--- a/firefox_ios/explores/ios_history_events.explore.lkml
+++ b/firefox_ios/explores/ios_history_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_history_events.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: ios_history_events {
   label: "History Event for iOS"
   view_name: ios_history_events
+  persist_with: events_unnested_last_updated
 }

--- a/firefox_ios/explores/ios_notification_events.explore.lkml
+++ b/firefox_ios/explores/ios_notification_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_notification_events.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: ios_notification_events {
   label: "Notification Event for iOS"
   view_name: ios_notification_events
+  persist_with: events_unnested_last_updated
 }

--- a/firefox_ios/explores/ios_notification_metrics.explore.lkml
+++ b/firefox_ios/explores/ios_notification_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_notification_metrics.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: ios_notification_metrics {
   label: "notification Metric for iOS"
   view_name: ios_notification_metrics
+  persist_with: metrics_last_updated
 }

--- a/firefox_ios/explores/ios_privacy_events.explore.lkml
+++ b/firefox_ios/explores/ios_privacy_events.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_privacy_events.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/events_unnested_last_updated.datagroup.lkml"
 
 explore: ios_privacy_events {
   label: "Privacy Event for iOS"
   view_name: ios_privacy_events
+  persist_with: events_unnested_last_updated
 }

--- a/firefox_ios/explores/ios_privacy_metrics.explore.lkml
+++ b/firefox_ios/explores/ios_privacy_metrics.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_privacy_metrics.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: ios_privacy_metrics {
   label: "Privacy Metric for iOS"
   view_name: ios_privacy_metrics
+  persist_with: metrics_last_updated
 }

--- a/firefox_ios/explores/ios_tab_count_metric.explore.lkml
+++ b/firefox_ios/explores/ios_tab_count_metric.explore.lkml
@@ -1,6 +1,8 @@
 include: "../views/ios_tab_count_metrics.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/metrics_last_updated.datagroup.lkml"
 
 explore: ios_tab_count_metrics {
   label: "Tab Count Metric for iOS"
   view_name: ios_tab_count_metrics
+  persist_with: metrics_last_updated
 }

--- a/firefox_ios/explores/new_profile_activation.explore.lkml
+++ b/firefox_ios/explores/new_profile_activation.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/new_profile_activation_table.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/firefox_ios/datagroups/new_profile_activation_table_last_updated.datagroup.lkml"
 
 explore: firefox_ios_new_profile_activation {
   label: "Activation Metric for Firefox for iOS"
@@ -14,4 +15,6 @@ explore: firefox_ios_new_profile_activation {
     relationship: one_to_one
     sql_on: ${new_profile_activation_table.country} = ${countries.code} ;;
   }
+
+  persist_with: new_profile_activation_table_last_updated
 }

--- a/firefox_metrics/explores/desktop_engagement.explore.lkml
+++ b/firefox_metrics/explores/desktop_engagement.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/desktop_engagement.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/firefox_okrs/datagroups/desktop_engagement_last_updated.datagroup.lkml"
 
 explore: desktop_engagement {
   label: "Engagement for Firefox Desktop"
@@ -17,4 +18,6 @@ explore: desktop_engagement {
     relationship: one_to_one
     sql_on: ${desktop_engagement.country} = ${countries.code} ;;
   }
+
+  persist_with: desktop_engagement_last_updated
 }

--- a/firefox_metrics/explores/desktop_new_profiles.explore.lkml
+++ b/firefox_metrics/explores/desktop_new_profiles.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/desktop_new_profiles.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/desktop_new_profiles_last_updated.datagroup.lkml"
 
 explore: desktop_new_profiles {
   label: "New profiles for Firefox Desktop"
@@ -17,4 +18,6 @@ explore: desktop_new_profiles {
     relationship: one_to_one
     sql_on: ${desktop_new_profiles.country} = ${countries.code} ;;
   }
+
+  persist_with: desktop_new_profiles_last_updated
 }

--- a/firefox_metrics/explores/desktop_retention.explore.lkml
+++ b/firefox_metrics/explores/desktop_retention.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/desktop_retention.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/firefox_okrs/datagroups/desktop_retention_last_updated.datagroup.lkml"
 
 explore: desktop_retention {
   label: "Retention for Firefox Desktop"
@@ -17,4 +18,6 @@ explore: desktop_retention {
     relationship: one_to_one
     sql_on: ${desktop_retention.country} = ${countries.code} ;;
   }
+
+  persist_with: desktop_retention_last_updated
 }

--- a/firefox_metrics/explores/mobile_engagement.explore.lkml
+++ b/firefox_metrics/explores/mobile_engagement.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/mobile_engagement.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/firefox_okrs/datagroups/mobile_engagement_last_updated.datagroup.lkml"
 
 explore: mobile_engagement {
   label: "Engagement for Firefox Mobile"
@@ -17,4 +18,6 @@ explore: mobile_engagement {
     relationship: one_to_one
     sql_on: ${mobile_engagement.country} = ${countries.code} ;;
   }
+
+  persist_with: mobile_engagement_last_updated
 }

--- a/firefox_metrics/explores/mobile_new_profiles.explore.lkml
+++ b/firefox_metrics/explores/mobile_new_profiles.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/mobile_new_profiles.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/firefox_okrs/datagroups/mobile_new_profiles_last_updated.datagroup.lkml"
 
 explore: mobile_new_profiles {
   label: "New profiles for Firefox Mobile"
@@ -17,4 +18,6 @@ explore: mobile_new_profiles {
     relationship: one_to_one
     sql_on: ${mobile_new_profiles.country} = ${countries.code} ;;
   }
+
+  persist_with: mobile_new_profiles_last_updated
 }

--- a/firefox_metrics/explores/mobile_retention.explore.lkml
+++ b/firefox_metrics/explores/mobile_retention.explore.lkml
@@ -1,5 +1,6 @@
 include: "../views/mobile_retention.view.lkml"
 include: "/shared/views/countries.view.lkml"
+include: "//looker-hub/firefox_okrs/datagroups/mobile_retention_last_updated.datagroup.lkml"
 
 explore: mobile_retention {
   label: "Retention for Firefox Mobile"
@@ -17,4 +18,6 @@ explore: mobile_retention {
     relationship: one_to_one
     sql_on: ${mobile_retention.country} = ${countries.code} ;;
   }
+
+  persist_with: mobile_retention_last_updated
 }


### PR DESCRIPTION
Datagroups are now automatically generated for underlying tables and views. We can use those to cache results for explores by specifying datagroups as `persist_with`. I persisted a few explores that are frequently used as part of this PR

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
