### PR TITLE
Cumulative crash counts

### DIFF
--- a/experimentation/dashboards/experiment_enrollments.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments.dashboard.lookml
@@ -555,6 +555,15 @@
       events.sample_id: '0'
     sorts: [events.event_count desc]
     limit: 500
+    dynamic_fields:
+    - category: table_calculation
+      expression: "${events.event_count} * 100"
+      label: Approximate Event Count
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: approx_count
+      _type_hint: number
     column_limit: 50
     show_view_names: false
     show_row_numbers: true
@@ -598,6 +607,9 @@
     totals_color: "#808080"
     defaults_version: 1
     y_axes: []
+    note_state: expanded
+    note_display: above
+    note_text: Event counts are *approximate* due to sampling (1% sample).
     listen:
       Time Range [UTC]: events.submission_date
       Experiment: events.event_string_value
@@ -793,7 +805,7 @@
     fields: [error_count]
     filters:
       logs.timestamp_date: 3 days
-      logs.exception_type: "-EndedException,-NoEnrollmentPeriodException,-HighPopulationException,-EnrollmentLongerThanAnalysisException,-ExplicitSkipException,-NoStartDateException"
+      logs.exception_type: "-EndedException,-NoEnrollmentPeriodException,-HighPopulationException,-EnrollmentLongerThanAnalysisException,-ExplicitSkipException,-NoStartDateException,-EnrollmentNotCompleteException"
       logs.log_level: ERROR
       logs.message: "-%Error while computing statistic%"
     limit: 500
@@ -832,8 +844,7 @@
       experiment_enrollment_overall.time_date]
     pivots: [experiment_enrollment_overall.branch]
     fill_fields: [experiment_enrollment_overall.time_date]
-    filters:
-      experiment_enrollment_overall.timeframe: 28 days
+    filters: {}
     sorts: [experiment_enrollment_overall.branch, experiment_enrollment_overall.time_date
         desc]
     limit: 5000
@@ -880,6 +891,7 @@
     note_display: above
     note_text: Updated daily
     listen:
+      Time Range [UTC]: experiment_enrollment_overall.timeframe
       Experiment: experiment_enrollment_overall.experiment
     row: 25
     col: 12
@@ -892,8 +904,7 @@
     type: looker_column
     fields: [experiment_enrollment_overall.Total, experiment_enrollment_overall.time_date]
     fill_fields: [experiment_enrollment_overall.time_date]
-    filters:
-      experiment_enrollment_overall.timeframe: 28 days
+    filters: {}
     sorts: [experiment_enrollment_overall.time_date desc]
     limit: 5000
     column_limit: 50
@@ -934,6 +945,7 @@
     note_display: above
     note_text: Updated daily
     listen:
+      Time Range [UTC]: experiment_enrollment_overall.timeframe
       Experiment: experiment_enrollment_overall.experiment
     row: 25
     col: 0

--- a/experimentation/dashboards/experiment_enrollments.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments.dashboard.lookml
@@ -554,15 +554,6 @@
     filters:
       events.sample_id: '0'
     sorts: [events.event_count desc]
-    dynamic_fields:
-    - category: table_calculation
-      expression: "${events.event_count} * 100"
-      label: Approximate Event Count
-      value_format:
-      value_format_name:
-      _kind_hint: measure
-      table_calculation: approx_count
-      _type_hint: number
     limit: 500
     column_limit: 50
     show_view_names: false
@@ -607,9 +598,6 @@
     totals_color: "#808080"
     defaults_version: 1
     y_axes: []
-    note_state: expanded
-    note_display: above
-    note_text: Event counts are *approximate* due to sampling (1% sample).
     listen:
       Time Range [UTC]: events.submission_date
       Experiment: events.event_string_value
@@ -805,7 +793,7 @@
     fields: [error_count]
     filters:
       logs.timestamp_date: 3 days
-      logs.exception_type: "-EndedException,-NoEnrollmentPeriodException,-HighPopulationException,-EnrollmentLongerThanAnalysisException,-ExplicitSkipException,-NoStartDateException,-EnrollmentNotCompleteException"
+      logs.exception_type: "-EndedException,-NoEnrollmentPeriodException,-HighPopulationException,-EnrollmentLongerThanAnalysisException,-ExplicitSkipException,-NoStartDateException"
       logs.log_level: ERROR
       logs.message: "-%Error while computing statistic%"
     limit: 500
@@ -844,7 +832,8 @@
       experiment_enrollment_overall.time_date]
     pivots: [experiment_enrollment_overall.branch]
     fill_fields: [experiment_enrollment_overall.time_date]
-    filters: {}
+    filters:
+      experiment_enrollment_overall.timeframe: 28 days
     sorts: [experiment_enrollment_overall.branch, experiment_enrollment_overall.time_date
         desc]
     limit: 5000
@@ -891,7 +880,6 @@
     note_display: above
     note_text: Updated daily
     listen:
-      Time Range [UTC]: experiment_enrollment_overall.timeframe
       Experiment: experiment_enrollment_overall.experiment
     row: 25
     col: 12
@@ -904,7 +892,8 @@
     type: looker_column
     fields: [experiment_enrollment_overall.Total, experiment_enrollment_overall.time_date]
     fill_fields: [experiment_enrollment_overall.time_date]
-    filters: {}
+    filters:
+      experiment_enrollment_overall.timeframe: 28 days
     sorts: [experiment_enrollment_overall.time_date desc]
     limit: 5000
     column_limit: 50
@@ -945,142 +934,8 @@
     note_display: above
     note_text: Updated daily
     listen:
-      Time Range [UTC]: experiment_enrollment_overall.timeframe
       Experiment: experiment_enrollment_overall.experiment
     row: 25
-    col: 0
-    width: 12
-    height: 7
-  - title: Crash Counts by Branch
-    name: Crash Counts by Branch
-    model: experimentation
-    explore: experiment_crash_rates
-    type: looker_column
-    fields: [sum_of_crash_count, experiment_crash_rates.branch, experiment_crash_rates.window_start_time]
-    pivots: [experiment_crash_rates.branch]
-    filters: {}
-    sorts: [experiment_crash_rates.branch, experiment_crash_rates.window_start_time
-        desc]
-    limit: 5000
-    column_limit: 50
-    dynamic_fields:
-    - _kind_hint: measure
-      _type_hint: number
-      based_on: experiment_crash_rates.crash_count
-      expression: ''
-      label: Sum of Crash Count
-      measure: sum_of_crash_count
-      type: sum
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    y_axes: [{label: Total, orientation: left, series: [{axisId: sum_of_crash_count,
-            id: change-non-user - sum_of_crash_count, name: change-non-user}, {axisId: sum_of_crash_count,
-            id: no-change-non-user - sum_of_crash_count, name: no-change-non-user}],
-        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
-        tickDensityCustom: 5, type: linear}]
-    x_axis_label: Time [UTC]
-    x_axis_zoom: true
-    y_axis_zoom: true
-    hidden_pivots: {}
-    show_null_points: true
-    interpolation: linear
-    defaults_version: 1
-    listen:
-      Time Range [UTC]: experiment_crash_rates.window_start_date
-      Experiment: experiment_crash_rates.experiment
-    row: 84
-    col: 12
-    width: 12
-    height: 7
-  - title: Crash Counts By Process Type
-    name: Crash Counts By Process Type
-    model: experimentation
-    explore: experiment_crash_rates
-    type: looker_line
-    fields: [sum_of_crash_count, experiment_crash_rates.crash_process_type, experiment_crash_rates.window_start_time]
-    pivots: [experiment_crash_rates.crash_process_type]
-    filters: {}
-    sorts: [experiment_crash_rates.crash_process_type, experiment_crash_rates.window_start_time
-        desc]
-    limit: 5000
-    column_limit: 50
-    dynamic_fields:
-    - _kind_hint: measure
-      _type_hint: number
-      based_on: experiment_crash_rates.crash_count
-      expression: ''
-      label: Sum of Crash Count
-      measure: sum_of_crash_count
-      type: sum
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    show_null_points: true
-    interpolation: linear
-    y_axes: [{label: Total, orientation: left, series: [{axisId: sum_of_crash_count,
-            id: content - sum_of_crash_count, name: content}, {axisId: sum_of_crash_count,
-            id: gpu - sum_of_crash_count, name: gpu}, {axisId: sum_of_crash_count,
-            id: main - sum_of_crash_count, name: main}, {axisId: sum_of_crash_count,
-            id: rdd - sum_of_crash_count, name: rdd}], showLabels: true, showValues: true,
-        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
-    x_axis_label: Time [UTC]
-    x_axis_zoom: true
-    y_axis_zoom: true
-    hidden_pivots: {}
-    defaults_version: 1
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    listen:
-      Time Range [UTC]: experiment_crash_rates.window_start_date
-      Experiment: experiment_crash_rates.experiment
-    row: 91
     col: 0
     width: 12
     height: 7
@@ -1094,69 +949,6 @@
     col: 0
     width: 24
     height: 2
-  - title: Crash Counts
-    name: Crash Counts
-    model: experimentation
-    explore: experiment_crash_rates
-    type: looker_column
-    fields: [sum_of_crash_count, experiment_crash_rates.window_start_time]
-    filters: {}
-    sorts: [experiment_crash_rates.window_start_time desc]
-    limit: 5000
-    column_limit: 50
-    dynamic_fields:
-    - _kind_hint: measure
-      _type_hint: number
-      based_on: experiment_crash_rates.crash_count
-      expression: ''
-      label: Sum of Crash Count
-      measure: sum_of_crash_count
-      type: sum
-    x_axis_gridlines: false
-    y_axis_gridlines: true
-    show_view_names: false
-    show_y_axis_labels: true
-    show_y_axis_ticks: true
-    y_axis_tick_density: default
-    y_axis_tick_density_custom: 5
-    show_x_axis_label: true
-    show_x_axis_ticks: true
-    y_axis_scale_mode: linear
-    x_axis_reversed: false
-    y_axis_reversed: false
-    plot_size_by_field: false
-    trellis: ''
-    stacking: ''
-    limit_displayed_rows: false
-    legend_position: center
-    point_style: none
-    show_value_labels: false
-    label_density: 25
-    x_axis_scale: auto
-    y_axis_combined: true
-    ordering: none
-    show_null_labels: false
-    show_totals_labels: false
-    show_silhouette: false
-    totals_color: "#808080"
-    y_axes: [{label: Total, orientation: left, series: [{axisId: sum_of_crash_count,
-            id: sum_of_crash_count, name: Sum of Crash Count}], showLabels: true,
-        showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
-        type: linear}]
-    x_axis_label: Time [UTC]
-    x_axis_zoom: true
-    y_axis_zoom: true
-    hidden_pivots: {}
-    show_null_points: true
-    interpolation: linear
-    defaults_version: 1
-    listen:
-      Time Range [UTC]: experiment_crash_rates.window_start_date
-      Experiment: experiment_crash_rates.experiment
-    row: 84
-    col: 0
-    width: 12
-    height: 7
   - name: " (3)"
     type: text
     title_text: ''
@@ -1477,6 +1269,227 @@
       Experiment: experiment_cumulative_search_with_ads_count.experiment
     row: 75
     col: 12
+    width: 12
+    height: 7
+  - title: Cumulative Crash Counts
+    name: Cumulative Crash Counts
+    model: experimentation
+    explore: experiment_crash_rates
+    type: looker_line
+    fields: [sum_of_crash_count, experiment_crash_rates.window_start_time]
+    filters:
+      experiment_crash_rates.experiment: new-users-sidebar-genai
+      experiment_crash_rates.window_start_date: 28 days
+    sorts: [experiment_crash_rates.window_start_time]
+    limit: 5000
+    column_limit: 50
+    dynamic_fields:
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: experiment_crash_rates.crash_count
+      expression: ''
+      label: Sum of Crash Count
+      measure: sum_of_crash_count
+      type: sum
+    - category: table_calculation
+      expression: running_total(${sum_of_crash_count})
+      label: Cumulative Crash Count
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: cumulative_crash_count
+      _type_hint: number
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    y_axes: [{label: Total, orientation: left, series: [{axisId: sum_of_crash_count,
+            id: sum_of_crash_count, name: Sum of Crash Count}], showLabels: true,
+        showValues: true, unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
+        type: linear}]
+    x_axis_label: Time [UTC]
+    x_axis_zoom: true
+    y_axis_zoom: true
+    hidden_pivots: {}
+    defaults_version: 1
+    hidden_fields: [sum_of_crash_count]
+    listen: {}
+    row: 84
+    col: 0
+    width: 12
+    height: 7
+  - title: Cumulative Crash Counts by Branch
+    name: Cumulative Crash Counts by Branch
+    model: experimentation
+    explore: experiment_crash_rates
+    type: looker_line
+    fields: [sum_of_crash_count, experiment_crash_rates.branch, experiment_crash_rates.window_start_time]
+    pivots: [experiment_crash_rates.branch]
+    filters:
+      experiment_crash_rates.experiment: new-users-sidebar-genai
+      experiment_crash_rates.window_start_date: 28 days
+    sorts: [experiment_crash_rates.branch, experiment_crash_rates.window_start_time]
+    limit: 5000
+    column_limit: 50
+    dynamic_fields:
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: experiment_crash_rates.crash_count
+      expression: ''
+      label: Sum of Crash Count
+      measure: sum_of_crash_count
+      type: sum
+    - category: table_calculation
+      expression: running_total(${sum_of_crash_count})
+      label: Cumulative Crash Counts
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: cumulative_crash_counts
+      _type_hint: number
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    y_axes: [{label: Total, orientation: left, series: [{axisId: sum_of_crash_count,
+            id: change-non-user - sum_of_crash_count, name: change-non-user}, {axisId: sum_of_crash_count,
+            id: no-change-non-user - sum_of_crash_count, name: no-change-non-user}],
+        showLabels: true, showValues: true, unpinAxis: false, tickDensity: default,
+        tickDensityCustom: 5, type: linear}]
+    x_axis_label: Time [UTC]
+    x_axis_zoom: true
+    y_axis_zoom: true
+    hidden_pivots: {}
+    defaults_version: 1
+    hidden_fields: [sum_of_crash_count]
+    listen: {}
+    row: 84
+    col: 12
+    width: 12
+    height: 7
+  - title: Cumulative Crash Counts by Process
+    name: Cumulative Crash Counts by Process
+    model: experimentation
+    explore: experiment_crash_rates
+    type: looker_line
+    fields: [sum_of_crash_count, experiment_crash_rates.crash_process_type, experiment_crash_rates.window_start_time]
+    pivots: [experiment_crash_rates.crash_process_type]
+    filters:
+      experiment_crash_rates.experiment: bug-1727596-pref-search-experiment-measuring-the-impacts-of-diffe-release-79-96
+      experiment_crash_rates.window_start_date: 28 days
+    sorts: [experiment_crash_rates.crash_process_type, experiment_crash_rates.window_start_time]
+    limit: 5000
+    column_limit: 50
+    dynamic_fields:
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: experiment_crash_rates.crash_count
+      expression: ''
+      label: Sum of Crash Count
+      measure: sum_of_crash_count
+      type: sum
+    - category: table_calculation
+      expression: running_total(${sum_of_crash_count})
+      label: Cumulative Crash Counts
+      value_format:
+      value_format_name:
+      _kind_hint: measure
+      table_calculation: cumulative_crash_counts
+      _type_hint: number
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_view_names: false
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    limit_displayed_rows: false
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    show_null_points: true
+    interpolation: linear
+    y_axes: [{label: Total, orientation: left, series: [{axisId: sum_of_crash_count,
+            id: content - sum_of_crash_count, name: content}, {axisId: sum_of_crash_count,
+            id: gpu - sum_of_crash_count, name: gpu}, {axisId: sum_of_crash_count,
+            id: main - sum_of_crash_count, name: main}, {axisId: sum_of_crash_count,
+            id: rdd - sum_of_crash_count, name: rdd}], showLabels: true, showValues: true,
+        unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
+    x_axis_label: Time [UTC]
+    x_axis_zoom: true
+    y_axis_zoom: true
+    hidden_pivots: {}
+    defaults_version: 1
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    hidden_fields: [sum_of_crash_count]
+    listen: {}
+    row: 91
+    col: 0
     width: 12
     height: 7
   filters:


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
