### PR TITLE
Add explore for rss feed table

### DIFF
--- a/firefox_desktop/explores/rss_feed_items.explore.lkml
+++ b/firefox_desktop/explores/rss_feed_items.explore.lkml
@@ -1,0 +1,6 @@
+include: "../views/rss_feed_items.view.lkml"
+
+explore: rss_feed_items {
+  label: "RSS Feed Items"
+
+}

--- a/firefox_desktop/views/rss_feed_items.view.lkml
+++ b/firefox_desktop/views/rss_feed_items.view.lkml
@@ -1,0 +1,93 @@
+view: rss_feed_items {
+  sql_table_name: `moz-fx-mozsoc-ml-prod.prod_rss_news.rss_feed_items` ;;
+  drill_fields: [id]
+
+  dimension: id {
+    primary_key: yes
+    type: string
+    sql: ${TABLE}.id ;;
+  }
+  dimension: author {
+    type: string
+    sql: ${TABLE}.author ;;
+  }
+  dimension: canonical_url {
+    type: string
+    sql: ${TABLE}.canonical_url ;;
+  }
+  dimension: category {
+    type: string
+    sql: ${TABLE}.category ;;
+  }
+  dimension: content_cleaned {
+    type: string
+    sql: ${TABLE}.content_cleaned ;;
+  }
+  dimension_group: crawled_at {
+    type: time
+    timeframes: [raw, time, date, week, month, quarter, year]
+    sql: ${TABLE}.crawled_at ;;
+  }
+  dimension: crawled_date {
+    type: string
+    sql: ${TABLE}.crawled_date ;;
+  }
+  dimension: engagement {
+    type: number
+    sql: ${TABLE}.engagement ;;
+  }
+  dimension: keywords {
+    type: string
+    sql: ${TABLE}.keywords ;;
+  }
+  dimension: language {
+    type: string
+    sql: ${TABLE}.language ;;
+  }
+  dimension: load_count {
+    type: number
+    sql: ${TABLE}.load_count ;;
+  }
+  dimension_group: loaded {
+    type: time
+    timeframes: [raw, time, date, week, month, quarter, year]
+    sql: ${TABLE}.loaded_at ;;
+  }
+  dimension: origin_title {
+    type: string
+    sql: ${TABLE}.origin_title ;;
+  }
+  dimension: origin_url {
+    type: string
+    sql: ${TABLE}.origin_url ;;
+  }
+  dimension_group: published_at {
+    type: time
+    timeframes: [raw, time, date, week, month, quarter, year]
+    sql: ${TABLE}.published_at ;;
+  }
+  dimension: published_date {
+    type: string
+    sql: ${TABLE}.published_date ;;
+  }
+  dimension: summary {
+    type: string
+    sql: ${TABLE}.summary ;;
+  }
+  dimension: surface {
+    type: string
+    sql: ${TABLE}.surface ;;
+  }
+  dimension: title {
+    type: string
+    sql: ${TABLE}.title ;;
+  }
+  dimension: unread {
+    type: yesno
+    sql: ${TABLE}.unread ;;
+  }
+  measure: count {
+    type: count
+    drill_fields: [id]
+  }
+}


### PR DESCRIPTION
This pull request adds a new explore for the rss feed table, which we'll surface on dashboards for the Firefox New Tab. 

It includes a change to reference explores created by @kwindau earlier today :) 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
