### PR TITLE
Add zyte cache explore

### DIFF
--- a/firefox_desktop/explores/zyte_cache.explore.lkml
+++ b/firefox_desktop/explores/zyte_cache.explore.lkml
@@ -1,0 +1,6 @@
+include: "../views/zyte_cache.view.lkml"
+
+explore: zyte_cache{
+  label: "Zyte Article Parsing Cache"
+
+}

--- a/firefox_desktop/views/zyte_cache.view.lkml
+++ b/firefox_desktop/views/zyte_cache.view.lkml
@@ -1,0 +1,61 @@
+view: zyte_cache {
+  sql_table_name: `moz-fx-mozsoc-ml-prod.prod_articles.zyte_cache` ;;
+
+  dimension: canonical_url {
+    type: string
+    sql: ${TABLE}.canonical_url ;;
+  }
+  dimension: zyte_article_body {
+    type: string
+    sql: ${TABLE}.zyte_articleBody ;;
+  }
+  dimension: zyte_authors {
+    type: string
+    sql: ${TABLE}.zyte_authors ;;
+  }
+  dimension: zyte_breadcrumbs {
+    type: string
+    sql: ${TABLE}.zyte_breadcrumbs ;;
+  }
+  dimension_group: zyte_cached {
+    type: time
+    timeframes: [raw, time, date, week, month, quarter, year]
+    datatype: datetime
+    sql: ${TABLE}.zyte_cached_at ;;
+  }
+  dimension: zyte_canonical_url {
+    type: string
+    sql: ${TABLE}.zyte_canonicalUrl ;;
+  }
+  dimension: zyte_date_modified {
+    type: string
+    sql: ${TABLE}.zyte_dateModified ;;
+  }
+  dimension: zyte_date_published {
+    type: string
+    sql: ${TABLE}.zyte_datePublished ;;
+  }
+  dimension: zyte_date_published_raw {
+    type: string
+    sql: ${TABLE}.zyte_datePublishedRaw ;;
+  }
+  dimension: zyte_description {
+    type: string
+    sql: ${TABLE}.zyte_description ;;
+  }
+  dimension: zyte_headline {
+    type: string
+    sql: ${TABLE}.zyte_headline ;;
+  }
+  dimension: zyte_in_language {
+    type: string
+    sql: ${TABLE}.zyte_inLanguage ;;
+  }
+  dimension: zyte_main_image {
+    type: string
+    sql: ${TABLE}.zyte_mainImage ;;
+  }
+  measure: count {
+    type: count
+  }
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
