### PR TITLE
Switch Monitor SaaSboard to use service subscription explores (DS-3083)

### DIFF
--- a/subscription_platform/dashboards/monitor_saasboard__active_subscriptions.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__active_subscriptions.dashboard.lookml
@@ -67,12 +67,12 @@
   - title: Most Recent Data
     name: Most Recent Data
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: single_value
-    fields: [daily_active_logical_subscriptions.date_date]
+    fields: [daily_active_service_subscriptions.date_date]
     filters:
-      daily_active_logical_subscriptions.date_date: 1 month
-    sorts: [daily_active_logical_subscriptions.date_date desc]
+      daily_active_service_subscriptions.date_date: 1 month
+    sorts: [daily_active_service_subscriptions.date_date desc]
     limit: 1
     column_limit: 50
     custom_color_enabled: true
@@ -130,12 +130,12 @@
   - title: Active Subscriptions
     name: Active Subscriptions
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: single_value
-    fields: [daily_active_logical_subscriptions.date_date, daily_active_logical_subscriptions.logical_subscription_count]
+    fields: [daily_active_service_subscriptions.date_date, daily_active_service_subscriptions.service_subscription_count]
     filters:
-      daily_active_logical_subscriptions.was_active_at_day_end: 'Yes'
-    sorts: [daily_active_logical_subscriptions.date_date desc]
+      daily_active_service_subscriptions.was_active_at_day_end: 'Yes'
+    sorts: [daily_active_service_subscriptions.date_date desc]
     limit: 1
     column_limit: 50
     custom_color_enabled: true
@@ -171,8 +171,8 @@
     y_axis_combined: true
     show_null_points: false
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_logical_subscriptions.logical_subscription_count,
-            id: daily_active_logical_subscriptions.logical_subscription_count, name: Logical
+    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_service_subscriptions.service_subscription_count,
+            id: daily_active_service_subscriptions.service_subscription_count, name: Service
               Subscription Count}], showLabels: true, showValues: true, unpinAxis: true,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_zoom: true
@@ -183,11 +183,11 @@
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: daily_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: daily_active_logical_subscriptions.subscription__plan_interval
-      Plan: daily_active_logical_subscriptions.subscription__plan_summary
-      Active Date: daily_active_logical_subscriptions.date_date
+      Service ID: daily_active_service_subscriptions.subscription__service__id
+      Payment Provider: daily_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: daily_active_service_subscriptions.subscription__plan_interval
+      Plan: daily_active_service_subscriptions.subscription__plan_summary
+      Active Date: daily_active_service_subscriptions.date_date
     row: 8
     col: 0
     width: 8
@@ -195,12 +195,12 @@
   - title: Daily Active Subscriptions
     name: Daily Active Subscriptions
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: looker_line
-    fields: [daily_active_logical_subscriptions.date_date, daily_active_logical_subscriptions.logical_subscription_count]
+    fields: [daily_active_service_subscriptions.date_date, daily_active_service_subscriptions.service_subscription_count]
     filters:
-      daily_active_logical_subscriptions.was_active_at_day_end: 'Yes'
-    sorts: [daily_active_logical_subscriptions.date_date desc]
+      daily_active_service_subscriptions.was_active_at_day_end: 'Yes'
+    sorts: [daily_active_service_subscriptions.date_date desc]
     limit: 5000
     column_limit: 50
     x_axis_gridlines: false
@@ -227,8 +227,8 @@
     y_axis_combined: true
     show_null_points: false
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_logical_subscriptions.logical_subscription_count,
-            id: daily_active_logical_subscriptions.logical_subscription_count, name: Logical
+    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_service_subscriptions.service_subscription_count,
+            id: daily_active_service_subscriptions.service_subscription_count, name: Service
               Subscription Count}], showLabels: false, showValues: true, unpinAxis: true,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_zoom: true
@@ -239,11 +239,11 @@
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: daily_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: daily_active_logical_subscriptions.subscription__plan_interval
-      Plan: daily_active_logical_subscriptions.subscription__plan_summary
-      Active Date: daily_active_logical_subscriptions.date_date
+      Service ID: daily_active_service_subscriptions.subscription__service__id
+      Payment Provider: daily_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: daily_active_service_subscriptions.subscription__plan_interval
+      Plan: daily_active_service_subscriptions.subscription__plan_summary
+      Active Date: daily_active_service_subscriptions.date_date
     row: 8
     col: 8
     width: 16
@@ -264,19 +264,19 @@
   - title: Active Subscriptions by Plan
     name: Active Subscriptions by Plan
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: looker_pie
-    fields: [daily_active_logical_subscriptions.date_date, daily_active_logical_subscriptions.subscription__plan_summary,
-      daily_active_logical_subscriptions.logical_subscription_count]
+    fields: [daily_active_service_subscriptions.date_date, daily_active_service_subscriptions.subscription__plan_summary,
+      daily_active_service_subscriptions.service_subscription_count]
     filters:
-      daily_active_logical_subscriptions.was_active_at_day_end: 'Yes'
-    sorts: [daily_active_logical_subscriptions.date_date desc, daily_active_logical_subscriptions.logical_subscription_count
+      daily_active_service_subscriptions.was_active_at_day_end: 'Yes'
+    sorts: [daily_active_service_subscriptions.date_date desc, daily_active_service_subscriptions.service_subscription_count
         desc]
     limit: 50
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${daily_active_logical_subscriptions.date_date} = index(${daily_active_logical_subscriptions.date_date},\
+      expression: "${daily_active_service_subscriptions.date_date} = index(${daily_active_service_subscriptions.date_date},\
         \ 1)"
       label: Is Latest Date
       value_format:
@@ -310,25 +310,25 @@
     y_axis_combined: true
     show_null_points: false
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_logical_subscriptions.logical_subscription_count,
-            id: daily_active_logical_subscriptions.logical_subscription_count, name: Logical
+    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_service_subscriptions.service_subscription_count,
+            id: daily_active_service_subscriptions.service_subscription_count, name: Service
               Subscription Count}], showLabels: true, showValues: true, unpinAxis: true,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_zoom: true
     y_axis_zoom: true
     defaults_version: 1
-    hidden_fields: [is_latest_date, daily_active_logical_subscriptions.date_date]
+    hidden_fields: [is_latest_date, daily_active_service_subscriptions.date_date]
     hidden_points_if_no: [is_latest_date]
     listen:
       Country: countries.name
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: daily_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: daily_active_logical_subscriptions.subscription__plan_interval
-      Plan: daily_active_logical_subscriptions.subscription__plan_summary
-      Active Date: daily_active_logical_subscriptions.date_date
+      Service ID: daily_active_service_subscriptions.subscription__service__id
+      Payment Provider: daily_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: daily_active_service_subscriptions.subscription__plan_interval
+      Plan: daily_active_service_subscriptions.subscription__plan_summary
+      Active Date: daily_active_service_subscriptions.date_date
     row: 18
     col: 0
     width: 12
@@ -336,14 +336,14 @@
   - title: Monthly Active Subscriptions by Plan
     name: Monthly Active Subscriptions by Plan
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_column
-    fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.logical_subscription_count,
-      monthly_active_logical_subscriptions.subscription__plan_summary]
-    pivots: [monthly_active_logical_subscriptions.subscription__plan_summary]
+    fields: [monthly_active_service_subscriptions.month_month, monthly_active_service_subscriptions.service_subscription_count,
+      monthly_active_service_subscriptions.subscription__plan_summary]
+    pivots: [monthly_active_service_subscriptions.subscription__plan_summary]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_end: 'Yes'
-    sorts: [monthly_active_logical_subscriptions.month_month desc, monthly_active_logical_subscriptions.subscription__plan_summary]
+      monthly_active_service_subscriptions.was_active_at_month_end: 'Yes'
+    sorts: [monthly_active_service_subscriptions.month_month desc, monthly_active_service_subscriptions.subscription__plan_summary]
     limit: 5000
     column_limit: 100
     x_axis_gridlines: false
@@ -382,11 +382,11 @@
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
-      Active Date: monthly_active_logical_subscriptions.month_month
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
+      Active Date: monthly_active_service_subscriptions.month_month
     row: 18
     col: 12
     width: 12
@@ -407,19 +407,19 @@
   - title: Active Subscriptions by Plan Interval
     name: Active Subscriptions by Plan Interval
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: looker_pie
-    fields: [daily_active_logical_subscriptions.date_date, daily_active_logical_subscriptions.subscription__plan_interval,
-      daily_active_logical_subscriptions.logical_subscription_count]
+    fields: [daily_active_service_subscriptions.date_date, daily_active_service_subscriptions.subscription__plan_interval,
+      daily_active_service_subscriptions.service_subscription_count]
     filters:
-      daily_active_logical_subscriptions.was_active_at_day_end: 'Yes'
-    sorts: [daily_active_logical_subscriptions.date_date desc, daily_active_logical_subscriptions.logical_subscription_count
+      daily_active_service_subscriptions.was_active_at_day_end: 'Yes'
+    sorts: [daily_active_service_subscriptions.date_date desc, daily_active_service_subscriptions.service_subscription_count
         desc]
     limit: 50
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${daily_active_logical_subscriptions.date_date} = index(${daily_active_logical_subscriptions.date_date},\
+      expression: "${daily_active_service_subscriptions.date_date} = index(${daily_active_service_subscriptions.date_date},\
         \ 1)"
       label: Is Latest Date
       value_format:
@@ -453,25 +453,25 @@
     y_axis_combined: true
     show_null_points: false
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_logical_subscriptions.logical_subscription_count,
-            id: daily_active_logical_subscriptions.logical_subscription_count, name: Logical
+    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_service_subscriptions.service_subscription_count,
+            id: daily_active_service_subscriptions.service_subscription_count, name: Service
               Subscription Count}], showLabels: true, showValues: true, unpinAxis: true,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_zoom: true
     y_axis_zoom: true
     defaults_version: 1
-    hidden_fields: [daily_active_logical_subscriptions.date_date]
+    hidden_fields: [daily_active_service_subscriptions.date_date]
     hidden_points_if_no: [is_latest_date]
     listen:
       Country: countries.name
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: daily_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: daily_active_logical_subscriptions.subscription__plan_interval
-      Plan: daily_active_logical_subscriptions.subscription__plan_summary
-      Active Date: daily_active_logical_subscriptions.date_date
+      Service ID: daily_active_service_subscriptions.subscription__service__id
+      Payment Provider: daily_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: daily_active_service_subscriptions.subscription__plan_interval
+      Plan: daily_active_service_subscriptions.subscription__plan_summary
+      Active Date: daily_active_service_subscriptions.date_date
     row: 28
     col: 0
     width: 12
@@ -479,14 +479,14 @@
   - title: Monthly Active Subscriptions by Plan Interval
     name: Monthly Active Subscriptions by Plan Interval
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_column
-    fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.logical_subscription_count,
-      monthly_active_logical_subscriptions.subscription__plan_interval]
-    pivots: [monthly_active_logical_subscriptions.subscription__plan_interval]
+    fields: [monthly_active_service_subscriptions.month_month, monthly_active_service_subscriptions.service_subscription_count,
+      monthly_active_service_subscriptions.subscription__plan_interval]
+    pivots: [monthly_active_service_subscriptions.subscription__plan_interval]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_end: 'Yes'
-    sorts: [monthly_active_logical_subscriptions.month_month desc, monthly_active_logical_subscriptions.subscription__plan_interval]
+      monthly_active_service_subscriptions.was_active_at_month_end: 'Yes'
+    sorts: [monthly_active_service_subscriptions.month_month desc, monthly_active_service_subscriptions.subscription__plan_interval]
     limit: 500
     column_limit: 50
     x_axis_gridlines: false
@@ -525,11 +525,11 @@
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
-      Active Date: monthly_active_logical_subscriptions.month_month
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
+      Active Date: monthly_active_service_subscriptions.month_month
     row: 28
     col: 12
     width: 12
@@ -550,19 +550,19 @@
   - title: Active Subscriptions by Payment Provider
     name: Active Subscriptions by Payment Provider
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: looker_pie
-    fields: [daily_active_logical_subscriptions.date_date, daily_active_logical_subscriptions.subscription__payment_provider,
-      daily_active_logical_subscriptions.logical_subscription_count]
+    fields: [daily_active_service_subscriptions.date_date, daily_active_service_subscriptions.subscription__payment_provider,
+      daily_active_service_subscriptions.service_subscription_count]
     filters:
-      daily_active_logical_subscriptions.was_active_at_day_end: 'Yes'
-    sorts: [daily_active_logical_subscriptions.date_date desc, daily_active_logical_subscriptions.logical_subscription_count
+      daily_active_service_subscriptions.was_active_at_day_end: 'Yes'
+    sorts: [daily_active_service_subscriptions.date_date desc, daily_active_service_subscriptions.service_subscription_count
         desc]
     limit: 50
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${daily_active_logical_subscriptions.date_date} = index(${daily_active_logical_subscriptions.date_date},\
+      expression: "${daily_active_service_subscriptions.date_date} = index(${daily_active_service_subscriptions.date_date},\
         \ 1)"
       label: Is Latest Date
       value_format:
@@ -596,25 +596,25 @@
     y_axis_combined: true
     show_null_points: false
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_logical_subscriptions.logical_subscription_count,
-            id: daily_active_logical_subscriptions.logical_subscription_count, name: Logical
+    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_service_subscriptions.service_subscription_count,
+            id: daily_active_service_subscriptions.service_subscription_count, name: Service
               Subscription Count}], showLabels: true, showValues: true, unpinAxis: true,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_zoom: true
     y_axis_zoom: true
     defaults_version: 1
-    hidden_fields: [daily_active_logical_subscriptions.date_date]
+    hidden_fields: [daily_active_service_subscriptions.date_date]
     hidden_points_if_no: [is_latest_date]
     listen:
       Country: countries.name
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: daily_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: daily_active_logical_subscriptions.subscription__plan_interval
-      Plan: daily_active_logical_subscriptions.subscription__plan_summary
-      Active Date: daily_active_logical_subscriptions.date_date
+      Service ID: daily_active_service_subscriptions.subscription__service__id
+      Payment Provider: daily_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: daily_active_service_subscriptions.subscription__plan_interval
+      Plan: daily_active_service_subscriptions.subscription__plan_summary
+      Active Date: daily_active_service_subscriptions.date_date
     row: 38
     col: 0
     width: 12
@@ -622,14 +622,14 @@
   - title: Monthly Active Subscriptions by Payment Provider
     name: Monthly Active Subscriptions by Payment Provider
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_column
-    fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.logical_subscription_count,
-      monthly_active_logical_subscriptions.subscription__payment_provider]
-    pivots: [monthly_active_logical_subscriptions.subscription__payment_provider]
+    fields: [monthly_active_service_subscriptions.month_month, monthly_active_service_subscriptions.service_subscription_count,
+      monthly_active_service_subscriptions.subscription__payment_provider]
+    pivots: [monthly_active_service_subscriptions.subscription__payment_provider]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_end: 'Yes'
-    sorts: [monthly_active_logical_subscriptions.month_month desc, monthly_active_logical_subscriptions.subscription__payment_provider]
+      monthly_active_service_subscriptions.was_active_at_month_end: 'Yes'
+    sorts: [monthly_active_service_subscriptions.month_month desc, monthly_active_service_subscriptions.subscription__payment_provider]
     limit: 500
     column_limit: 50
     x_axis_gridlines: false
@@ -668,11 +668,11 @@
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
-      Active Date: monthly_active_logical_subscriptions.month_month
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
+      Active Date: monthly_active_service_subscriptions.month_month
     row: 38
     col: 12
     width: 12
@@ -693,18 +693,18 @@
   - title: Active Subscriptions by Country
     name: Active Subscriptions by Country
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: looker_pie
-    fields: [daily_active_logical_subscriptions.date_date, countries.name, daily_active_logical_subscriptions.logical_subscription_count]
+    fields: [daily_active_service_subscriptions.date_date, countries.name, daily_active_service_subscriptions.service_subscription_count]
     filters:
-      daily_active_logical_subscriptions.was_active_at_day_end: 'Yes'
-    sorts: [daily_active_logical_subscriptions.date_date desc, daily_active_logical_subscriptions.logical_subscription_count
+      daily_active_service_subscriptions.was_active_at_day_end: 'Yes'
+    sorts: [daily_active_service_subscriptions.date_date desc, daily_active_service_subscriptions.service_subscription_count
         desc]
     limit: 50
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${daily_active_logical_subscriptions.date_date} = index(${daily_active_logical_subscriptions.date_date},\
+      expression: "${daily_active_service_subscriptions.date_date} = index(${daily_active_service_subscriptions.date_date},\
         \ 1)"
       label: Is Latest Date
       value_format:
@@ -738,8 +738,8 @@
     y_axis_combined: true
     show_null_points: false
     interpolation: linear
-    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_logical_subscriptions.logical_subscription_count,
-            id: daily_active_logical_subscriptions.logical_subscription_count, name: Logical
+    y_axes: [{label: '', orientation: left, series: [{axisId: daily_active_service_subscriptions.service_subscription_count,
+            id: daily_active_service_subscriptions.service_subscription_count, name: Service
               Subscription Count}], showLabels: true, showValues: true, unpinAxis: true,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_zoom: true
@@ -747,17 +747,17 @@
     defaults_version: 1
     hidden_pivots: {}
     hidden_points_if_no: [is_latest_date]
-    hidden_fields: [daily_active_logical_subscriptions.date_date]
+    hidden_fields: [daily_active_service_subscriptions.date_date]
     listen:
       Country: countries.name
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: daily_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: daily_active_logical_subscriptions.subscription__plan_interval
-      Plan: daily_active_logical_subscriptions.subscription__plan_summary
-      Active Date: daily_active_logical_subscriptions.date_date
+      Service ID: daily_active_service_subscriptions.subscription__service__id
+      Payment Provider: daily_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: daily_active_service_subscriptions.subscription__plan_interval
+      Plan: daily_active_service_subscriptions.subscription__plan_summary
+      Active Date: daily_active_service_subscriptions.date_date
     row: 48
     col: 0
     width: 12
@@ -765,14 +765,14 @@
   - title: Monthly Active Subscriptions by Country
     name: Monthly Active Subscriptions by Country
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_column
-    fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.logical_subscription_count,
+    fields: [monthly_active_service_subscriptions.month_month, monthly_active_service_subscriptions.service_subscription_count,
       countries.name]
     pivots: [countries.name]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_end: 'Yes'
-    sorts: [monthly_active_logical_subscriptions.month_month desc, countries.name]
+      monthly_active_service_subscriptions.was_active_at_month_end: 'Yes'
+    sorts: [monthly_active_service_subscriptions.month_month desc, countries.name]
     limit: 5000
     column_limit: 100
     x_axis_gridlines: false
@@ -811,11 +811,11 @@
       Region: countries.region_name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
-      Active Date: monthly_active_logical_subscriptions.month_month
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
+      Active Date: monthly_active_service_subscriptions.month_month
     row: 48
     col: 12
     width: 12
@@ -832,9 +832,9 @@
       display: popover
       options: []
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     listens_to_filters: []
-    field: daily_active_logical_subscriptions.date_date
+    field: daily_active_service_subscriptions.date_date
   - name: Payment Provider
     title: Payment Provider
     type: field_filter
@@ -845,9 +845,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     listens_to_filters: [Service ID, Active Date]
-    field: daily_active_logical_subscriptions.subscription__payment_provider
+    field: daily_active_service_subscriptions.subscription__payment_provider
   - name: Plan Interval
     title: Plan Interval
     type: field_filter
@@ -858,9 +858,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     listens_to_filters: [Service ID, Active Date]
-    field: daily_active_logical_subscriptions.subscription__plan_interval
+    field: daily_active_service_subscriptions.subscription__plan_interval
   - name: Plan
     title: Plan
     type: field_filter
@@ -871,9 +871,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     listens_to_filters: [Service ID, Active Date, Plan Interval]
-    field: daily_active_logical_subscriptions.subscription__plan_summary
+    field: daily_active_service_subscriptions.subscription__plan_summary
   - name: Region
     title: Region
     type: field_filter
@@ -884,7 +884,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     listens_to_filters: [Service ID, Active Date]
     field: countries.region_name
   - name: Country
@@ -897,7 +897,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     listens_to_filters: [Region, Service ID, Active Date]
     field: countries.name
   - name: Has Fraudulent Charges (Yes / No)
@@ -910,7 +910,7 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     listens_to_filters: []
     field: current_subscription_state.has_fraudulent_charges
   - name: Has Refunds (Yes / No)
@@ -923,7 +923,7 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     listens_to_filters: []
     field: current_subscription_state.has_refunds
   - name: Service ID
@@ -938,6 +938,6 @@
       options:
       - Monitor
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     listens_to_filters: []
-    field: subscription_services.id
+    field: daily_active_service_subscriptions.subscription__service__id

--- a/subscription_platform/dashboards/monitor_saasboard__churn.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__churn.dashboard.lookml
@@ -67,12 +67,12 @@
   - title: Most Recent Data
     name: Most Recent Data
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: single_value
-    fields: [daily_active_logical_subscriptions.date_date]
+    fields: [daily_active_service_subscriptions.date_date]
     filters:
-      daily_active_logical_subscriptions.date_date: 1 month
-    sorts: [daily_active_logical_subscriptions.date_date desc]
+      daily_active_service_subscriptions.date_date: 1 month
+    sorts: [daily_active_service_subscriptions.date_date desc]
     limit: 1
     column_limit: 50
     custom_color_enabled: true
@@ -117,7 +117,7 @@
   - title: Churn by Subscription Month Number
     name: Churn by Subscription Month Number
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_column
     fields: [retention_by_month.subscription_month_number, retention_by_month.churned_subscription_count,
       retention_by_month.previously_retained_subscription_count]
@@ -177,15 +177,15 @@
     defaults_version: 1
     hidden_fields: [retention_by_month.previously_retained_subscription_count]
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Subscription Start Date: service_subscriptions.started_at_date
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 6
     col: 0
     width: 12
@@ -193,11 +193,11 @@
   - title: Total Churn Rate by Cohort
     name: Total Churn Rate by Cohort
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_line
     fields: [retention_by_month.churned_subscription_count, retention_by_month.previously_retained_subscription_count,
-      logical_subscriptions.started_at_month]
-    sorts: [logical_subscriptions.started_at_month]
+      service_subscriptions.started_at_month]
+    sorts: [service_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -252,15 +252,15 @@
     defaults_version: 1
     hidden_fields: [retention_by_month.previously_retained_subscription_count, retention_by_month.churned_subscription_count]
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Subscription Start Date: service_subscriptions.started_at_date
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 6
     col: 12
     width: 12
@@ -268,20 +268,20 @@
   - title: Pooled Churn
     name: Pooled Churn
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_column
-    fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.logical_subscription_count,
-      next_month_still_active_subscriptions.logical_subscription_count]
+    fields: [monthly_active_service_subscriptions.month_month, monthly_active_service_subscriptions.service_subscription_count,
+      next_month_still_active_subscriptions.service_subscription_count]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_start: 'Yes'
-      next_month_still_active_subscriptions.logical_subscription_count: ">0"
-    sorts: [monthly_active_logical_subscriptions.month_month]
+      monthly_active_service_subscriptions.was_active_at_month_start: 'Yes'
+      next_month_still_active_subscriptions.service_subscription_count: ">0"
+    sorts: [monthly_active_service_subscriptions.month_month]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${monthly_active_logical_subscriptions.logical_subscription_count}\
-        \ - ${next_month_still_active_subscriptions.logical_subscription_count}"
+      expression: "${monthly_active_service_subscriptions.service_subscription_count}\
+        \ - ${next_month_still_active_subscriptions.service_subscription_count}"
       label: Churned Subscription Count
       value_format:
       value_format_name:
@@ -289,9 +289,9 @@
       table_calculation: churned_subscription_count
       _type_hint: number
     - category: table_calculation
-      expression: "(${monthly_active_logical_subscriptions.logical_subscription_count}\
-        \ - ${next_month_still_active_subscriptions.logical_subscription_count}) /\
-        \ ${monthly_active_logical_subscriptions.logical_subscription_count}"
+      expression: "(${monthly_active_service_subscriptions.service_subscription_count}\
+        \ - ${next_month_still_active_subscriptions.service_subscription_count}) /\
+        \ ${monthly_active_service_subscriptions.service_subscription_count}"
       label: Pooled Churn Rate
       value_format:
       value_format_name: percent_0
@@ -347,18 +347,18 @@
     interpolation: linear
     hidden_pivots: {}
     defaults_version: 1
-    hidden_fields: [monthly_active_logical_subscriptions.logical_subscription_count,
-      next_month_still_active_subscriptions.logical_subscription_count]
+    hidden_fields: [monthly_active_service_subscriptions.service_subscription_count,
+      next_month_still_active_subscriptions.service_subscription_count]
     listen:
-      Subscription Start Date: monthly_active_logical_subscriptions.subscription__started_at_date
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
+      Subscription Start Date: monthly_active_service_subscriptions.subscription__started_at_date
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
       Has Refunds (Yes / No): current_subscription_state.has_refunds
-      Service ID: subscription_services.id
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
     row: 14
     col: 0
     width: 12
@@ -366,11 +366,11 @@
   - title: Daily Churn
     name: Daily Churn
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_column
-    fields: [logical_subscriptions.ended_at_date, logical_subscriptions.logical_subscription_count]
+    fields: [service_subscriptions.ended_at_date, service_subscriptions.service_subscription_count]
     filters: {}
-    sorts: [logical_subscriptions.ended_at_date desc]
+    sorts: [service_subscriptions.ended_at_date desc]
     limit: 5000
     column_limit: 50
     x_axis_gridlines: false
@@ -400,29 +400,29 @@
     show_totals_labels: false
     show_silhouette: false
     totals_color: "#808080"
-    y_axes: [{label: '', orientation: left, series: [{axisId: logical_subscriptions.logical_subscription_count,
-            id: logical_subscriptions.logical_subscription_count, name: Logical Subscription
+    y_axes: [{label: '', orientation: left, series: [{axisId: service_subscriptions.service_subscription_count,
+            id: service_subscriptions.service_subscription_count, name: Service Subscription
               Count}], showLabels: false, showValues: true, unpinAxis: false, tickDensity: default,
         tickDensityCustom: 5, type: linear}]
     x_axis_zoom: true
     y_axis_zoom: true
     series_colors:
-      logical_subscriptions.logical_subscription_count: "#FF7139"
+      service_subscriptions.service_subscription_count: "#FF7139"
     series_labels:
-      logical_subscriptions.logical_subscription_count: Churned Subscription Count
+      service_subscriptions.service_subscription_count: Churned Subscription Count
     show_null_points: true
     interpolation: linear
     defaults_version: 1
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Subscription Start Date: service_subscriptions.started_at_date
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 14
     col: 12
     width: 12
@@ -443,16 +443,16 @@
   - title: Upcoming Cancellations by Plan Interval
     name: Upcoming Cancellations by Plan Interval
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_column
-    fields: [logical_subscriptions.logical_subscription_count, logical_subscriptions.current_period_ends_at_month,
-      logical_subscriptions.plan_interval]
-    pivots: [logical_subscriptions.plan_interval]
-    fill_fields: [logical_subscriptions.current_period_ends_at_month]
+    fields: [service_subscriptions.service_subscription_count, service_subscriptions.current_period_ends_at_month,
+      service_subscriptions.plan_interval]
+    pivots: [service_subscriptions.plan_interval]
+    fill_fields: [service_subscriptions.current_period_ends_at_month]
     filters:
-      logical_subscriptions.auto_renew: 'No'
-      logical_subscriptions.current_period_ends_at_date: after 0 days ago
-    sorts: [logical_subscriptions.current_period_ends_at_month, logical_subscriptions.plan_interval]
+      service_subscriptions.auto_renew: 'No'
+      service_subscriptions.current_period_ends_at_date: after 0 days ago
+    sorts: [service_subscriptions.current_period_ends_at_month, service_subscriptions.plan_interval]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -495,7 +495,7 @@
     x_axis_zoom: true
     y_axis_zoom: true
     series_colors:
-      logical_subscriptions.logical_subscription_count: "#ffc286"
+      service_subscriptions.service_subscription_count: "#ffc286"
     hidden_pivots: {}
     show_null_points: true
     interpolation: linear
@@ -504,14 +504,14 @@
     note_display: hover
     note_text: The Subscription Start Date filter does not apply to this chart.
     listen:
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 24
     col: 0
     width: 12
@@ -519,21 +519,21 @@
   - title: Days to Disable Auto-Renew by Plan Interval
     name: Days to Disable Auto-Renew by Plan Interval
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_area
-    fields: [auto_renew_disabled_date_difference_days, logical_subscription_events.subscription__plan_interval,
-      logical_subscription_events.logical_subscription_count]
-    pivots: [logical_subscription_events.subscription__plan_interval]
+    fields: [auto_renew_disabled_date_difference_days, service_subscription_events.subscription__plan_interval,
+      service_subscription_events.service_subscription_count]
+    pivots: [service_subscription_events.subscription__plan_interval]
     filters:
-      logical_subscription_events.reason: Auto-Renew Disabled
-      logical_subscription_events.type: Auto-Renew Change
-    sorts: [logical_subscription_events.subscription__plan_interval, auto_renew_disabled_date_difference_days]
+      service_subscription_events.reason: Auto-Renew Disabled
+      service_subscription_events.type: Auto-Renew Change
+    sorts: [service_subscription_events.subscription__plan_interval, auto_renew_disabled_date_difference_days]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: dimension
-      expression: diff_days(${logical_subscription_events.subscription__started_at_date},
-        ${logical_subscription_events.subscription__auto_renew_disabled_at_date})
+      expression: diff_days(${service_subscription_events.subscription__started_at_date},
+        ${service_subscription_events.subscription__auto_renew_disabled_at_date})
       label: Auto-Renew Disabled Date Difference (Days)
       value_format:
       value_format_name:
@@ -541,13 +541,13 @@
       _kind_hint: dimension
       _type_hint: number
     - args:
-      - logical_subscription_events.logical_subscription_count
+      - service_subscription_events.service_subscription_count
       calculation_type: percent_of_column_sum
       category: table_calculation
-      based_on: logical_subscription_events.logical_subscription_count
-      label: Percent of Logical Subscription Events Logical Subscription Count
-      source_field: logical_subscription_events.logical_subscription_count
-      table_calculation: percent_of_logical_subscription_events_logical_subscription_count
+      based_on: service_subscription_events.service_subscription_count
+      label: Percent of Service Subscription Events Service Subscription Count
+      source_field: service_subscription_events.service_subscription_count
+      table_calculation: percent_of_service_subscription_events_service_subscription_count
       value_format:
       value_format_name: percent_0
       _kind_hint: measure
@@ -593,21 +593,21 @@
     conditional_formatting_include_totals: false
     conditional_formatting_include_nulls: false
     defaults_version: 1
-    hidden_fields: [logical_subscription_events.logical_subscription_count]
+    hidden_fields: [service_subscription_events.service_subscription_count]
     note_state: collapsed
     note_display: hover
     note_text: Time to disabling auto-renew is measured relative to the subscription
       start date.
     listen:
-      Subscription Start Date: logical_subscription_events.subscription__started_at_date
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Plan: logical_subscription_events.subscription__plan_summary
+      Subscription Start Date: service_subscription_events.subscription__started_at_date
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscription_events.subscription__has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscription_events.subscription__has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscription_events.subscription__has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscription_events.subscription__has_refunds
+      Service ID: service_subscription_events.subscription__service__id
     row: 24
     col: 12
     width: 12
@@ -615,16 +615,16 @@
   - title: Auto-Renew Disabled Occurrences
     name: Auto-Renew Disabled Occurrences
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_column
-    fields: [logical_subscription_events.timestamp_date, logical_subscription_events.subscription__plan_interval,
-      logical_subscription_events.logical_subscription_count]
-    pivots: [logical_subscription_events.subscription__plan_interval]
-    fill_fields: [logical_subscription_events.timestamp_date]
+    fields: [service_subscription_events.timestamp_date, service_subscription_events.subscription__plan_interval,
+      service_subscription_events.service_subscription_count]
+    pivots: [service_subscription_events.subscription__plan_interval]
+    fill_fields: [service_subscription_events.timestamp_date]
     filters:
-      logical_subscription_events.reason: Auto-Renew Disabled
-      logical_subscription_events.type: Auto-Renew Change
-    sorts: [logical_subscription_events.timestamp_date desc, logical_subscription_events.subscription__plan_interval]
+      service_subscription_events.reason: Auto-Renew Disabled
+      service_subscription_events.type: Auto-Renew Change
+    sorts: [service_subscription_events.timestamp_date desc, service_subscription_events.subscription__plan_interval]
     limit: 500
     column_limit: 50
     x_axis_gridlines: false
@@ -661,15 +661,15 @@
     interpolation: linear
     defaults_version: 1
     listen:
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Plan: logical_subscription_events.subscription__plan_summary
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscription_events.subscription__has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscription_events.subscription__has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscription_events.subscription__has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscription_events.subscription__has_refunds
+      Service ID: service_subscription_events.subscription__service__id
     row: 32
     col: 0
     width: 12
@@ -677,15 +677,15 @@
   - title: Percent of Active Subscriptions with Auto-Renew Disabled
     name: Percent of Active Subscriptions with Auto-Renew Disabled
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: looker_line
-    fields: [auto_renew_disabled_subscription_count, daily_active_logical_subscriptions.date_date,
-      daily_active_logical_subscriptions.subscription__plan_interval, daily_active_logical_subscriptions.logical_subscription_count]
-    pivots: [daily_active_logical_subscriptions.subscription__plan_interval]
-    fill_fields: [daily_active_logical_subscriptions.date_date]
+    fields: [auto_renew_disabled_subscription_count, daily_active_service_subscriptions.date_date,
+      daily_active_service_subscriptions.subscription__plan_interval, daily_active_service_subscriptions.service_subscription_count]
+    pivots: [daily_active_service_subscriptions.subscription__plan_interval]
+    fill_fields: [daily_active_service_subscriptions.date_date]
     filters:
-      daily_active_logical_subscriptions.was_active_at_day_end: 'Yes'
-    sorts: [daily_active_logical_subscriptions.date_date desc, daily_active_logical_subscriptions.subscription__plan_interval]
+      daily_active_service_subscriptions.was_active_at_day_end: 'Yes'
+    sorts: [daily_active_service_subscriptions.date_date desc, daily_active_service_subscriptions.subscription__plan_interval]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -694,7 +694,7 @@
       label: Auto-Renew Disabled Subscription Count
       value_format:
       value_format_name:
-      based_on: daily_active_logical_subscriptions.logical_subscription_count
+      based_on: daily_active_service_subscriptions.service_subscription_count
       _kind_hint: measure
       measure: auto_renew_disabled_subscription_count
       type: count_distinct
@@ -702,7 +702,7 @@
       filters:
         current_subscription_state.auto_renew: 'No'
     - category: table_calculation
-      expression: "${auto_renew_disabled_subscription_count} / ${daily_active_logical_subscriptions.logical_subscription_count}"
+      expression: "${auto_renew_disabled_subscription_count} / ${daily_active_service_subscriptions.service_subscription_count}"
       label: Percent Active Subscriptions Disabled Auto-Renew
       value_format:
       value_format_name: percent_1
@@ -735,17 +735,17 @@
     interpolation: linear
     hidden_pivots: {}
     defaults_version: 1
-    hidden_fields: [auto_renew_disabled_subscription_count, daily_active_logical_subscriptions.logical_subscription_count]
+    hidden_fields: [auto_renew_disabled_subscription_count, daily_active_service_subscriptions.service_subscription_count]
     listen:
-      Subscription Start Date: daily_active_logical_subscriptions.date_date
-      Payment Provider: daily_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: daily_active_logical_subscriptions.subscription__plan_interval
-      Plan: daily_active_logical_subscriptions.subscription__plan_summary
+      Subscription Start Date: daily_active_service_subscriptions.date_date
+      Payment Provider: daily_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: daily_active_service_subscriptions.subscription__plan_interval
+      Plan: daily_active_service_subscriptions.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): daily_active_logical_subscriptions.subscription__has_fraudulent_charges
-      Has Refunds (Yes / No): daily_active_logical_subscriptions.subscription__has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): daily_active_service_subscriptions.subscription__has_fraudulent_charges
+      Has Refunds (Yes / No): daily_active_service_subscriptions.subscription__has_refunds
+      Service ID: daily_active_service_subscriptions.subscription__service__id
     row: 32
     col: 12
     width: 12
@@ -766,12 +766,12 @@
   - title: Churn Rate by Plan Interval
     name: Churn Rate by Plan Interval
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_line
     fields: [retention_by_month.churned_subscription_count, retention_by_month.previously_retained_subscription_count,
-      retention_by_month.subscription_month_number, logical_subscriptions.plan_interval]
-    pivots: [logical_subscriptions.plan_interval]
-    sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval]
+      retention_by_month.subscription_month_number, service_subscriptions.plan_interval]
+    pivots: [service_subscriptions.plan_interval]
+    sorts: [retention_by_month.subscription_month_number, service_subscriptions.plan_interval]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -821,15 +821,15 @@
     hidden_fields: [retention_by_month.previously_retained_subscription_count, retention_by_month.churned_subscription_count]
     hidden_pivots: {}
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Subscription Start Date: service_subscriptions.started_at_date
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 42
     col: 0
     width: 24
@@ -837,13 +837,13 @@
   - title: Churn Rate Table by Plan Interval
     name: Churn Rate Table by Plan Interval
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_grid
     fields: [retention_by_month.churned_subscription_count, retention_by_month.previously_retained_subscription_count,
-      retention_by_month.subscription_month_number, logical_subscriptions.plan_interval,
-      logical_subscriptions.plan_interval_months]
+      retention_by_month.subscription_month_number, service_subscriptions.plan_interval,
+      service_subscriptions.plan_interval_months]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval_months]
+    sorts: [retention_by_month.subscription_month_number, service_subscriptions.plan_interval_months]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -919,20 +919,20 @@
     totals_color: "#808080"
     defaults_version: 1
     hidden_fields: [retention_by_month.previously_retained_subscription_count, retention_by_month.churned_subscription_count,
-      logical_subscriptions.plan_interval_months]
+      service_subscriptions.plan_interval_months]
     hidden_pivots: {}
     show_null_points: true
     interpolation: linear
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Subscription Start Date: service_subscriptions.started_at_date
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 48
     col: 0
     width: 24
@@ -940,12 +940,12 @@
   - title: Churn Counts Table by Plan Interval
     name: Churn Counts Table by Plan Interval
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_grid
     fields: [retention_by_month.churned_subscription_count, retention_by_month.subscription_month_number,
-      logical_subscriptions.plan_interval, logical_subscriptions.plan_interval_months]
+      service_subscriptions.plan_interval, service_subscriptions.plan_interval_months]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval_months]
+    sorts: [retention_by_month.subscription_month_number, service_subscriptions.plan_interval_months]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -1024,20 +1024,20 @@
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.plan_interval_months]
+    hidden_fields: [service_subscriptions.plan_interval_months]
     hidden_pivots: {}
     show_null_points: true
     interpolation: linear
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Subscription Start Date: service_subscriptions.started_at_date
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 52
     col: 0
     width: 24
@@ -1058,12 +1058,12 @@
   - title: Cohort Churn Rate by Subscription Month Number
     name: Cohort Churn Rate by Subscription Month Number
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_line
-    fields: [logical_subscriptions.started_at_month, retention_by_month.churned_subscription_count,
+    fields: [service_subscriptions.started_at_month, retention_by_month.churned_subscription_count,
       retention_by_month.previously_retained_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [retention_by_month.subscription_month_number, logical_subscriptions.started_at_month]
+    sorts: [retention_by_month.subscription_month_number, service_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -1130,15 +1130,15 @@
     defaults_version: 1
     hidden_fields: [retention_by_month.churned_subscription_count, retention_by_month.previously_retained_subscription_count]
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Subscription Start Date: service_subscriptions.started_at_date
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 58
     col: 0
     width: 24
@@ -1146,12 +1146,12 @@
   - title: Churn Rate Table by Cohort
     name: Churn Rate Table by Cohort
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_grid
-    fields: [logical_subscriptions.started_at_month, retention_by_month.churned_subscription_count,
+    fields: [service_subscriptions.started_at_month, retention_by_month.churned_subscription_count,
       retention_by_month.previously_retained_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [retention_by_month.subscription_month_number, logical_subscriptions.started_at_month]
+    sorts: [retention_by_month.subscription_month_number, service_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -1225,15 +1225,15 @@
     defaults_version: 1
     hidden_fields: [retention_by_month.churned_subscription_count, retention_by_month.previously_retained_subscription_count]
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Subscription Start Date: service_subscriptions.started_at_date
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 65
     col: 0
     width: 24
@@ -1241,12 +1241,12 @@
   - title: Churn Counts Table by Cohort
     name: Churn Counts Table by Cohort
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_grid
-    fields: [logical_subscriptions.started_at_month, retention_by_month.churned_subscription_count,
+    fields: [service_subscriptions.started_at_month, retention_by_month.churned_subscription_count,
       retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [retention_by_month.subscription_month_number, logical_subscriptions.started_at_month]
+    sorts: [retention_by_month.subscription_month_number, service_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
     dynamic_fields:
@@ -1332,15 +1332,15 @@
     show_silhouette: false
     totals_color: "#808080"
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Payment Provider: logical_subscriptions.payment_provider
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Subscription Start Date: service_subscriptions.started_at_date
+      Payment Provider: service_subscriptions.payment_provider
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
       Region: countries.region_name
       Country: countries.name
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Service ID: subscription_services.id
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Service ID: service_subscriptions.service__id
     row: 70
     col: 0
     width: 24
@@ -1357,9 +1357,9 @@
       display: popover
       options: []
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: []
-    field: logical_subscriptions.started_at_date
+    field: service_subscriptions.started_at_date
   - name: Payment Provider
     title: Payment Provider
     type: field_filter
@@ -1370,9 +1370,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Subscription Start Date, Service ID]
-    field: logical_subscriptions.payment_provider
+    field: service_subscriptions.payment_provider
   - name: Plan Interval
     title: Plan Interval
     type: field_filter
@@ -1383,9 +1383,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Subscription Start Date, Service ID]
-    field: logical_subscriptions.plan_interval
+    field: service_subscriptions.plan_interval
   - name: Plan
     title: Plan
     type: field_filter
@@ -1396,9 +1396,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Subscription Start Date, Plan Interval, Service ID]
-    field: logical_subscriptions.plan_summary
+    field: service_subscriptions.plan_summary
   - name: Region
     title: Region
     type: field_filter
@@ -1409,7 +1409,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Subscription Start Date, Service ID]
     field: countries.region_name
   - name: Country
@@ -1422,7 +1422,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Region, Subscription Start Date, Service ID]
     field: countries.name
   - name: Has Fraudulent Charges (Yes / No)
@@ -1435,9 +1435,9 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: []
-    field: logical_subscriptions.has_fraudulent_charges
+    field: service_subscriptions.has_fraudulent_charges
   - name: Has Refunds (Yes / No)
     title: Has Refunds (Yes / No)
     type: field_filter
@@ -1448,9 +1448,9 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: []
-    field: logical_subscriptions.has_refunds
+    field: service_subscriptions.has_refunds
   - name: Service ID
     title: Service ID
     type: field_filter
@@ -1463,6 +1463,6 @@
       options:
       - Monitor
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: []
-    field: subscription_services.id
+    field: service_subscriptions.service__id

--- a/subscription_platform/dashboards/monitor_saasboard__retention.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__retention.dashboard.lookml
@@ -67,12 +67,12 @@
   - title: Most Recent Data
     name: Most Recent Data
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: single_value
-    fields: [daily_active_logical_subscriptions.date_date]
+    fields: [daily_active_service_subscriptions.date_date]
     filters:
-      daily_active_logical_subscriptions.date_date: 1 month
-    sorts: [daily_active_logical_subscriptions.date_date desc]
+      daily_active_service_subscriptions.date_date: 1 month
+    sorts: [daily_active_service_subscriptions.date_date desc]
     limit: 1
     column_limit: 50
     custom_color_enabled: true
@@ -130,16 +130,16 @@
   - title: Retention by Subscription Month Number
     name: Retention by Subscription Month Number
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_column
     fields: [retention_by_month.subscription_month_number, retention_by_month.retained_subscription_count,
-      logical_subscriptions.logical_subscription_count]
+      service_subscriptions.service_subscription_count]
     sorts: [retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${retention_by_month.retained_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${retention_by_month.retained_subscription_count} / ${service_subscriptions.service_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_0
@@ -190,18 +190,18 @@
       retention_by_month.retained_subscription_count: "#0060E0"
       retention_rate: "#080808"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.logical_subscription_count]
+    hidden_fields: [service_subscriptions.service_subscription_count]
     hidden_pivots: {}
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Payment Provider: logical_subscriptions.payment_provider
+      Subscription Start Date: service_subscriptions.started_at_date
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Payment Provider: service_subscriptions.payment_provider
       Region: countries.region_name
       Country: countries.name
-      Service ID: subscription_services.id
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Service ID: service_subscriptions.service__id
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
     row: 8
     col: 0
     width: 12
@@ -209,16 +209,16 @@
   - title: Retention by Cohort
     name: Retention by Cohort
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_column
-    fields: [logical_subscriptions.started_at_month, logical_subscriptions.active_logical_subscription_count,
-      logical_subscriptions.logical_subscription_count]
-    sorts: [logical_subscriptions.started_at_month]
+    fields: [service_subscriptions.started_at_month, service_subscriptions.active_service_subscription_count,
+      service_subscriptions.service_subscription_count]
+    sorts: [service_subscriptions.started_at_month]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${logical_subscriptions.active_logical_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${service_subscriptions.active_service_subscription_count} / ${service_subscriptions.service_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_0
@@ -269,20 +269,20 @@
       retention_by_month.churned_subscription_count: "#FF7139"
       retention_by_month.retained_subscription_count: "#0060E0"
       retention_rate: "#000000"
-      logical_subscriptions.active_logical_subscription_count: "#0060E0"
+      service_subscriptions.active_service_subscription_count: "#0060E0"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.logical_subscription_count]
+    hidden_fields: [service_subscriptions.service_subscription_count]
     hidden_pivots: {}
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Payment Provider: logical_subscriptions.payment_provider
+      Subscription Start Date: service_subscriptions.started_at_date
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Payment Provider: service_subscriptions.payment_provider
       Region: countries.region_name
       Country: countries.name
-      Service ID: subscription_services.id
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Service ID: service_subscriptions.service__id
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
     row: 8
     col: 12
     width: 12
@@ -303,17 +303,17 @@
   - title: Retention Rate by Plan Interval
     name: Retention Rate by Plan Interval
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_line
     fields: [retention_by_month.subscription_month_number, retention_by_month.retained_subscription_count,
-      logical_subscriptions.logical_subscription_count, logical_subscriptions.plan_interval]
-    pivots: [logical_subscriptions.plan_interval]
-    sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval]
+      service_subscriptions.service_subscription_count, service_subscriptions.plan_interval]
+    pivots: [service_subscriptions.plan_interval]
+    sorts: [retention_by_month.subscription_month_number, service_subscriptions.plan_interval]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${retention_by_month.retained_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${retention_by_month.retained_subscription_count} / ${service_subscriptions.service_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_0
@@ -359,18 +359,18 @@
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.logical_subscription_count, retention_by_month.retained_subscription_count]
+    hidden_fields: [service_subscriptions.service_subscription_count, retention_by_month.retained_subscription_count]
     hidden_pivots: {}
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Payment Provider: logical_subscriptions.payment_provider
+      Subscription Start Date: service_subscriptions.started_at_date
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Payment Provider: service_subscriptions.payment_provider
       Region: countries.region_name
       Country: countries.name
-      Service ID: subscription_services.id
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Service ID: service_subscriptions.service__id
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
     row: 19
     col: 0
     width: 24
@@ -378,18 +378,18 @@
   - title: Retention Rate Table by Plan Interval
     name: Retention Rate Table by Plan Interval
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_grid
     fields: [retention_by_month.subscription_month_number, retention_by_month.retained_subscription_count,
-      logical_subscriptions.logical_subscription_count, logical_subscriptions.plan_interval,
-      logical_subscriptions.plan_interval_months]
+      service_subscriptions.service_subscription_count, service_subscriptions.plan_interval,
+      service_subscriptions.plan_interval_months]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval_months]
+    sorts: [retention_by_month.subscription_month_number, service_subscriptions.plan_interval_months]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${retention_by_month.retained_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${retention_by_month.retained_subscription_count} / ${service_subscriptions.service_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_1
@@ -470,21 +470,21 @@
       retention_by_month.churned_subscription_count: "#FF7139"
       retention_by_month.retained_subscription_count: "#005E5D"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.logical_subscription_count, retention_by_month.retained_subscription_count,
-      logical_subscriptions.plan_interval_months]
+    hidden_fields: [service_subscriptions.service_subscription_count, retention_by_month.retained_subscription_count,
+      service_subscriptions.plan_interval_months]
     hidden_pivots: {}
     show_null_points: true
     interpolation: linear
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Payment Provider: logical_subscriptions.payment_provider
+      Subscription Start Date: service_subscriptions.started_at_date
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Payment Provider: service_subscriptions.payment_provider
       Region: countries.region_name
       Country: countries.name
-      Service ID: subscription_services.id
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Service ID: service_subscriptions.service__id
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
     row: 25
     col: 0
     width: 24
@@ -492,17 +492,17 @@
   - title: Retention Counts Table by Plan Interval
     name: Retention Counts Table by Plan Interval
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_grid
     fields: [retention_by_month.subscription_month_number, retention_by_month.retained_subscription_count,
-      logical_subscriptions.plan_interval, logical_subscriptions.plan_interval_months]
+      service_subscriptions.plan_interval, service_subscriptions.plan_interval_months]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [retention_by_month.subscription_month_number, logical_subscriptions.plan_interval_months]
+    sorts: [retention_by_month.subscription_month_number, service_subscriptions.plan_interval_months]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${retention_by_month.retained_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${retention_by_month.retained_subscription_count} / ${service_subscriptions.service_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_2
@@ -586,20 +586,20 @@
       retention_by_month.churned_subscription_count: "#FF7139"
       retention_by_month.retained_subscription_count: "#005E5D"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.plan_interval_months]
+    hidden_fields: [service_subscriptions.plan_interval_months]
     hidden_pivots: {}
     show_null_points: true
     interpolation: linear
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Payment Provider: logical_subscriptions.payment_provider
+      Subscription Start Date: service_subscriptions.started_at_date
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Payment Provider: service_subscriptions.payment_provider
       Region: countries.region_name
       Country: countries.name
-      Service ID: subscription_services.id
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Service ID: service_subscriptions.service__id
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
     row: 29
     col: 0
     width: 24
@@ -620,17 +620,17 @@
   - title: Subscription Month Number Retention Rate by Cohort
     name: Subscription Month Number Retention Rate by Cohort
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_line
-    fields: [logical_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
-      logical_subscriptions.logical_subscription_count, retention_by_month.subscription_month_number]
+    fields: [service_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
+      service_subscriptions.service_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [logical_subscriptions.started_at_month, retention_by_month.subscription_month_number]
+    sorts: [service_subscriptions.started_at_month, retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${retention_by_month.retained_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${retention_by_month.retained_subscription_count} / ${service_subscriptions.service_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_0
@@ -674,18 +674,18 @@
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.logical_subscription_count, retention_by_month.retained_subscription_count]
+    hidden_fields: [service_subscriptions.service_subscription_count, retention_by_month.retained_subscription_count]
     hidden_pivots: {}
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Payment Provider: logical_subscriptions.payment_provider
+      Subscription Start Date: service_subscriptions.started_at_date
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Payment Provider: service_subscriptions.payment_provider
       Region: countries.region_name
       Country: countries.name
-      Service ID: subscription_services.id
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Service ID: service_subscriptions.service__id
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
     row: 35
     col: 0
     width: 12
@@ -693,17 +693,17 @@
   - title: Cohort Retention Rate by Subscription Month Number
     name: Cohort Retention Rate by Subscription Month Number
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_line
-    fields: [logical_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
-      logical_subscriptions.logical_subscription_count, retention_by_month.subscription_month_number]
-    pivots: [logical_subscriptions.started_at_month]
-    sorts: [logical_subscriptions.started_at_month, retention_by_month.subscription_month_number]
+    fields: [service_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
+      service_subscriptions.service_subscription_count, retention_by_month.subscription_month_number]
+    pivots: [service_subscriptions.started_at_month]
+    sorts: [service_subscriptions.started_at_month, retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${retention_by_month.retained_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${retention_by_month.retained_subscription_count} / ${service_subscriptions.service_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_0
@@ -745,18 +745,18 @@
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.logical_subscription_count, retention_by_month.retained_subscription_count]
+    hidden_fields: [service_subscriptions.service_subscription_count, retention_by_month.retained_subscription_count]
     hidden_pivots: {}
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Payment Provider: logical_subscriptions.payment_provider
+      Subscription Start Date: service_subscriptions.started_at_date
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Payment Provider: service_subscriptions.payment_provider
       Region: countries.region_name
       Country: countries.name
-      Service ID: subscription_services.id
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Service ID: service_subscriptions.service__id
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
     row: 35
     col: 12
     width: 12
@@ -764,17 +764,17 @@
   - title: Retention Rate Table by Cohort
     name: Retention Rate Table by Cohort
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_grid
-    fields: [logical_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
-      logical_subscriptions.logical_subscription_count, retention_by_month.subscription_month_number]
+    fields: [service_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
+      service_subscriptions.service_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [logical_subscriptions.started_at_month, retention_by_month.subscription_month_number]
+    sorts: [service_subscriptions.started_at_month, retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${retention_by_month.retained_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${retention_by_month.retained_subscription_count} / ${service_subscriptions.service_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_1
@@ -857,18 +857,18 @@
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.logical_subscription_count, retention_by_month.retained_subscription_count]
+    hidden_fields: [service_subscriptions.service_subscription_count, retention_by_month.retained_subscription_count]
     hidden_pivots: {}
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Payment Provider: logical_subscriptions.payment_provider
+      Subscription Start Date: service_subscriptions.started_at_date
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Payment Provider: service_subscriptions.payment_provider
       Region: countries.region_name
       Country: countries.name
-      Service ID: subscription_services.id
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Service ID: service_subscriptions.service__id
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
     row: 43
     col: 0
     width: 24
@@ -876,17 +876,17 @@
   - title: Retention Counts Table by Cohort
     name: Retention Counts Table by Cohort
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     type: looker_grid
-    fields: [logical_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
-      logical_subscriptions.logical_subscription_count, retention_by_month.subscription_month_number]
+    fields: [service_subscriptions.started_at_month, retention_by_month.retained_subscription_count,
+      service_subscriptions.service_subscription_count, retention_by_month.subscription_month_number]
     pivots: [retention_by_month.subscription_month_number]
-    sorts: [logical_subscriptions.started_at_month, retention_by_month.subscription_month_number]
+    sorts: [service_subscriptions.started_at_month, retention_by_month.subscription_month_number]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${retention_by_month.retained_subscription_count} / ${logical_subscriptions.logical_subscription_count}"
+      expression: "${retention_by_month.retained_subscription_count} / ${service_subscriptions.service_subscription_count}"
       label: Retention Rate
       value_format:
       value_format_name: percent_2
@@ -965,18 +965,18 @@
     show_silhouette: false
     totals_color: "#808080"
     defaults_version: 1
-    hidden_fields: [logical_subscriptions.logical_subscription_count, retention_rate]
+    hidden_fields: [service_subscriptions.service_subscription_count, retention_rate]
     hidden_pivots: {}
     listen:
-      Subscription Start Date: logical_subscriptions.started_at_date
-      Has Refunds (Yes / No): logical_subscriptions.has_refunds
-      Has Fraudulent Charges (Yes / No): logical_subscriptions.has_fraudulent_charges
-      Payment Provider: logical_subscriptions.payment_provider
+      Subscription Start Date: service_subscriptions.started_at_date
+      Has Refunds (Yes / No): service_subscriptions.has_refunds
+      Has Fraudulent Charges (Yes / No): service_subscriptions.has_fraudulent_charges
+      Payment Provider: service_subscriptions.payment_provider
       Region: countries.region_name
       Country: countries.name
-      Service ID: subscription_services.id
-      Plan Interval: logical_subscriptions.plan_interval
-      Plan: logical_subscriptions.plan_summary
+      Service ID: service_subscriptions.service__id
+      Plan Interval: service_subscriptions.plan_interval
+      Plan: service_subscriptions.plan_summary
     row: 48
     col: 0
     width: 24
@@ -993,9 +993,9 @@
       display: popover
       options: []
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: []
-    field: logical_subscriptions.started_at_date
+    field: service_subscriptions.started_at_date
   - name: Payment Provider
     title: Payment Provider
     type: field_filter
@@ -1006,9 +1006,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Subscription Start Date, Service ID]
-    field: logical_subscriptions.payment_provider
+    field: service_subscriptions.payment_provider
   - name: Plan Interval
     title: Plan Interval
     type: field_filter
@@ -1019,9 +1019,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Subscription Start Date, Service ID]
-    field: logical_subscriptions.plan_interval
+    field: service_subscriptions.plan_interval
   - name: Plan
     title: Plan
     type: field_filter
@@ -1032,9 +1032,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Plan Interval, Subscription Start Date, Service ID]
-    field: logical_subscriptions.plan_summary
+    field: service_subscriptions.plan_summary
   - name: Region
     title: Region
     type: field_filter
@@ -1045,7 +1045,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Subscription Start Date, Service ID]
     field: countries.region_name
   - name: Country
@@ -1058,7 +1058,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: [Region, Subscription Start Date, Service ID]
     field: countries.name
   - name: Has Fraudulent Charges (Yes / No)
@@ -1071,9 +1071,9 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: []
-    field: logical_subscriptions.has_fraudulent_charges
+    field: service_subscriptions.has_fraudulent_charges
   - name: Has Refunds (Yes / No)
     title: Has Refunds (Yes / No)
     type: field_filter
@@ -1084,9 +1084,9 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: []
-    field: logical_subscriptions.has_refunds
+    field: service_subscriptions.has_refunds
   - name: Service ID
     title: Service ID
     type: field_filter
@@ -1099,6 +1099,6 @@
       options:
       - Monitor
     model: subscription_platform
-    explore: logical_subscriptions
+    explore: service_subscriptions
     listens_to_filters: []
-    field: subscription_services.id
+    field: service_subscriptions.service__id

--- a/subscription_platform/dashboards/monitor_saasboard__revenue.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__revenue.dashboard.lookml
@@ -62,12 +62,12 @@
   - title: Most Recent Data
     name: Most Recent Data
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: single_value
-    fields: [daily_active_logical_subscriptions.date_date]
+    fields: [daily_active_service_subscriptions.date_date]
     filters:
-      daily_active_logical_subscriptions.date_date: 1 months
-    sorts: [daily_active_logical_subscriptions.date_date desc]
+      daily_active_service_subscriptions.date_date: 1 months
+    sorts: [daily_active_service_subscriptions.date_date desc]
     limit: 1
     column_limit: 50
     custom_color_enabled: true
@@ -112,19 +112,19 @@
   - title: Annual Recurring Revenue
     name: Annual Recurring Revenue
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_column
-    fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-      monthly_active_logical_subscriptions.logical_subscription_count]
+    fields: [monthly_active_service_subscriptions.month_month, monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+      monthly_active_service_subscriptions.service_subscription_count]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_end: 'Yes'
-    sorts: [monthly_active_logical_subscriptions.month_month desc]
+      monthly_active_service_subscriptions.was_active_at_month_end: 'Yes'
+    sorts: [monthly_active_service_subscriptions.month_month desc]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd}\
-        \ / ${monthly_active_logical_subscriptions.logical_subscription_count}"
+      expression: "${monthly_active_service_subscriptions.total_annual_recurring_revenue_usd}\
+        \ / ${monthly_active_service_subscriptions.service_subscription_count}"
       label: ARPU (ARR/Active Subs)
       value_format:
       value_format_name: decimal_1
@@ -163,8 +163,8 @@
       palette_id: mozilla-categorical-0
       options:
         steps: 5
-    y_axes: [{label: "$ in thousands", orientation: left, series: [{axisId: monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
+    y_axes: [{label: "$ in thousands", orientation: left, series: [{axisId: monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
             name: Total Annual Recurring Revenue (USD)}], showLabels: true, showValues: true,
         valueFormat: '$#, "K"', unpinAxis: false, tickDensity: default, tickDensityCustom: 5,
         type: linear}, {label: ARPU in $, orientation: right, series: [{axisId: arpu_arractive_subs,
@@ -181,18 +181,18 @@
     show_null_points: true
     interpolation: linear
     defaults_version: 1
-    hidden_fields: [monthly_active_logical_subscriptions.logical_subscription_count,
+    hidden_fields: [monthly_active_service_subscriptions.service_subscription_count,
       arpu_arractive_subs]
     listen:
-      Active Date: monthly_active_logical_subscriptions.month_month
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
+      Active Date: monthly_active_service_subscriptions.month_month
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
       Has Refunds (Yes / No): current_subscription_state.has_refunds
-      Service ID: subscription_services.id
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
     row: 6
     col: 0
     width: 12
@@ -200,19 +200,19 @@
   - title: Average Revenue Per Unit
     name: Average Revenue Per Unit
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_column
-    fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-      monthly_active_logical_subscriptions.logical_subscription_count]
+    fields: [monthly_active_service_subscriptions.month_month, monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+      monthly_active_service_subscriptions.service_subscription_count]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_end: 'Yes'
-    sorts: [monthly_active_logical_subscriptions.month_month desc]
+      monthly_active_service_subscriptions.was_active_at_month_end: 'Yes'
+    sorts: [monthly_active_service_subscriptions.month_month desc]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd}\
-        \ / ${monthly_active_logical_subscriptions.logical_subscription_count}"
+      expression: "${monthly_active_service_subscriptions.total_annual_recurring_revenue_usd}\
+        \ / ${monthly_active_service_subscriptions.service_subscription_count}"
       label: ARPU (ARR/Active Subs)
       value_format:
       value_format_name: decimal_1
@@ -257,25 +257,25 @@
     series_types:
       arpu_arractive_subs: line
     series_colors:
-      monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd: "#FF7139"
+      monthly_active_service_subscriptions.total_annual_recurring_revenue_usd: "#FF7139"
     show_null_points: true
     interpolation: linear
     defaults_version: 1
-    hidden_fields: [monthly_active_logical_subscriptions.logical_subscription_count,
-      monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd]
+    hidden_fields: [monthly_active_service_subscriptions.service_subscription_count,
+      monthly_active_service_subscriptions.total_annual_recurring_revenue_usd]
     note_state: collapsed
     note_display: hover
     note_text: ARPU = ARR / Active Subscriptions
     listen:
-      Active Date: monthly_active_logical_subscriptions.month_month
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
+      Active Date: monthly_active_service_subscriptions.month_month
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
       Has Refunds (Yes / No): current_subscription_state.has_refunds
-      Service ID: subscription_services.id
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
     row: 6
     col: 12
     width: 12
@@ -283,13 +283,13 @@
   - title: Annual Recurring Revenue by Country
     name: Annual Recurring Revenue by Country
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_column
-    fields: [monthly_active_logical_subscriptions.month_month, countries.name, monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd]
+    fields: [monthly_active_service_subscriptions.month_month, countries.name, monthly_active_service_subscriptions.total_annual_recurring_revenue_usd]
     pivots: [countries.name]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_end: 'Yes'
-    sorts: [monthly_active_logical_subscriptions.month_month desc, countries.name]
+      monthly_active_service_subscriptions.was_active_at_month_end: 'Yes'
+    sorts: [monthly_active_service_subscriptions.month_month desc, countries.name]
     limit: 500
     column_limit: 50
     x_axis_gridlines: false
@@ -325,22 +325,22 @@
       options:
         steps: 5
     y_axes: [{label: "$ in thousands", orientation: left, series: [{axisId: Canada
-              - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: Canada - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: Canada}, {axisId: Germany - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: Germany - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: Germany}, {axisId: Romania - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: Romania - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: Romania}, {axisId: Singapore - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: Singapore - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: Singapore}, {axisId: Switzerland - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: Switzerland - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: Switzerland}, {axisId: United Kingdom - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: United Kingdom - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: United Kingdom}, {axisId: United States - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: United States - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: United States}, {axisId: countries.name___null - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: countries.name___null - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
+              - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: Canada - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: Canada}, {axisId: Germany - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: Germany - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: Germany}, {axisId: Romania - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: Romania - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: Romania}, {axisId: Singapore - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: Singapore - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: Singapore}, {axisId: Switzerland - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: Switzerland - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: Switzerland}, {axisId: United Kingdom - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: United Kingdom - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: United Kingdom}, {axisId: United States - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: United States - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: United States}, {axisId: countries.name___null - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: countries.name___null - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
             name: "∅"}], showLabels: true, showValues: true, valueFormat: '$#, "K"',
         unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Month
@@ -352,15 +352,15 @@
     interpolation: linear
     defaults_version: 1
     listen:
-      Active Date: monthly_active_logical_subscriptions.month_month
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
+      Active Date: monthly_active_service_subscriptions.month_month
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
       Has Refunds (Yes / No): current_subscription_state.has_refunds
-      Service ID: subscription_services.id
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
     row: 14
     col: 0
     width: 12
@@ -368,14 +368,14 @@
   - title: Annual Recurring Revenue by Plan
     name: Annual Recurring Revenue by Plan
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_column
-    fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-      monthly_active_logical_subscriptions.subscription__plan_summary]
-    pivots: [monthly_active_logical_subscriptions.subscription__plan_summary]
+    fields: [monthly_active_service_subscriptions.month_month, monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+      monthly_active_service_subscriptions.subscription__plan_summary]
+    pivots: [monthly_active_service_subscriptions.subscription__plan_summary]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_end: 'Yes'
-    sorts: [monthly_active_logical_subscriptions.month_month desc, monthly_active_logical_subscriptions.subscription__plan_summary]
+      monthly_active_service_subscriptions.was_active_at_month_end: 'Yes'
+    sorts: [monthly_active_service_subscriptions.month_month desc, monthly_active_service_subscriptions.subscription__plan_summary]
     limit: 500
     column_limit: 50
     x_axis_gridlines: false
@@ -411,12 +411,12 @@
       options:
         steps: 5
     y_axes: [{label: "$ in thousands", orientation: left, series: [{axisId: 1 month
-              USD 13.99 - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: 1 month USD 13.99 - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: 1 month USD 13.99}, {axisId: 1 year USD 100.00 - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: 1 year USD 100.00 - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: 1 year USD 100.00}, {axisId: 1 year USD 107.88 - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: 1 year USD 107.88 - monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
+              USD 13.99 - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: 1 month USD 13.99 - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: 1 month USD 13.99}, {axisId: 1 year USD 100.00 - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: 1 year USD 100.00 - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: 1 year USD 100.00}, {axisId: 1 year USD 107.88 - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: 1 year USD 107.88 - monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
             name: 1 year USD 107.88}], showLabels: true, showValues: true, valueFormat: '$#,
           "K"', unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Month
@@ -428,15 +428,15 @@
     interpolation: linear
     defaults_version: 1
     listen:
-      Active Date: monthly_active_logical_subscriptions.month_month
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
+      Active Date: monthly_active_service_subscriptions.month_month
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
       Has Refunds (Yes / No): current_subscription_state.has_refunds
-      Service ID: subscription_services.id
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
     row: 14
     col: 12
     width: 12
@@ -444,19 +444,19 @@
   - title: Month Over Month Growth Rates
     name: Month Over Month Growth Rates
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     type: looker_line
-    fields: [monthly_active_logical_subscriptions.month_month, monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-      monthly_active_logical_subscriptions.logical_subscription_count]
+    fields: [monthly_active_service_subscriptions.month_month, monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+      monthly_active_service_subscriptions.service_subscription_count]
     filters:
-      monthly_active_logical_subscriptions.was_active_at_month_end: 'Yes'
-    sorts: [monthly_active_logical_subscriptions.month_month]
+      monthly_active_service_subscriptions.was_active_at_month_end: 'Yes'
+    sorts: [monthly_active_service_subscriptions.month_month]
     limit: 500
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: "${monthly_active_logical_subscriptions.logical_subscription_count}\
-        \ / offset(${monthly_active_logical_subscriptions.logical_subscription_count},\
+      expression: "${monthly_active_service_subscriptions.service_subscription_count}\
+        \ / offset(${monthly_active_service_subscriptions.service_subscription_count},\
         \ -1) -1"
       label: Active Subscriptions
       value_format:
@@ -465,8 +465,8 @@
       table_calculation: active_subscriptions
       _type_hint: number
     - category: table_calculation
-      expression: "${monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd}\
-        \ / offset(${monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd},\
+      expression: "${monthly_active_service_subscriptions.total_annual_recurring_revenue_usd}\
+        \ / offset(${monthly_active_service_subscriptions.total_annual_recurring_revenue_usd},\
         \ -1) -1"
       label: Annual Recurring Revenue
       value_format:
@@ -503,10 +503,10 @@
       palette_id: mozilla-categorical-0
       options:
         steps: 5
-    y_axes: [{label: '', orientation: left, series: [{axisId: monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            id: monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-            name: Total Annual Recurring Revenue (USD)}, {axisId: monthly_active_logical_subscriptions.logical_subscription_count,
-            id: monthly_active_logical_subscriptions.logical_subscription_count, name: Logical
+    y_axes: [{label: '', orientation: left, series: [{axisId: monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            id: monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+            name: Total Annual Recurring Revenue (USD)}, {axisId: monthly_active_service_subscriptions.service_subscription_count,
+            id: monthly_active_service_subscriptions.service_subscription_count, name: Service
               Subscription Count}], showLabels: true, showValues: true, valueFormat: '',
         unpinAxis: false, tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Month
@@ -521,18 +521,18 @@
     totals_color: "#808080"
     hidden_pivots: {}
     defaults_version: 1
-    hidden_fields: [monthly_active_logical_subscriptions.total_annual_recurring_revenue_usd,
-      monthly_active_logical_subscriptions.logical_subscription_count]
+    hidden_fields: [monthly_active_service_subscriptions.total_annual_recurring_revenue_usd,
+      monthly_active_service_subscriptions.service_subscription_count]
     listen:
-      Active Date: monthly_active_logical_subscriptions.month_month
-      Payment Provider: monthly_active_logical_subscriptions.subscription__payment_provider
-      Plan Interval: monthly_active_logical_subscriptions.subscription__plan_interval
-      Plan: monthly_active_logical_subscriptions.subscription__plan_summary
+      Active Date: monthly_active_service_subscriptions.month_month
+      Payment Provider: monthly_active_service_subscriptions.subscription__payment_provider
+      Plan Interval: monthly_active_service_subscriptions.subscription__plan_interval
+      Plan: monthly_active_service_subscriptions.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
       Has Refunds (Yes / No): current_subscription_state.has_refunds
-      Service ID: subscription_services.id
+      Service ID: monthly_active_service_subscriptions.subscription__service__id
     row: 22
     col: 0
     width: 12
@@ -549,9 +549,9 @@
       display: popover
       options: []
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     listens_to_filters: []
-    field: monthly_active_logical_subscriptions.month_month
+    field: monthly_active_service_subscriptions.month_month
   - name: Payment Provider
     title: Payment Provider
     type: field_filter
@@ -562,9 +562,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     listens_to_filters: [Active Date, Service ID]
-    field: monthly_active_logical_subscriptions.subscription__payment_provider
+    field: monthly_active_service_subscriptions.subscription__payment_provider
   - name: Plan Interval
     title: Plan Interval
     type: field_filter
@@ -575,9 +575,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     listens_to_filters: [Active Date, Service ID]
-    field: monthly_active_logical_subscriptions.subscription__plan_interval
+    field: monthly_active_service_subscriptions.subscription__plan_interval
   - name: Plan
     title: Plan
     type: field_filter
@@ -588,9 +588,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     listens_to_filters: [Active Date, Service ID, Plan Interval]
-    field: monthly_active_logical_subscriptions.subscription__plan_summary
+    field: monthly_active_service_subscriptions.subscription__plan_summary
   - name: Region
     title: Region
     type: field_filter
@@ -601,7 +601,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     listens_to_filters: [Active Date, Service ID]
     field: countries.region_name
   - name: Country
@@ -614,7 +614,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     listens_to_filters: [Active Date, Service ID, Region]
     field: countries.name
   - name: Has Refunds (Yes / No)
@@ -627,7 +627,7 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     listens_to_filters: []
     field: current_subscription_state.has_refunds
   - name: Has Fraudulent Charges (Yes / No)
@@ -640,7 +640,7 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     listens_to_filters: []
     field: current_subscription_state.has_fraudulent_charges
   - name: Service ID
@@ -655,6 +655,6 @@
       options:
       - Monitor
     model: subscription_platform
-    explore: monthly_active_logical_subscriptions
+    explore: monthly_active_service_subscriptions
     listens_to_filters: []
-    field: subscription_services.id
+    field: monthly_active_service_subscriptions.subscription__service__id

--- a/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
+++ b/subscription_platform/dashboards/monitor_saasboard__subscriptions_growth.dashboard.lookml
@@ -67,12 +67,12 @@
   - title: Most Recent Data
     name: Most Recent Data
     model: subscription_platform
-    explore: daily_active_logical_subscriptions
+    explore: daily_active_service_subscriptions
     type: single_value
-    fields: [daily_active_logical_subscriptions.date_date]
+    fields: [daily_active_service_subscriptions.date_date]
     filters:
-      daily_active_logical_subscriptions.date_date: 1 month
-    sorts: [daily_active_logical_subscriptions.date_date desc]
+      daily_active_service_subscriptions.date_date: 1 month
+    sorts: [daily_active_service_subscriptions.date_date desc]
     limit: 1
     column_limit: 50
     custom_color_enabled: true
@@ -130,11 +130,11 @@
   - title: New Subscriptions
     name: New Subscriptions
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: single_value
-    fields: [logical_subscription_events.logical_subscription_count]
+    fields: [service_subscription_events.service_subscription_count]
     filters:
-      logical_subscription_events.type: Subscription Start
+      service_subscription_events.type: Subscription Start
     limit: 1
     column_limit: 50
     custom_color_enabled: true
@@ -172,8 +172,8 @@
     y_axis_combined: true
     show_null_points: false
     interpolation: linear
-    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
-            id: logical_subscription_events.logical_subscription_count, name: Logical
+    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: service_subscription_events.service_subscription_count,
+            id: service_subscription_events.service_subscription_count, name: Service
               Subscription Count}], showLabels: true, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Date
@@ -181,15 +181,15 @@
     y_axis_zoom: true
     defaults_version: 1
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 8
     col: 0
     width: 8
@@ -197,13 +197,13 @@
   - title: Daily New Subscriptions
     name: Daily New Subscriptions
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_column
-    fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.timestamp_date]
-    fill_fields: [logical_subscription_events.timestamp_date]
+    fields: [service_subscription_events.service_subscription_count, service_subscription_events.timestamp_date]
+    fill_fields: [service_subscription_events.timestamp_date]
     filters:
-      logical_subscription_events.type: Subscription Start
-    sorts: [logical_subscription_events.timestamp_date desc]
+      service_subscription_events.type: Subscription Start
+    sorts: [service_subscription_events.timestamp_date desc]
     limit: 5000
     column_limit: 50
     x_axis_gridlines: false
@@ -235,8 +235,8 @@
     totals_color: "#808080"
     show_null_points: true
     interpolation: linear
-    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
-            id: logical_subscription_events.logical_subscription_count, name: Logical
+    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: service_subscription_events.service_subscription_count,
+            id: service_subscription_events.service_subscription_count, name: Service
               Subscription Count}], showLabels: false, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Date
@@ -244,15 +244,15 @@
     y_axis_zoom: true
     defaults_version: 1
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 8
     col: 8
     width: 16
@@ -260,14 +260,14 @@
   - title: Monthly New Subscriptions by Country
     name: Monthly New Subscriptions by Country
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_column
-    fields: [logical_subscription_events.logical_subscription_count, countries.name,
-      logical_subscription_events.timestamp_month]
+    fields: [service_subscription_events.service_subscription_count, countries.name,
+      service_subscription_events.timestamp_month]
     pivots: [countries.name]
     filters:
-      logical_subscription_events.type: Subscription Start
-    sorts: [logical_subscription_events.timestamp_month desc, countries.name]
+      service_subscription_events.type: Subscription Start
+    sorts: [service_subscription_events.timestamp_month desc, countries.name]
     limit: 5000
     column_limit: 100
     x_axis_gridlines: false
@@ -297,8 +297,8 @@
     show_totals_labels: true
     show_silhouette: false
     totals_color: "#808080"
-    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
-            id: logical_subscription_events.logical_subscription_count, name: Logical
+    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: service_subscription_events.service_subscription_count,
+            id: service_subscription_events.service_subscription_count, name: Service
               Subscription Count}], showLabels: false, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Date
@@ -309,15 +309,15 @@
     defaults_version: 1
     hidden_pivots: {}
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 15
     col: 0
     width: 12
@@ -325,14 +325,14 @@
   - title: Monthly New Subscriptions by Plan Interval
     name: Monthly New Subscriptions by Plan Interval
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_column
-    fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.subscription__plan_interval,
-      logical_subscription_events.timestamp_month]
-    pivots: [logical_subscription_events.subscription__plan_interval]
+    fields: [service_subscription_events.service_subscription_count, service_subscription_events.subscription__plan_interval,
+      service_subscription_events.timestamp_month]
+    pivots: [service_subscription_events.subscription__plan_interval]
     filters:
-      logical_subscription_events.type: Subscription Start
-    sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.subscription__plan_interval]
+      service_subscription_events.type: Subscription Start
+    sorts: [service_subscription_events.timestamp_month desc, service_subscription_events.subscription__plan_interval]
     limit: 5000
     column_limit: 50
     x_axis_gridlines: false
@@ -362,8 +362,8 @@
     show_totals_labels: true
     show_silhouette: false
     totals_color: "#808080"
-    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
-            id: logical_subscription_events.logical_subscription_count, name: Logical
+    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: service_subscription_events.service_subscription_count,
+            id: service_subscription_events.service_subscription_count, name: Service
               Subscription Count}], showLabels: false, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Date
@@ -374,15 +374,15 @@
     defaults_version: 1
     hidden_pivots: {}
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 15
     col: 12
     width: 12
@@ -390,14 +390,14 @@
   - title: Monthly New Subscriptions Proportions by Plan Interval
     name: Monthly New Subscriptions Proportions by Plan Interval
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_area
-    fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.subscription__plan_interval,
-      logical_subscription_events.timestamp_month]
-    pivots: [logical_subscription_events.subscription__plan_interval]
+    fields: [service_subscription_events.service_subscription_count, service_subscription_events.subscription__plan_interval,
+      service_subscription_events.timestamp_month]
+    pivots: [service_subscription_events.subscription__plan_interval]
     filters:
-      logical_subscription_events.type: Subscription Start
-    sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.subscription__plan_interval]
+      service_subscription_events.type: Subscription Start
+    sorts: [service_subscription_events.timestamp_month desc, service_subscription_events.subscription__plan_interval]
     limit: 5000
     column_limit: 50
     x_axis_gridlines: false
@@ -427,8 +427,8 @@
     show_totals_labels: false
     show_silhouette: false
     totals_color: "#808080"
-    y_axes: [{label: '', orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
-            id: logical_subscription_events.logical_subscription_count, name: Logical
+    y_axes: [{label: '', orientation: left, series: [{axisId: service_subscription_events.service_subscription_count,
+            id: service_subscription_events.service_subscription_count, name: Service
               Subscription Count}], showLabels: false, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Date
@@ -439,15 +439,15 @@
     defaults_version: 1
     hidden_pivots: {}
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 21
     col: 12
     width: 12
@@ -455,14 +455,14 @@
   - title: Monthly New Subscriptions by Payment Provider
     name: Monthly New Subscriptions by Payment Provider
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_column
-    fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.subscription__payment_provider,
-      logical_subscription_events.timestamp_month]
-    pivots: [logical_subscription_events.subscription__payment_provider]
+    fields: [service_subscription_events.service_subscription_count, service_subscription_events.subscription__payment_provider,
+      service_subscription_events.timestamp_month]
+    pivots: [service_subscription_events.subscription__payment_provider]
     filters:
-      logical_subscription_events.type: Subscription Start
-    sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.subscription__payment_provider]
+      service_subscription_events.type: Subscription Start
+    sorts: [service_subscription_events.timestamp_month desc, service_subscription_events.subscription__payment_provider]
     limit: 5000
     column_limit: 50
     x_axis_gridlines: false
@@ -492,8 +492,8 @@
     show_totals_labels: true
     show_silhouette: false
     totals_color: "#808080"
-    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
-            id: logical_subscription_events.logical_subscription_count, name: Logical
+    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: service_subscription_events.service_subscription_count,
+            id: service_subscription_events.service_subscription_count, name: Service
               Subscription Count}], showLabels: false, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Date
@@ -504,15 +504,15 @@
     defaults_version: 1
     hidden_pivots: {}
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 27
     col: 0
     width: 12
@@ -520,14 +520,14 @@
   - title: Monthly New Subscriptions by Plan
     name: Monthly New Subscriptions by Plan
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_column
-    fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.subscription__plan_summary,
-      logical_subscription_events.timestamp_month]
-    pivots: [logical_subscription_events.subscription__plan_summary]
+    fields: [service_subscription_events.service_subscription_count, service_subscription_events.subscription__plan_summary,
+      service_subscription_events.timestamp_month]
+    pivots: [service_subscription_events.subscription__plan_summary]
     filters:
-      logical_subscription_events.type: Subscription Start
-    sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.subscription__plan_summary]
+      service_subscription_events.type: Subscription Start
+    sorts: [service_subscription_events.timestamp_month desc, service_subscription_events.subscription__plan_summary]
     limit: 5000
     column_limit: 100
     x_axis_gridlines: false
@@ -557,8 +557,8 @@
     show_totals_labels: true
     show_silhouette: false
     totals_color: "#808080"
-    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
-            id: logical_subscription_events.logical_subscription_count, name: Logical
+    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: service_subscription_events.service_subscription_count,
+            id: service_subscription_events.service_subscription_count, name: Service
               Subscription Count}], showLabels: false, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Date
@@ -569,15 +569,15 @@
     defaults_version: 1
     hidden_pivots: {}
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 27
     col: 12
     width: 12
@@ -585,14 +585,14 @@
   - title: Monthly New Subscriptions by Type
     name: Monthly New Subscriptions by Type
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_column
-    fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.reason,
-      logical_subscription_events.timestamp_month]
-    pivots: [logical_subscription_events.reason]
+    fields: [service_subscription_events.service_subscription_count, service_subscription_events.reason,
+      service_subscription_events.timestamp_month]
+    pivots: [service_subscription_events.reason]
     filters:
-      logical_subscription_events.type: Subscription Start
-    sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.reason]
+      service_subscription_events.type: Subscription Start
+    sorts: [service_subscription_events.timestamp_month desc, service_subscription_events.reason]
     limit: 5000
     column_limit: 50
     x_axis_gridlines: false
@@ -622,8 +622,8 @@
     show_totals_labels: true
     show_silhouette: false
     totals_color: "#808080"
-    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
-            id: logical_subscription_events.logical_subscription_count, name: Logical
+    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: service_subscription_events.service_subscription_count,
+            id: service_subscription_events.service_subscription_count, name: Service
               Subscription Count}], showLabels: false, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Date
@@ -634,15 +634,15 @@
     defaults_version: 1
     hidden_pivots: {}
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 37
     col: 0
     width: 12
@@ -650,15 +650,15 @@
   - title: Monthly New Subscriptions by Campaign
     name: Monthly New Subscriptions by Campaign
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_column
-    fields: [logical_subscription_events.logical_subscription_count, logical_subscription_events.timestamp_month,
-      logical_subscription_events.subscription__last_touch_attribution__utm_campaign]
-    pivots: [logical_subscription_events.subscription__last_touch_attribution__utm_campaign]
+    fields: [service_subscription_events.service_subscription_count, service_subscription_events.timestamp_month,
+      service_subscription_events.subscription__last_touch_attribution__utm_campaign]
+    pivots: [service_subscription_events.subscription__last_touch_attribution__utm_campaign]
     filters:
-      logical_subscription_events.type: Subscription Start
-      logical_subscription_events.subscription__last_touch_attribution__utm_campaign: "-EMPTY"
-    sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.subscription__last_touch_attribution__utm_campaign]
+      service_subscription_events.type: Subscription Start
+      service_subscription_events.subscription__last_touch_attribution__utm_campaign: "-EMPTY"
+    sorts: [service_subscription_events.timestamp_month desc, service_subscription_events.subscription__last_touch_attribution__utm_campaign]
     limit: 5000
     column_limit: 50
     x_axis_gridlines: false
@@ -688,8 +688,8 @@
     show_totals_labels: true
     show_silhouette: false
     totals_color: "#808080"
-    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: logical_subscription_events.logical_subscription_count,
-            id: logical_subscription_events.logical_subscription_count, name: Logical
+    y_axes: [{label: New Subscriptions, orientation: left, series: [{axisId: service_subscription_events.service_subscription_count,
+            id: service_subscription_events.service_subscription_count, name: Service
               Subscription Count}], showLabels: false, showValues: true, unpinAxis: false,
         tickDensity: default, tickDensityCustom: 5, type: linear}]
     x_axis_label: Date
@@ -704,15 +704,15 @@
     note_text: This chart only includes new subscriptions that were attributed to
       a campaign.
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 37
     col: 12
     width: 12
@@ -733,19 +733,19 @@
   - title: Net New Subscriptions
     name: Net New Subscriptions
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     type: looker_column
-    fields: [logical_subscription_events.net_logical_subscription_count, logical_subscription_events.timestamp_month,
-      logical_subscription_events.type]
-    pivots: [logical_subscription_events.type]
+    fields: [service_subscription_events.net_service_subscription_count, service_subscription_events.timestamp_month,
+      service_subscription_events.type]
+    pivots: [service_subscription_events.type]
     filters:
-      logical_subscription_events.type: Subscription Start,Subscription End
-    sorts: [logical_subscription_events.timestamp_month desc, logical_subscription_events.type]
+      service_subscription_events.type: Subscription Start,Subscription End
+    sorts: [service_subscription_events.timestamp_month desc, service_subscription_events.type]
     limit: 5000
     column_limit: 50
     dynamic_fields:
     - category: table_calculation
-      expression: sum(pivot_row(${logical_subscription_events.net_logical_subscription_count}))
+      expression: sum(pivot_row(${service_subscription_events.net_service_subscription_count}))
       label: Net subscriptions
       value_format:
       value_format_name:
@@ -780,10 +780,10 @@
     show_silhouette: false
     totals_color: "#0000FF"
     y_axes: [{label: '', orientation: left, series: [{axisId: net_subscriptions, id: net_subscriptions,
-            name: Net subscriptions}, {axisId: Subscription End - logical_subscription_events.net_logical_subscription_count,
-            id: Subscription End - logical_subscription_events.net_logical_subscription_count,
-            name: Canceled}, {axisId: Subscription Start - logical_subscription_events.net_logical_subscription_count,
-            id: Subscription Start - logical_subscription_events.net_logical_subscription_count,
+            name: Net subscriptions}, {axisId: Subscription End - service_subscription_events.net_service_subscription_count,
+            id: Subscription End - service_subscription_events.net_service_subscription_count,
+            name: Canceled}, {axisId: Subscription Start - service_subscription_events.net_service_subscription_count,
+            id: Subscription Start - service_subscription_events.net_service_subscription_count,
             name: New}], showLabels: false, showValues: true, unpinAxis: false, tickDensity: default,
         type: linear}]
     x_axis_label: Date
@@ -792,27 +792,27 @@
     series_types:
       net_subscriptions: line
     series_colors:
-      Subscription End - logical_subscription_events.net_logical_subscription_count: "#FF0000"
-      Subscription Start - logical_subscription_events.net_logical_subscription_count: "#16bd49"
+      Subscription End - service_subscription_events.net_service_subscription_count: "#FF0000"
+      Subscription Start - service_subscription_events.net_service_subscription_count: "#16bd49"
       net_subscriptions: "#0000FF"
     series_labels:
-      Subscription End - logical_subscription_events.net_logical_subscription_count: Canceled
-      Subscription Start - logical_subscription_events.net_logical_subscription_count: New
+      Subscription End - service_subscription_events.net_service_subscription_count: Canceled
+      Subscription Start - service_subscription_events.net_service_subscription_count: New
       net_subscriptions: Net
     show_null_points: true
     interpolation: linear
     defaults_version: 1
     hidden_pivots: {}
     listen:
-      Payment Provider: logical_subscription_events.subscription__payment_provider
-      Plan Interval: logical_subscription_events.subscription__plan_interval
-      Subscription Start Date: logical_subscription_events.timestamp_date
-      Plan: logical_subscription_events.subscription__plan_summary
+      Payment Provider: service_subscription_events.subscription__payment_provider
+      Plan Interval: service_subscription_events.subscription__plan_interval
+      Subscription Start Date: service_subscription_events.timestamp_date
+      Plan: service_subscription_events.subscription__plan_summary
       Region: countries.region_name
       Country: countries.name
       Has Refunds (Yes / No): current_subscription_state.has_refunds
       Has Fraudulent Charges (Yes / No): current_subscription_state.has_fraudulent_charges
-      Service ID: subscription_services.id
+      Service ID: service_subscription_events.subscription__service__id
     row: 49
     col: 0
     width: 12
@@ -829,9 +829,9 @@
       display: popover
       options: []
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     listens_to_filters: []
-    field: logical_subscription_events.timestamp_date
+    field: service_subscription_events.timestamp_date
   - name: Payment Provider
     title: Payment Provider
     type: field_filter
@@ -842,9 +842,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     listens_to_filters: [Service ID, Subscription Start Date]
-    field: logical_subscription_events.subscription__payment_provider
+    field: service_subscription_events.subscription__payment_provider
   - name: Plan Interval
     title: Plan Interval
     type: field_filter
@@ -855,9 +855,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     listens_to_filters: [Service ID, Subscription Start Date]
-    field: logical_subscription_events.subscription__plan_interval
+    field: service_subscription_events.subscription__plan_interval
   - name: Plan
     title: Plan
     type: field_filter
@@ -868,9 +868,9 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     listens_to_filters: [Service ID, Subscription Start Date, Plan Interval]
-    field: logical_subscription_events.subscription__plan_summary
+    field: service_subscription_events.subscription__plan_summary
   - name: Region
     title: Region
     type: field_filter
@@ -881,7 +881,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     listens_to_filters: [Service ID, Subscription Start Date]
     field: countries.region_name
   - name: Country
@@ -894,7 +894,7 @@
       type: checkboxes
       display: popover
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     listens_to_filters: [Region, Service ID, Subscription Start Date]
     field: countries.name
   - name: Has Fraudulent Charges (Yes / No)
@@ -907,7 +907,7 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     listens_to_filters: []
     field: current_subscription_state.has_fraudulent_charges
   - name: Has Refunds (Yes / No)
@@ -920,7 +920,7 @@
       type: dropdown_menu
       display: overflow
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     listens_to_filters: []
     field: current_subscription_state.has_refunds
   - name: Service ID
@@ -935,6 +935,6 @@
       options:
       - Monitor
     model: subscription_platform
-    explore: logical_subscription_events
+    explore: service_subscription_events
     listens_to_filters: []
-    field: subscription_services.id
+    field: service_subscription_events.subscription__service__id


### PR DESCRIPTION
## [DS-3083](https://mozilla-hub.atlassian.net/browse/DS-3083): SubPlat service subscriptions Looker explores

The Monitor SaaSboard was always intended to use the service subscription explores, but in order to have the Monitor SaaSboard ready for the Monitor Plus launch in February 2024 we initially built it using the logical subscription explores since the service subscription ETLs hadn't been set up yet.

The service subscriptions layer of the [SubPlat consolidated reporting ETL design](https://docs.google.com/document/d/13TgTN7UJ_89dhh0S64eh0oDsYNHPdeJyEmLk0uScoGI/edit?tab=t.0) is intended to properly handle multi-product bundle subscriptions, and Monitor will soon be included in a multi-product bundle offer.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
