### PR TITLE
Update subscription plan type dimensions for the "Privacy protection plan" bundle (DENG-8391)

### DIFF
--- a/mozilla_vpn/views/active_subscriptions_table.view.lkml
+++ b/mozilla_vpn/views/active_subscriptions_table.view.lkml
@@ -41,7 +41,13 @@ view: +active_subscriptions_table {
   dimension: plan_interval_type {
     description: "Indicates the plan interval type (1 year, 6 month, 1 month, etc)"
     type: string
-    sql: CONCAT(IF(${product_name} LIKE "%Relay%", CONCAT("bundle", "_"), ""), ${plan_interval_count}, "_", ${plan_interval});;
+    sql:
+      CONCAT(
+        IF(${product_name} LIKE "%Relay%" OR ${product_name} = "Privacy protection plan", "bundle_", ""),
+        ${plan_interval_count},
+        "_",
+        ${plan_interval}
+      ) ;;
   }
 
   dimension: promotion_discounts_amount {

--- a/mozilla_vpn/views/channel_group_proportions_table.view.lkml
+++ b/mozilla_vpn/views/channel_group_proportions_table.view.lkml
@@ -22,7 +22,13 @@ view: +channel_group_proportions_table {
   dimension: plan_group {
     description: "Indicates the plan type (1 year, 6 month, 1 month, bundle 1 year)"
     type: string
-    sql: CONCAT(IF(${product_name} LIKE "%Relay%", CONCAT("bundle", "_"), ""), ${plan_interval_count}, "_", ${plan_interval});;
+    sql:
+      CONCAT(
+        IF(${product_name} LIKE "%Relay%" OR ${product_name} = "Privacy protection plan", "bundle_", ""),
+        ${plan_interval_count},
+        "_",
+        ${plan_interval}
+      ) ;;
   }
 
   dimension: country {

--- a/mozilla_vpn/views/subscription_events_table.view.lkml
+++ b/mozilla_vpn/views/subscription_events_table.view.lkml
@@ -11,7 +11,13 @@ view: +subscription_events_table {
   dimension: plan_interval_type {
     description: "Indicates the plan interval type (1 year, 6 month, 1 month, etc)"
     type: string
-    sql: CONCAT(IF(${product_name} LIKE "%Relay%", CONCAT("bundle", "_"), ""), ${plan_interval_count}, "_", ${plan_interval});;
+    sql:
+      CONCAT(
+        IF(${product_name} LIKE "%Relay%" OR ${product_name} = "Privacy protection plan", "bundle_", ""),
+        ${plan_interval_count},
+        "_",
+        ${plan_interval}
+      ) ;;
   }
 
   dimension: forecast_region {

--- a/mozilla_vpn/views/subscriptions.view.lkml
+++ b/mozilla_vpn/views/subscriptions.view.lkml
@@ -76,7 +76,13 @@ view: +subscriptions {
   dimension: plan_interval_type {
     description: "Indicates the plan interval type (1 year, 6 month, 1 month, etc)"
     type: string
-    sql: CONCAT(IF(${product_name} LIKE "%Relay%", CONCAT("bundle", "_"), ""), ${plan_interval_count}, "_", ${plan_interval});;
+    sql:
+      CONCAT(
+        IF(${product_name} LIKE "%Relay%" OR ${product_name} = "Privacy protection plan", "bundle_", ""),
+        ${plan_interval_count},
+        "_",
+        ${plan_interval}
+      ) ;;
   }
 
   dimension: forecast_region {

--- a/relay/views/active_subscriptions.view.lkml
+++ b/relay/views/active_subscriptions.view.lkml
@@ -42,7 +42,9 @@ view: +active_subscriptions {
     type: string
     sql:  CONCAT(
             CASE
-              WHEN ${product_name} LIKE "%VPN%" THEN "bundle"
+              WHEN ${product_name} LIKE "%VPN%"
+                OR ${product_name} = "Privacy protection plan"
+                THEN "bundle"
               WHEN (${plan_interval} = "month" AND ${plan_amount} > 400)
                 OR (${plan_interval} = "year" AND ${plan_amount} > 4000)
                 THEN "phone"

--- a/relay/views/subscription_events.view.lkml
+++ b/relay/views/subscription_events.view.lkml
@@ -12,7 +12,9 @@ view: +subscription_events {
     type: string
     sql:  CONCAT(
             CASE
-              WHEN ${product_name} LIKE "%VPN%" THEN "bundle"
+              WHEN ${product_name} LIKE "%VPN%"
+                OR ${product_name} = "Privacy protection plan"
+                THEN "bundle"
               WHEN (${plan_interval} = "month" AND ${plan_amount} > 400)
                 OR (${plan_interval} = "year" AND ${plan_amount} > 4000)
                 THEN "phone"

--- a/relay/views/subscriptions.view.lkml
+++ b/relay/views/subscriptions.view.lkml
@@ -42,7 +42,9 @@ view: +subscriptions {
     type: string
     sql:  CONCAT(
           CASE
-            WHEN ${product_name} LIKE "%VPN%" THEN "bundle"
+            WHEN ${product_name} LIKE "%VPN%"
+              OR ${product_name} = "Privacy protection plan"
+              THEN "bundle"
             WHEN (${plan_interval} = "month" AND ${plan_amount} > 400)
               OR (${plan_interval} = "year" AND ${plan_amount} > 4000)
               THEN "phone"


### PR DESCRIPTION
## [DENG-8391](https://mozilla-hub.atlassian.net/browse/DENG-8391): Privacy Product Bundle

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
