### PR TITLE
Add ability to group results by various tags

### DIFF
--- a/fxci/views/task_runs.view.lkml
+++ b/fxci/views/task_runs.view.lkml
@@ -10,6 +10,7 @@ view: task_runs {
   parameter: date_bucket {
     type: string
     label: "Date Bucket"
+    allowed_value: { label: "None" value: "none" }
     allowed_value: { label: "Day" value: "day" }
     allowed_value: { label: "Week" value: "week" }
     allowed_value: { label: "Month" value: "month" }
@@ -21,10 +22,11 @@ view: task_runs {
     type: date
     sql:
     CASE
+      WHEN {% parameter date_bucket %}  = 'day' THEN ${task_runs.submission_date}
       WHEN {% parameter date_bucket %}  = 'week' THEN DATE(FORMAT_DATE('%F', DATE_TRUNC(${task_runs.submission_date} , WEEK(SUNDAY))))
       WHEN {% parameter date_bucket %}  = 'month' THEN DATE(FORMAT_DATE('%Y-%m-%d', DATE_TRUNC(${task_runs.submission_date}, MONTH )))
       WHEN {% parameter date_bucket %}  = 'quarter' THEN DATE(FORMAT_DATE('%Y-%m-%d', DATE_TRUNC(${task_runs.submission_date} , QUARTER)))
-      ELSE ${task_runs.submission_date}
+      ELSE DATE "1970-01-01"
     END
   ;;
   }

--- a/fxci/views/tasks.view.lkml
+++ b/fxci/views/tasks.view.lkml
@@ -5,11 +5,12 @@ view: tasks {
 
   parameter: group_by_tag_field {
     type: string
+    allowed_value: { label: "None" value: "none" }
     allowed_value: { label: "Label" value: "label" }
     allowed_value: { label: "Kind" value: "kind" }
     allowed_value: { label: "Project" value: "project" }
     allowed_value: { label: "Trust Domain" value: "trust_domain" }
-    default_value: "label"
+    default_value: "none"
   }
 
   dimension: group_by_tag {
@@ -20,7 +21,7 @@ view: tasks {
       WHEN {% parameter group_by_tag_field %}  = 'kind' THEN ${tags__kind}
       WHEN {% parameter group_by_tag_field %}  = 'project' THEN ${tags__project}
       WHEN {% parameter group_by_tag_field %}  = 'trust_domain' THEN ${tags__trust_domain}
-      ELSE ${tags__label}
+      ELSE "All Tasks"
     END
   ;;
   }


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
