### PR TITLE
[DENG-7602] Add ping counts to schema errors and missing columns

### DIFF
--- a/monitoring/views/stable_and_derived_table_sizes.view.lkml
+++ b/monitoring/views/stable_and_derived_table_sizes.view.lkml
@@ -1,0 +1,10 @@
+include: "//looker-hub/monitoring/views/stable_and_derived_table_sizes.view.lkml"
+
+view: +stable_and_derived_table_sizes {
+  # for deduping aggregations when joined
+  dimension: primary_key {
+    primary_key: yes
+    hidden: yes
+    sql: CONCAT(${submission_date}, "__", ${dataset_id}, "__", ${table_id}) ;;
+  }
+}

--- a/monitoring/views/structured_missing_columns.view.lkml
+++ b/monitoring/views/structured_missing_columns.view.lkml
@@ -62,4 +62,11 @@ view: +structured_missing_columns {
     sql: (${path_count_last_week} - ${path_count_prev_week}) / nullif(${path_count_prev_week}, 0)  ;;
     value_format_name: percent_2
   }
+
+  measure: total_ping_count {
+    label: "Total Ping Count (last 7 days)"
+    type: sum
+    sql: ${stable_and_derived_table_sizes.row_count} ;;
+    filters: [submission_date: "7 days ago for 7 days"]
+  }
 }

--- a/monitoring/views/telemetry_missing_columns.view.lkml
+++ b/monitoring/views/telemetry_missing_columns.view.lkml
@@ -62,4 +62,11 @@ view: +telemetry_missing_columns {
     sql: (${path_count_last_week} - ${path_count_prev_week}) / nullif(${path_count_prev_week}, 0)  ;;
     value_format_name: percent_2
   }
+
+  measure: total_ping_count {
+    label: "Total Ping Count (last 7 days)"
+    type: sum
+    sql: ${stable_and_derived_table_sizes.row_count} ;;
+    filters: [submission_date: "7 days ago for 7 days"]
+  }
 }


### PR DESCRIPTION
[DENG-7602](https://mozilla-hub.atlassian.net/browse/DENG-7602)

Adds ping counts from stable_and_derived_table_sizes to schema errors and missing columns.  I didn't add the custom measure to the schema_errors view because it doesn't dedupe properly like it does for missing_columns.  I can't figure out why but it works correctly if a custom field is created in the looker UI so I'll just do that.

![image](https://github.com/user-attachments/assets/505c486a-eeb4-493b-9b06-96865159f6d8)

`Sum of Row Count` is the correct value from aggregating in the UI.  `Total Ping Count` is the lookml one I tried

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
