### PR TITLE
Add view and explore for scheduled_articles_report_v1 table

### DIFF
--- a/firefox_desktop/explores/scheduled_articles_report_v1.explore.lkml
+++ b/firefox_desktop/explores/scheduled_articles_report_v1.explore.lkml
@@ -1,0 +1,6 @@
+include: "../views/scheduled_articles_report_v1.view.lkml"
+
+explore: scheduled_articles_report {
+  label: "Numerical data for Scheduled Articles Report in Looker"
+
+}

--- a/firefox_desktop/views/scheduled_articles_report_v1.view.lkml
+++ b/firefox_desktop/views/scheduled_articles_report_v1.view.lkml
@@ -1,0 +1,63 @@
+view: scheduled_articles_report_v1 {
+  sql_table_name: `moz-fx-data-shared-prod.snowflake_migration_derived.scheduled_articles_report_v1` ;;
+
+  dimension: approved_total {
+    type: number
+    description: "The number of items approved on this day"
+    sql: ${TABLE}.approved_total ;;
+  }
+  dimension: manual_outside_rate {
+    type: number
+    description: "The percentage of items added manually outside of the tool on this day."
+    sql: ${TABLE}.manual_outside_rate ;;
+  }
+  dimension: manual_outside_tool_total {
+    type: number
+    description: "The number of items added manually outside of the tool on this day"
+    sql: ${TABLE}.manual_outside_tool_total ;;
+  }
+  dimension: manual_within_tool_total {
+    type: number
+    description: "The number of items added manually in the tool on this day"
+    sql: ${TABLE}.manual_within_tool_total ;;
+  }
+  dimension: rejected_total {
+    type: number
+    description: "The number of items rejected on this day"
+    sql: ${TABLE}.rejected_total ;;
+  }
+  dimension: rejection_rate {
+    type: number
+    description: "The percentage of items rejected on this day."
+    sql: ${TABLE}.rejection_rate ;;
+  }
+  dimension: removal_rate {
+    type: number
+    description: "The percentage of items removed on this day."
+    sql: ${TABLE}.removal_rate ;;
+  }
+  dimension: removed_total {
+    type: number
+    description: "The number of items removed on this day"
+    sql: ${TABLE}.removed_total ;;
+  }
+  dimension: schedule_failure_rate {
+    type: number
+    description: "The percentage of total items rejected, removed, or added manually outside of the tool on this day."
+    sql: ${TABLE}.schedule_failure_rate ;;
+  }
+  dimension_group: scheduled {
+    type: time
+    description: "The date of the schedule"
+    timeframes: [raw, time, date, week, month, quarter, year]
+    sql: ${TABLE}.scheduled_date ;;
+  }
+  dimension: scheduled_surface_id {
+    type: string
+    description: "The curated rec destination where the corpus item is expected to appear (NEW_TAB_EN_INTL, NEW_TAB_EN_US, NEW_TAB_DE_DE, NEW_TAB_EN_GB)."
+    sql: ${TABLE}.scheduled_surface_id ;;
+  }
+  measure: count {
+    type: count
+  }
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
