### PR TITLE
Remove desktop_search_alert_latest_daily

### DIFF
--- a/search/search.model.lkml
+++ b/search/search.model.lkml
@@ -1,7 +1,6 @@
 connection: "telemetry"
 label: "Search"
 include: "//looker-hub/search/explores/*"
-include: "//looker-hub/search/views/desktop_search_alert_latest_daily.view.lkml"
 include: "views/bizdev_search_core_users.view.lkml"
 include: "views/mobile_search_aggregates.view.lkml"
 include: "views/mobile_search_clients_engines_sources_daily.view.lkml"
@@ -45,8 +44,6 @@ explore: +desktop_search_counts {
 
   persist_with: search_clients_engines_sources_daily_last_updated
 }
-
-explore: desktop_search_alert_latest_daily {}
 
 explore: business_development_core_search_users_monthly {
   view_name: bizdev_search_core_users


### PR DESCRIPTION
`mozdata.analysis.desktop_search_alert_latest_daily` got removed. It was only used on a dashboard that hasn't been in use for a while and got archived. Removing artifacts in this PR

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
