### PR TITLE
Add slot hour and tb billed sum to bigquery_usage

### DIFF
--- a/monitoring/views/bigquery_usage.view.lkml
+++ b/monitoring/views/bigquery_usage.view.lkml
@@ -41,6 +41,13 @@ view: +bigquery_usage {
     value_format: "#,##0.00"
   }
 
+  measure: sum_total_terabytes_billed{
+    type: sum_distinct
+    sql_distinct_key: ${job_id} ;;
+    sql: ${total_terabytes_billed} ;;
+    value_format: "#,##0.00"
+  }
+
   measure: number_of_unique_job_ids{
     description: "count distinct number of job ids"
     type: count_distinct
@@ -58,5 +65,6 @@ view: +bigquery_usage {
     type: sum_distinct
     sql_distinct_key: ${job_id} ;;
     sql: ${total_slot_hours} ;;
+    value_format: "#,##0.0"
   }
 }

--- a/monitoring/views/bigquery_usage.view.lkml
+++ b/monitoring/views/bigquery_usage.view.lkml
@@ -53,4 +53,10 @@ view: +bigquery_usage {
     sql: ${cost} ;;
     value_format: "$#.00;($#.00)"
   }
+
+  measure: sum_slot_hours{
+    type: sum_distinct
+    sql_distinct_key: ${job_id} ;;
+    sql: ${total_slot_hours} ;;
+  }
 }


### PR DESCRIPTION
Adds a slot hour and tb billed sum measures to bigquery usage because `sum_total_cost_usd` is misleading due to there being different ways queries can be billed

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
