### PR TITLE
Add new cohort_churn view and explore

### DIFF
--- a/combined_browser_metrics/explores/cohort_churn.explore.lkml
+++ b/combined_browser_metrics/explores/cohort_churn.explore.lkml
@@ -1,0 +1,5 @@
+include: "../views/cohort_churn.view.lkml"
+
+explore: cohort_churn {
+
+}

--- a/combined_browser_metrics/views/cohort_churn.view.lkml
+++ b/combined_browser_metrics/views/cohort_churn.view.lkml
@@ -1,0 +1,93 @@
+include: "//looker-hub/combined_browser_metrics/views/cohort_churn.view.lkml"
+
+view: +cohort_churn {
+  dimension: num_clients_in_cohort {
+    hidden: yes
+  }
+
+  dimension: num_clients_returned_on_day_1 {
+    hidden: yes
+  }
+
+  dimension: num_clients_returned_any_day_between_day_1_and_day_2 {
+    hidden: yes
+  }
+
+  dimension: num_clients_returned_any_day_between_day_1_and_day_3 {
+    hidden: yes
+  }
+
+  dimension: num_clients_returned_any_day_between_day_1_and_day_4 {
+    hidden: yes
+  }
+
+  dimension: num_clients_returned_any_day_between_day_1_and_day_5 {
+    hidden: yes
+  }
+
+  dimension: num_clients_returned_any_day_between_day_1_and_day_6 {
+    hidden: yes
+  }
+
+  dimension: num_clients_returned_any_day_between_day_1_and_day_7 {
+    hidden: yes
+  }
+
+  dimension: num_clients_returned_any_day_between_day_1_and_day_28 {
+    hidden: yes
+  }
+
+  measure: sum_num_clients_in_cohort {
+    type: sum
+    sql: ${num_clients_in_cohort} ;;
+    label: "Number of Clients in Cohort"
+  }
+
+  measure: sum_num_clients_returned_on_day_1 {
+    type: sum
+    sql: ${num_clients_returned_on_day_1} ;;
+    label: "Number of Clients Returned on Day 1"
+  }
+
+  measure: sum_num_clients_returned_any_day_between_day_1_and_day_2 {
+    type: sum
+    sql: ${num_clients_returned_any_day_between_day_1_and_day_2} ;;
+    label: "Number of Clients Returned Any Day Between Day 1 and Day 2"
+  }
+
+  measure: sum_num_clients_returned_any_day_between_day_1_and_day_3 {
+    type: sum
+    sql: ${num_clients_returned_any_day_between_day_1_and_day_3} ;;
+    label: "Number of Clients Returned Any Day Between Day 1 and Day 3"
+  }
+
+  measure: sum_num_clients_returned_any_day_between_day_1_and_day_4 {
+    type: sum
+    sql: ${num_clients_returned_any_day_between_day_1_and_day_4} ;;
+    label: "Number of Clients Returned Any Day Between Day 1 and Day 4"
+  }
+
+  measure: sum_num_clients_returned_any_day_between_day_1_and_day_5 {
+    type: sum
+    sql: ${num_clients_returned_any_day_between_day_1_and_day_5} ;;
+    label: "Number of Clients Returned Any Day Between Day 1 and Day 5"
+  }
+
+  measure: sum_num_clients_returned_any_day_between_day_1_and_day_6 {
+    type: sum
+    sql: ${num_clients_returned_any_day_between_day_1_and_day_6} ;;
+    label: "Number of Clients Returned Any Day Between Day 1 and Day 6"
+  }
+
+  measure: sum_num_clients_returned_any_day_between_day_1_and_day_7 {
+    type: sum
+    sql: ${num_clients_returned_any_day_between_day_1_and_day_7} ;;
+    label: "Number of Clients Returned Any Day Between Day 1 and Day 7"
+  }
+
+  measure: sum_num_clients_returned_any_day_between_day_1_and_day_28 {
+    type: sum
+    sql: ${num_clients_returned_any_day_between_day_1_and_day_28} ;;
+    label: "Number of Clients Returned Any Day Between Day 1 and Day 28"
+  }
+}


### PR DESCRIPTION
Related JIRA ticket: [DENG-8925](https://mozilla-hub.atlassian.net/browse/DENG-8925)

This is a fix for my earlier attempt [PR-1109](https://github.com/mozilla/looker-spoke-default/pull/1109/files) which had to be reverted due to lookml errors.  This time, I am hiding some dimensions and adding measures with different names (before I was adding measures with the same names as existing dimensions which was causing issues).

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
