### PR TITLE
add include for persist, change is_reply to boolean, take out extrane…

### DIFF
--- a/relay_backend/explores/events_stream_with_extras.explore.lkml
+++ b/relay_backend/explores/events_stream_with_extras.explore.lkml
@@ -1,5 +1,5 @@
 include: "../views/events_stream_with_extras.view.lkml"
-
+include: "//looker-hub/relay_backend/datagroups/events_stream_table_last_updated.datagroup.lkml"
 
 explore: events_stream_with_extras {
   hidden: no
@@ -8,7 +8,7 @@ explore: events_stream_with_extras {
 
   always_filter: {
     filters: [
-      submission_date: "This year to second",
+      submission_date: "28 days",
     ]
   }
 

--- a/relay_backend/views/events_stream_with_extras.view.lkml
+++ b/relay_backend/views/events_stream_with_extras.view.lkml
@@ -1,28 +1,24 @@
 include: "//looker-hub/relay_backend/views/events_stream_table.view.lkml"
 
-  view: events_stream_with_extras {
-    extends: [events_stream_table]
+view: events_stream_with_extras {
+  extends: [events_stream_table]
 
-    dimension: event_id {
-      sql: CONCAT(${TABLE}.document_id, '-',"somestring";;
-      type:  string
-    }
+  dimension: extra_is_reply {
+    sql: LAX_BOOL(${TABLE}.event_extra.is_reply) ;;
+    type:  yesno
+    group_label: "Event extra"
+    group_item_label: "Is Reply"
+  }
 
-    dimension: extra_is_reply {
-      sql: LAX_STRING(${TABLE}.event_extra.is_reply) ;;
-      type:  string
-      group_label: "Event extra"
-    }
+  dimension: extra_premium_status{
+    sql: LAX_STRING(${TABLE}.event_extra.premium_status) ;;
+    type:  string
+    group_label: "Event extra"
+    group_item_label: "Premium Status"
+  }
 
-    dimension: extra_premium_status{
-        sql: LAX_STRING(${TABLE}.event_extra.premium_status) ;;
-        type:  string
-        group_label: "Event extra"
-      }
-
-    measure: event_count {
-      type: count
-      description: "The number of times the event(s) occurred."
-    }
-
+  measure: event_count {
+    type: count
+    description: "The number of times the event(s) occurred."
+  }
 }


### PR DESCRIPTION
…ous dimensions, revise submission-date filter time, add group item labels

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
