### PR TITLE
Use `subscription_platform.exchange_rates` and `subscription_platform.vat_rates` views where appropriate

### DIFF
--- a/relay/explores/active_subscriptions.explore.lkml
+++ b/relay/explores/active_subscriptions.explore.lkml
@@ -1,7 +1,7 @@
 include: "../views/active_subscriptions.view"
 include: "../views/table_metadata.view"
 include: "/mozilla_vpn/views/vat_rates.view"
-include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view"
+include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: active_subscriptions {
   # from: active_subscriptions
@@ -30,11 +30,10 @@ explore: active_subscriptions {
     relationship: one_to_one
   }
 
-  join: exchange_rates_table {
-    view_label: "Exchange Rates"
+  join: exchange_rates {
     fields: [price]
-    sql_on: UPPER(${active_subscriptions.plan_currency}) = UPPER(${exchange_rates_table.base_currency})
-      AND ${active_subscriptions.active_raw} = ${exchange_rates_table.date_raw};;
+    sql_on: UPPER(${active_subscriptions.plan_currency}) = UPPER(${exchange_rates.base_currency})
+      AND ${active_subscriptions.active_raw} = ${exchange_rates.date_raw};;
     relationship: one_to_one
   }
 }

--- a/relay/explores/active_subscriptions.explore.lkml
+++ b/relay/explores/active_subscriptions.explore.lkml
@@ -1,6 +1,6 @@
 include: "../views/active_subscriptions.view"
 include: "../views/table_metadata.view"
-include: "/mozilla_vpn/views/vat_rates.view"
+include: "/subscription_platform/views/vat_rates.view.lkml"
 include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: active_subscriptions {

--- a/relay/explores/subscriptions.explore.lkml
+++ b/relay/explores/subscriptions.explore.lkml
@@ -1,5 +1,5 @@
 include: "../views/subscriptions.view"
-include: "/mozilla_vpn/views/vat_rates.view"
+include: "/subscription_platform/views/vat_rates.view.lkml"
 include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 include: "../views/table_metadata.view"
 

--- a/relay/explores/subscriptions.explore.lkml
+++ b/relay/explores/subscriptions.explore.lkml
@@ -1,6 +1,6 @@
 include: "../views/subscriptions.view"
 include: "/mozilla_vpn/views/vat_rates.view"
-include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view"
+include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 include: "../views/table_metadata.view"
 
 explore: subscriptions {
@@ -63,11 +63,10 @@ explore: subscriptions {
       relationship: one_to_one
     }
 
-    join: exchange_rates_table {
-      view_label: "Exchange Rates"
+    join: exchange_rates {
       fields: [price]
-      sql_on: UPPER(${subscriptions.plan_currency}) = UPPER(${exchange_rates_table.base_currency})
-        AND ${subscriptions__active.active_raw} = ${exchange_rates_table.date_raw};;
+      sql_on: UPPER(${subscriptions.plan_currency}) = UPPER(${exchange_rates.base_currency})
+        AND ${subscriptions__active.active_raw} = ${exchange_rates.date_raw};;
       relationship: one_to_one
     }
   }

--- a/relay/views/active_subscriptions.view.lkml
+++ b/relay/views/active_subscriptions.view.lkml
@@ -109,7 +109,7 @@ view: +active_subscriptions {
           ${plan_interval} = "month"
         THEN
           1 / ${plan_interval_count}
-        END * ${count} * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
+        END * ${count} * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates.price}, 1) / 100;;
     hidden: yes
   }
 

--- a/relay/views/subscriptions.view.lkml
+++ b/relay/views/subscriptions.view.lkml
@@ -163,7 +163,7 @@ view: +subscriptions {
         ${plan_interval} = "month"
       THEN
         12 / ${plan_interval_count}
-      END * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates_table.price}, 1) / 100;;
+      END * (${plan_amount} - IFNULL(${promotion_discounts_amount}, 0)) / (1 + IFNULL(${vat_rates.vat}, 0)) * IFNULL(${exchange_rates.price}, 1) / 100;;
     value_format: "$#,##0.00"
   }
   }

--- a/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
@@ -2,7 +2,7 @@ include: "../views/daily_active_logical_subscriptions.view.lkml"
 include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "../views/vat_rates.view.lkml"
 include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: daily_active_logical_subscriptions {

--- a/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
@@ -3,7 +3,7 @@ include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
 include: "/mozilla_vpn/views/vat_rates.view.lkml"
-include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
+include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: daily_active_logical_subscriptions {
 
@@ -56,12 +56,11 @@ explore: daily_active_logical_subscriptions {
     ]
   }
 
-  join: exchange_rates_table {
-    view_label: "Exchange Rates"
+  join: exchange_rates {
     sql_on:
-      ${daily_active_logical_subscriptions.subscription__plan_currency} = ${exchange_rates_table.base_currency}
-      AND ${exchange_rates_table.quote_currency} = 'USD'
-      AND ${daily_active_logical_subscriptions.date_raw} = ${exchange_rates_table.date_raw} ;;
+      ${daily_active_logical_subscriptions.subscription__plan_currency} = ${exchange_rates.base_currency}
+      AND ${exchange_rates.quote_currency} = 'USD'
+      AND ${daily_active_logical_subscriptions.date_raw} = ${exchange_rates.date_raw} ;;
     type: left_outer
     relationship: many_to_one
     fields: [

--- a/subscription_platform/explores/daily_active_service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_service_subscriptions.explore.lkml
@@ -3,7 +3,7 @@ include: "../views/service_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
 include: "/mozilla_vpn/views/vat_rates.view.lkml"
-include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
+include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: daily_active_service_subscriptions {
   join: countries {
@@ -56,12 +56,11 @@ explore: daily_active_service_subscriptions {
     ]
   }
 
-  join: exchange_rates_table {
-    view_label: "Exchange Rates"
+  join: exchange_rates {
     sql_on:
-      ${daily_active_service_subscriptions.subscription__plan_currency} = ${exchange_rates_table.base_currency}
-      AND ${exchange_rates_table.quote_currency} = 'USD'
-      AND ${daily_active_service_subscriptions.date_raw} = ${exchange_rates_table.date_raw} ;;
+      ${daily_active_service_subscriptions.subscription__plan_currency} = ${exchange_rates.base_currency}
+      AND ${exchange_rates.quote_currency} = 'USD'
+      AND ${daily_active_service_subscriptions.date_raw} = ${exchange_rates.date_raw} ;;
     type: left_outer
     relationship: many_to_one
     fields: [

--- a/subscription_platform/explores/daily_active_service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_service_subscriptions.explore.lkml
@@ -2,7 +2,7 @@ include: "../views/daily_active_service_subscriptions.view.lkml"
 include: "../views/service_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "../views/vat_rates.view.lkml"
 include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: daily_active_service_subscriptions {

--- a/subscription_platform/explores/logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/logical_subscriptions.explore.lkml
@@ -2,7 +2,7 @@ include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
 include: "/mozilla_vpn/views/vat_rates.view.lkml"
-include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
+include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: logical_subscriptions {
   join: countries {
@@ -50,12 +50,11 @@ explore: logical_subscriptions {
     ]
   }
 
-  join: exchange_rates_table {
-    view_label: "Exchange Rates"
+  join: exchange_rates {
     sql_on:
-      ${logical_subscriptions.plan_currency} = ${exchange_rates_table.base_currency}
-      AND ${exchange_rates_table.quote_currency} = 'USD'
-      AND ${logical_subscriptions.effective_date} = ${exchange_rates_table.date_raw} ;;
+      ${logical_subscriptions.plan_currency} = ${exchange_rates.base_currency}
+      AND ${exchange_rates.quote_currency} = 'USD'
+      AND ${logical_subscriptions.effective_date} = ${exchange_rates.date_raw} ;;
     type: left_outer
     relationship: many_to_one
     fields: [

--- a/subscription_platform/explores/logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/logical_subscriptions.explore.lkml
@@ -1,7 +1,7 @@
 include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "../views/vat_rates.view.lkml"
 include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: logical_subscriptions {

--- a/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
@@ -2,7 +2,7 @@ include: "../views/monthly_active_logical_subscriptions.view.lkml"
 include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "../views/vat_rates.view.lkml"
 include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: monthly_active_logical_subscriptions {

--- a/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
@@ -3,7 +3,7 @@ include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
 include: "/mozilla_vpn/views/vat_rates.view.lkml"
-include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
+include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: monthly_active_logical_subscriptions {
 
@@ -70,12 +70,11 @@ explore: monthly_active_logical_subscriptions {
     ]
   }
 
-  join: exchange_rates_table {
-    view_label: "Exchange Rates"
+  join: exchange_rates {
     sql_on:
-      ${monthly_active_logical_subscriptions.subscription__plan_currency} = ${exchange_rates_table.base_currency}
-      AND ${exchange_rates_table.quote_currency} = 'USD'
-      AND ${monthly_active_logical_subscriptions.effective_date} = ${exchange_rates_table.date_raw} ;;
+      ${monthly_active_logical_subscriptions.subscription__plan_currency} = ${exchange_rates.base_currency}
+      AND ${exchange_rates.quote_currency} = 'USD'
+      AND ${monthly_active_logical_subscriptions.effective_date} = ${exchange_rates.date_raw} ;;
     type: left_outer
     relationship: many_to_one
     fields: [

--- a/subscription_platform/explores/monthly_active_service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_service_subscriptions.explore.lkml
@@ -2,7 +2,7 @@ include: "../views/monthly_active_service_subscriptions.view.lkml"
 include: "../views/service_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "../views/vat_rates.view.lkml"
 include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: monthly_active_service_subscriptions {

--- a/subscription_platform/explores/monthly_active_service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_service_subscriptions.explore.lkml
@@ -3,7 +3,7 @@ include: "../views/service_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
 include: "/mozilla_vpn/views/vat_rates.view.lkml"
-include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
+include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: monthly_active_service_subscriptions {
   join: countries {
@@ -71,12 +71,11 @@ explore: monthly_active_service_subscriptions {
     ]
   }
 
-  join: exchange_rates_table {
-    view_label: "Exchange Rates"
+  join: exchange_rates {
     sql_on:
-      ${monthly_active_service_subscriptions.subscription__plan_currency} = ${exchange_rates_table.base_currency}
-      AND ${exchange_rates_table.quote_currency} = 'USD'
-      AND ${monthly_active_service_subscriptions.effective_date} = ${exchange_rates_table.date_raw} ;;
+      ${monthly_active_service_subscriptions.subscription__plan_currency} = ${exchange_rates.base_currency}
+      AND ${exchange_rates.quote_currency} = 'USD'
+      AND ${monthly_active_service_subscriptions.effective_date} = ${exchange_rates.date_raw} ;;
     type: left_outer
     relationship: many_to_one
     fields: [

--- a/subscription_platform/explores/service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/service_subscriptions.explore.lkml
@@ -1,7 +1,7 @@
 include: "../views/service_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "/mozilla_vpn/views/vat_rates.view.lkml"
+include: "../views/vat_rates.view.lkml"
 include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: service_subscriptions {

--- a/subscription_platform/explores/service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/service_subscriptions.explore.lkml
@@ -2,7 +2,7 @@ include: "../views/service_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
 include: "/mozilla_vpn/views/vat_rates.view.lkml"
-include: "//looker-hub/mozilla_vpn/views/exchange_rates_table.view.lkml"
+include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: service_subscriptions {
   join: countries {
@@ -50,12 +50,11 @@ explore: service_subscriptions {
     ]
   }
 
-  join: exchange_rates_table {
-    view_label: "Exchange Rates"
+  join: exchange_rates {
     sql_on:
-      ${service_subscriptions.plan_currency} = ${exchange_rates_table.base_currency}
-      AND ${exchange_rates_table.quote_currency} = 'USD'
-      AND ${service_subscriptions.effective_date} = ${exchange_rates_table.date_raw} ;;
+      ${service_subscriptions.plan_currency} = ${exchange_rates.base_currency}
+      AND ${exchange_rates.quote_currency} = 'USD'
+      AND ${service_subscriptions.effective_date} = ${exchange_rates.date_raw} ;;
     type: left_outer
     relationship: many_to_one
     fields: [

--- a/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
@@ -277,7 +277,7 @@ view: +daily_active_logical_subscriptions {
     type: number
     sql:
       ${annual_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 
@@ -324,7 +324,7 @@ view: +daily_active_logical_subscriptions {
     type: number
     sql:
       ${monthly_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/daily_active_service_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_service_subscriptions.view.lkml
@@ -291,7 +291,7 @@ view: +daily_active_service_subscriptions {
     type: number
     sql:
       ${annual_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 
@@ -338,7 +338,7 @@ view: +daily_active_service_subscriptions {
     type: number
     sql:
       ${monthly_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -297,7 +297,7 @@ view: +logical_subscriptions {
     type: number
     sql:
       ${annual_recurring_net_revenue}
-      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 
@@ -343,7 +343,7 @@ view: +logical_subscriptions {
     type: number
     sql:
       ${monthly_recurring_net_revenue}
-      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -299,7 +299,7 @@ view: +monthly_active_logical_subscriptions {
     type: number
     sql:
       ${annual_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 
@@ -346,7 +346,7 @@ view: +monthly_active_logical_subscriptions {
     type: number
     sql:
       ${monthly_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/monthly_active_service_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_service_subscriptions.view.lkml
@@ -313,7 +313,7 @@ view: +monthly_active_service_subscriptions {
     type: number
     sql:
       ${annual_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 
@@ -360,7 +360,7 @@ view: +monthly_active_service_subscriptions {
     type: number
     sql:
       ${monthly_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/service_subscriptions.view.lkml
+++ b/subscription_platform/views/service_subscriptions.view.lkml
@@ -305,7 +305,7 @@ view: +service_subscriptions {
     type: number
     sql:
       ${annual_recurring_net_revenue}
-      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 
@@ -351,7 +351,7 @@ view: +service_subscriptions {
     type: number
     sql:
       ${monthly_recurring_net_revenue}
-      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates_table.price}, 0)) ;;
+      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/vat_rates.view.lkml
+++ b/subscription_platform/views/vat_rates.view.lkml
@@ -1,0 +1,43 @@
+include: "//looker-hub/subscription_platform/views/vat_rates.view.lkml"
+
+view: +vat_rates {
+  derived_table: {
+    sql:
+      SELECT
+        *,
+        LAG(effective_date) OVER (PARTITION BY country_code ORDER BY effective_date) AS prev_effective_date,
+        LEAD(effective_date) OVER (PARTITION BY country_code ORDER BY effective_date) AS next_effective_date,
+      FROM
+        mozdata.subscription_platform.vat_rates ;;
+  }
+
+  dimension_group: next_effective {
+    sql: ${TABLE}.next_effective_date ;;
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+
+  dimension_group: prev_effective {
+    sql: ${TABLE}.prev_effective_date ;;
+    type: time
+    timeframes: [
+      raw,
+      date,
+      week,
+      month,
+      quarter,
+      year,
+    ]
+    convert_tz: no
+    datatype: date
+  }
+}


### PR DESCRIPTION
The associated BigQuery views were added in https://github.com/mozilla/bigquery-etl/pull/7957 and https://github.com/mozilla/bigquery-etl/pull/7958, the Looker views were just added in https://github.com/mozilla/lookml-generator/pull/1276, and this makes use of them for all non-VPN-specific explores.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
