### PR TITLE
[DENG-9430] Optimize browser KPI forecast

### DIFF
--- a/kpi/datagroups/daily_active_users_by_product_category_last_updated.datagroup.lkml
+++ b/kpi/datagroups/daily_active_users_by_product_category_last_updated.datagroup.lkml
@@ -1,0 +1,13 @@
+datagroup: daily_active_users_by_product_category_last_updated {
+  label: "events_table Last Updated"
+  sql_trigger: SELECT MAX(storage_last_modified_time)
+    FROM (
+
+    SELECT MAX(storage_last_modified_time) AS storage_last_modified_time
+    FROM `moz-fx-data-shared-prod`.`region-us`.INFORMATION_SCHEMA.TABLE_STORAGE
+    WHERE (table_schema = 'telemetry_derived' AND table_name = 'daily_active_users_by_product_category_v1')
+
+    ) ;;
+  description: "Updates for daily_active_users_by_product_category_v1 when referenced tables are modified."
+  max_cache_age: "24 hours"
+}

--- a/kpi/explores/browser_kpi_forecasts_2025.explore.lkml
+++ b/kpi/explores/browser_kpi_forecasts_2025.explore.lkml
@@ -1,8 +1,54 @@
 include: "/kpi/views/browser_kpi_forecasts_2025.view.lkml"
 include: "../../combined_browser_metrics/views/active_users_aggregates.view.lkml"
+include: "../datagroups/daily_active_users_by_product_category_last_updated.datagroup.lkml"
 
 explore: browser_kpi_forecasts_2025 {
   label: "Browser KPI Forecasts 2025"
   description: "Browser KPI Forecasts 2025"
   view_name: browser_kpi_forecasts_2025
+
+  aggregate_table: rollup__forecast_name__submission_day_date__desktop {
+    query: {
+      dimensions: [forecast_name, submission_day_date]
+      measures: [actual_dau28ma_2024, actual_dau28ma_2025, forecast_dau28ma, most_recent_actuals]
+      filters: [
+        browser_kpi_forecasts_2025.forecast_name: "actuals,AUG holiday smart AUG,AUG holiday smart PRIOR FORECAST",
+        browser_kpi_forecasts_2025.product: "desktop"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: daily_active_users_by_product_category_last_updated
+    }
+  }
+
+  aggregate_table: rollup__forecast_name__submission_day_date__mobile {
+    query: {
+      dimensions: [forecast_name, submission_day_date]
+      measures: [actual_dau28ma_2024, actual_dau28ma_2025, forecast_dau28ma, most_recent_actuals]
+      filters: [
+        browser_kpi_forecasts_2025.forecast_name: "actuals,AUG holiday smart AUG,AUG holiday smart PRIOR FORECAST",
+        browser_kpi_forecasts_2025.product: "mobile"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: daily_active_users_by_product_category_last_updated
+    }
+  }
+
+  aggregate_table: rollup__forecast_name__submission_day_date__mobile_desktop {
+    query: {
+      dimensions: [forecast_name, submission_day_date]
+      measures: [actual_dau28ma_2024, actual_dau28ma_2025, forecast_dau28ma, most_recent_actuals]
+      filters: [
+        browser_kpi_forecasts_2025.forecast_name: "actuals,AUG holiday smart AUG,AUG holiday smart PRIOR FORECAST",
+        browser_kpi_forecasts_2025.product: "mobile,desktop"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: daily_active_users_by_product_category_last_updated
+    }
+  }
 }

--- a/kpi/views/browser_kpi_forecasts_2025.view.lkml
+++ b/kpi/views/browser_kpi_forecasts_2025.view.lkml
@@ -10,15 +10,10 @@ view: browser_kpi_forecasts_2025 {
       aua AS (
         SELECT
           submission_date,
-          CASE
-            WHEN app_name = "Firefox Desktop" THEN "desktop"
-            WHEN app_name IN ("Fenix", "Firefox iOS", "Focus Android", "Focus iOS", "focus_android", "focus_ios") THEN "mobile"
-            ELSE "other"
-          END AS product,
-          SUM(dau) AS dau
-        FROM `moz-fx-data-shared-prod.telemetry.active_users_aggregates`
+          product_category AS product,
+          dau
+        FROM `moz-fx-data-shared-prod.telemetry.daily_active_users_by_product_category`
         WHERE submission_date >= "2023-12-01"
-        GROUP BY submission_date, product
       ),
 
       aua_ma AS (


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-9430

This uses the new `moz-fx-data-shared-prod.telemetry.daily_active_users_by_product_category` to improve query performance for https://mozilla.cloud.looker.com/dashboards/1245. This PR also adds aggregate tables for caching

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
