### PR TITLE
[DENG-9437] Aggregate tables for Browser Active Users

### DIFF
--- a/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
+++ b/combined_browser_metrics/explores/active_users_aggregates.explore.lkml
@@ -37,6 +37,187 @@ explore: active_users_aggregates {
     }
   }
 
+  aggregate_table: rollup__submission_date__60_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users, monthly_active_users, weekly_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Firefox Desktop",
+        active_users_aggregates.submission_date: "after 60 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__115_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Firefox Desktop",
+        active_users_aggregates.submission_date: "after 115 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__mobile__60_weeks{
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users, monthly_active_users, weekly_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Fenix,Firefox iOS,Focus Android,Focus iOS",
+        active_users_aggregates.submission_date: "after 60 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__mobile__115_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Fenix,Firefox iOS,Focus Android,Focus iOS",
+        active_users_aggregates.submission_date: "after 115 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__fenix__60_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users, monthly_active_users, weekly_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Fenix",
+        active_users_aggregates.submission_date: "after 60 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__fenix__115_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Fenix",
+        active_users_aggregates.submission_date: "after 115 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__firefox_ios__60_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users, monthly_active_users, weekly_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Firefox iOS",
+        active_users_aggregates.submission_date: "after 60 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__firefox_ios__115_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Firefox iOS",
+        active_users_aggregates.submission_date: "after 115 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__focus_android__60_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users, monthly_active_users, weekly_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Focus Android",
+        active_users_aggregates.submission_date: "after 60 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__focus_ios__60_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Focus iOS,\"focus_ios\"",
+        active_users_aggregates.submission_date: "after 60 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__combined__60_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users, monthly_active_users, weekly_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Fenix,Firefox iOS,Focus Android,Focus iOS,Firefox Desktop,\"focus_android\",\"focus_ios\"",
+        active_users_aggregates.submission_date: "after 60 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+  aggregate_table: rollup__submission_date__combined__115_weeks {
+    query: {
+      dimensions: [submission_date]
+      measures: [daily_active_users]
+      filters: [
+        active_users_aggregates.app_name: "Fenix,Firefox iOS,Focus Android,Focus iOS,Firefox Desktop,\"focus_android\",\"focus_ios\"",
+        active_users_aggregates.submission_date: "after 115 weeks ago"
+      ]
+    }
+
+    materialization: {
+      datagroup_trigger: active_users_aggregates_last_updated
+    }
+  }
+
+
   persist_with: active_users_aggregates_last_updated
 
 }


### PR DESCRIPTION
https://mozilla-hub.atlassian.net/browse/DENG-9437

This PR adds aggregate tables which improve the performance of the[Browser Active Users dashboard](https://mozilla.cloud.looker.com/dashboards/1178)

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
