### PR TITLE
Tab Group Prototype Explore (new view and explore, affects no existing views or explores)

### DIFF
--- a/firefox_desktop/explores/prototype_user_segmentation_tabgroups_v1.explore.lkml
+++ b/firefox_desktop/explores/prototype_user_segmentation_tabgroups_v1.explore.lkml
@@ -1,0 +1,6 @@
+include: "../views/prototype_user_segmentation_tabgroups_v1.view.lkml"
+
+explore: prototype_user_segmentation_tabgroups{
+  label: "Prototype User Segmentation Tab Groups"
+
+}

--- a/firefox_desktop/explores/prototype_user_segmentation_tabgroups_v1.explore.lkml
+++ b/firefox_desktop/explores/prototype_user_segmentation_tabgroups_v1.explore.lkml
@@ -1,6 +1,6 @@
 include: "../views/prototype_user_segmentation_tabgroups_v1.view.lkml"
 
-explore: prototype_user_segmentation_tabgroups{
+explore: prototype_user_segmentation_tabgroups_v1{
   label: "Prototype User Segmentation Tab Groups"
 
 }

--- a/firefox_desktop/views/prototype_user_segmentation_tabgroups_v1.view.lkml
+++ b/firefox_desktop/views/prototype_user_segmentation_tabgroups_v1.view.lkml
@@ -1,69 +1,74 @@
-view: prototype_user_segmentation_tabgroups {
+view: prototype_user_segmentation_tabgroups_v1 {
   sql_table_name: `moz-fx-data-shared-prod.firefox_desktop.prototype_user_segmentation_tabgroups_v1` ;;
 
+  dimension: branch {
+    type: string
+    sql: ${TABLE}.branch ;;
+  }
+  dimension_group: first_tab_group {
+    type: time
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.first_tab_group_date ;;
+  }
   dimension: legacy_client_id {
     type: string
-    primary_key: yes
     sql: ${TABLE}.legacy_client_id ;;
   }
-  dimension: first_tab_group_date {
-      type: date
-      sql: ${TABLE}.first_tab_group_date ;;
-  }
   dimension: os {
-      type: string
-      sql: ${TABLE}.os ;;
+    type: string
+    sql: ${TABLE}.os ;;
   }
   dimension: os_version {
-      type: string
-      sql: ${TABLE}.os_version ;;
-  }
-  dimension: branch {
-      type: string
-      sql: ${TABLE}.branch ;;
+    type: string
+    sql: ${TABLE}.os_version ;;
   }
   dimension: selection {
-      type: string
-      sql: ${TABLE}.selection ;;
-  }
-  dimension: tabgroup_open_group_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_open_group_event_sum ;;
+    type: string
+    sql: ${TABLE}.selection ;;
   }
   dimension: tabgroup_create_group_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_create_group_event_sum ;;
-  }
-  dimension: tabgroup_ungroup_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_ungroup_event_sum ;;
+    type: number
+    sql: ${TABLE}.tabgroup_create_group_event_sum ;;
   }
   dimension: tabgroup_delete_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_delete_event_sum ;;
+    type: number
+    sql: ${TABLE}.tabgroup_delete_event_sum ;;
+  }
+  dimension: tabgroup_open_group_event_sum {
+    type: number
+    sql: ${TABLE}.tabgroup_open_group_event_sum ;;
   }
   dimension: tabgroup_reopen_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_reopen_event_sum ;;
+    type: number
+    sql: ${TABLE}.tabgroup_reopen_event_sum ;;
   }
   dimension: tabgroup_save_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_save_event_sum ;;
+    type: number
+    sql: ${TABLE}.tabgroup_save_event_sum ;;
   }
   dimension: tabgroup_smart_tab_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_smart_tab_event_sum ;;
-  }
-  dimension: tabgroup_smart_tab_suggest_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_smart_tab_suggest_event_sum ;;
+    type: number
+    sql: ${TABLE}.tabgroup_smart_tab_event_sum ;;
   }
   dimension: tabgroup_smart_tab_optin_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_smart_tab_optin_event_sum ;;
+    type: number
+    sql: ${TABLE}.tabgroup_smart_tab_optin_event_sum ;;
+  }
+  dimension: tabgroup_smart_tab_suggest_event_sum {
+    type: number
+    sql: ${TABLE}.tabgroup_smart_tab_suggest_event_sum ;;
   }
   dimension: tabgroup_smart_tab_topic_event_sum {
-      type: number
-      sql: ${TABLE}.tabgroup_smart_tab_topic_event_sum ;;
+    type: number
+    sql: ${TABLE}.tabgroup_smart_tab_topic_event_sum ;;
+  }
+  dimension: tabgroup_ungroup_event_sum {
+    type: number
+    sql: ${TABLE}.tabgroup_ungroup_event_sum ;;
+  }
+  measure: count {
+    type: count
   }
 }

--- a/firefox_desktop/views/prototype_user_segmentation_tabgroups_v1.view.lkml
+++ b/firefox_desktop/views/prototype_user_segmentation_tabgroups_v1.view.lkml
@@ -1,0 +1,69 @@
+view: prototype_user_segmentation_tabgroups {
+  sql_table_name: `moz-fx-data-shared-prod.firefox_desktop.prototype_user_segmentation_tabgroups_v1` ;;
+
+  dimension: legacy_client_id {
+    type: string
+    primary_key: yes
+    sql: ${TABLE}.legacy_client_id ;;
+  }
+  dimension: first_tab_group_date {
+      type: date
+      sql: ${TABLE}.first_tab_group_date ;;
+  }
+  dimension: os {
+      type: string
+      sql: ${TABLE}.os ;;
+  }
+  dimension: os_version {
+      type: string
+      sql: ${TABLE}.os_version ;;
+  }
+  dimension: branch {
+      type: string
+      sql: ${TABLE}.branch ;;
+  }
+  dimension: selection {
+      type: string
+      sql: ${TABLE}.selection ;;
+  }
+  dimension: tabgroup_open_group_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_open_group_event_sum ;;
+  }
+  dimension: tabgroup_create_group_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_create_group_event_sum ;;
+  }
+  dimension: tabgroup_ungroup_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_ungroup_event_sum ;;
+  }
+  dimension: tabgroup_delete_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_delete_event_sum ;;
+  }
+  dimension: tabgroup_reopen_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_reopen_event_sum ;;
+  }
+  dimension: tabgroup_save_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_save_event_sum ;;
+  }
+  dimension: tabgroup_smart_tab_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_smart_tab_event_sum ;;
+  }
+  dimension: tabgroup_smart_tab_suggest_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_smart_tab_suggest_event_sum ;;
+  }
+  dimension: tabgroup_smart_tab_optin_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_smart_tab_optin_event_sum ;;
+  }
+  dimension: tabgroup_smart_tab_topic_event_sum {
+      type: number
+      sql: ${TABLE}.tabgroup_smart_tab_topic_event_sum ;;
+  }
+}


### PR DESCRIPTION
This PR adds an explore for the prototype table in BigQuery that fulfills [this ticket](https://mozilla-hub.atlassian.net/browse/DENG-9420?focusedCommentId=1126438).

We'll use this explore to make a dashboard for stakeholders for collecting feedback on what kind of information they need about tab group users.

Once we have their feedback, if we move forward with a continuously updated table, we'll delete this view and explore and make a new one for that table. 

This procedure works more smoothly than accepting feedback and then attempting to keep, while changing the schema, of an existing production table with data in it. 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
