### PR TITLE
fix: add count measures to BigEye views

### DIFF
--- a/bigeye/views/issues.view.lkml
+++ b/bigeye/views/issues.view.lkml
@@ -115,7 +115,7 @@ view: +issues {
   dimension: metric_metadata_field_name {
     hidden: yes
   }
-  dimension: opened_time_seconds {
+  dimension: opened_time {
     type: date
     sql:
       CASE
@@ -123,28 +123,12 @@ view: +issues {
         THEN DATE(TIMESTAMP_SECONDS(CAST(${TABLE}.opened_time_seconds AS INT64)))
       END ;;
   }
-  dimension: closed_time_second {
+  dimension: closed_time {
     type: date
     sql:
       CASE
-        WHEN ${TABLE}.closed_time_second IS NOT NULL
-        THEN DATE(TIMESTAMP_SECONDS(CAST(${TABLE}.closed_time_second AS INT64)))
-      END ;;
-  }
-  dimension: time_to_ack_seconds {
-    type: date
-    sql:
-      CASE
-        WHEN ${TABLE}.time_to_ack_seconds IS NOT NULL
-        THEN DATE(TIMESTAMP_SECONDS(CAST(${TABLE}.time_to_ack_seconds AS INT64)))
-      END ;;
-  }
-  dimension: time_to_resolve_seconds {
-    type: date
-    sql:
-      CASE
-        WHEN ${TABLE}.time_to_resolve_seconds IS NOT NULL
-        THEN DATE(TIMESTAMP_SECONDS(CAST(${TABLE}.time_to_resolve_seconds AS INT64)))
+        WHEN ${TABLE}.closed_time_seconds IS NOT NULL
+        THEN DATE(TIMESTAMP_SECONDS(CAST(${TABLE}.closed_time_seconds AS INT64)))
       END ;;
   }
   measure: count {

--- a/bigeye/views/issues.view.lkml
+++ b/bigeye/views/issues.view.lkml
@@ -147,4 +147,7 @@ view: +issues {
         THEN DATE(TIMESTAMP_SECONDS(CAST(${TABLE}.time_to_resolve_seconds AS INT64)))
       END ;;
   }
+  measure: count {
+    type: count
+  }
 }

--- a/bigeye/views/metrics.view.lkml
+++ b/bigeye/views/metrics.view.lkml
@@ -154,4 +154,15 @@ view: +metrics {
   dimension: refreshed_at {
     hidden: yes
   }
+  dimension: metric_metadata_created_at {
+    type: date
+    sql:
+      CASE
+        WHEN ${TABLE}.metric_metadata_created_at IS NOT NULL
+        THEN DATE(TIMESTAMP_SECONDS(CAST(${TABLE}.metric_metadata_created_at AS INT64)))
+      END ;;
+  }
+  measure: count {
+    type: count
+  }
 }


### PR DESCRIPTION
## Description
Add the `count` measure to `issues` and `metrics` BigEye views. 

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
