### PR TITLE
refactor(SubPlat): Use subscription revenue columns from underlying BigQuery views (DENG-9508)

### DIFF
--- a/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_logical_subscriptions.explore.lkml
@@ -2,8 +2,6 @@ include: "../views/daily_active_logical_subscriptions.view.lkml"
 include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "../views/vat_rates.view.lkml"
-include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: daily_active_logical_subscriptions {
 
@@ -40,32 +38,4 @@ explore: daily_active_logical_subscriptions {
     type: left_outer
     relationship: many_to_one
   }
-
-  join: vat_rates {
-    view_label: "VAT Rates"
-    sql_on:
-      ${daily_active_logical_subscriptions.subscription__country_code} = ${vat_rates.country_code}
-      AND (
-        ${daily_active_logical_subscriptions.date_raw} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
-        OR (${daily_active_logical_subscriptions.date_raw} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
-      ) ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      vat
-    ]
-  }
-
-  join: exchange_rates {
-    sql_on:
-      ${daily_active_logical_subscriptions.subscription__plan_currency} = ${exchange_rates.base_currency}
-      AND ${exchange_rates.quote_currency} = 'USD'
-      AND ${daily_active_logical_subscriptions.date_raw} = ${exchange_rates.date_raw} ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      price
-    ]
-  }
-
 }

--- a/subscription_platform/explores/daily_active_service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/daily_active_service_subscriptions.explore.lkml
@@ -2,8 +2,6 @@ include: "../views/daily_active_service_subscriptions.view.lkml"
 include: "../views/service_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "../views/vat_rates.view.lkml"
-include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: daily_active_service_subscriptions {
   join: countries {
@@ -39,32 +37,5 @@ explore: daily_active_service_subscriptions {
     sql_on: ${table_metadata.table_name} = 'daily_active_service_subscriptions_v1' ;;
     type: left_outer
     relationship: many_to_one
-  }
-
-  join: vat_rates {
-    view_label: "VAT Rates"
-    sql_on:
-      ${daily_active_service_subscriptions.subscription__country_code} = ${vat_rates.country_code}
-      AND (
-        ${daily_active_service_subscriptions.date_raw} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
-        OR (${daily_active_service_subscriptions.date_raw} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
-      ) ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      vat
-    ]
-  }
-
-  join: exchange_rates {
-    sql_on:
-      ${daily_active_service_subscriptions.subscription__plan_currency} = ${exchange_rates.base_currency}
-      AND ${exchange_rates.quote_currency} = 'USD'
-      AND ${daily_active_service_subscriptions.date_raw} = ${exchange_rates.date_raw} ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      price
-    ]
   }
 }

--- a/subscription_platform/explores/logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/logical_subscriptions.explore.lkml
@@ -1,8 +1,6 @@
 include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "../views/vat_rates.view.lkml"
-include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: logical_subscriptions {
   join: countries {
@@ -33,32 +31,5 @@ explore: logical_subscriptions {
     sql_on: ${table_metadata.table_name} = 'logical_subscriptions_history_v1' ;;
     type: left_outer
     relationship: many_to_one
-  }
-
-  join: vat_rates {
-    view_label: "VAT Rates"
-    sql_on:
-      ${logical_subscriptions.country_code} = ${vat_rates.country_code}
-      AND (
-        ${logical_subscriptions.effective_date} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
-        OR (${logical_subscriptions.effective_date} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
-      ) ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      vat
-    ]
-  }
-
-  join: exchange_rates {
-    sql_on:
-      ${logical_subscriptions.plan_currency} = ${exchange_rates.base_currency}
-      AND ${exchange_rates.quote_currency} = 'USD'
-      AND ${logical_subscriptions.effective_date} = ${exchange_rates.date_raw} ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      price
-    ]
   }
 }

--- a/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_logical_subscriptions.explore.lkml
@@ -2,8 +2,6 @@ include: "../views/monthly_active_logical_subscriptions.view.lkml"
 include: "../views/logical_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "../views/vat_rates.view.lkml"
-include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: monthly_active_logical_subscriptions {
 
@@ -54,32 +52,4 @@ explore: monthly_active_logical_subscriptions {
     type: left_outer
     relationship: many_to_one
   }
-
-  join: vat_rates {
-    view_label: "VAT Rates"
-    sql_on:
-      ${monthly_active_logical_subscriptions.subscription__country_code} = ${vat_rates.country_code}
-      AND (
-        ${monthly_active_logical_subscriptions.effective_date} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
-        OR (${monthly_active_logical_subscriptions.effective_date} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
-      ) ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      vat
-    ]
-  }
-
-  join: exchange_rates {
-    sql_on:
-      ${monthly_active_logical_subscriptions.subscription__plan_currency} = ${exchange_rates.base_currency}
-      AND ${exchange_rates.quote_currency} = 'USD'
-      AND ${monthly_active_logical_subscriptions.effective_date} = ${exchange_rates.date_raw} ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      price
-    ]
-  }
-
 }

--- a/subscription_platform/explores/monthly_active_service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/monthly_active_service_subscriptions.explore.lkml
@@ -2,8 +2,6 @@ include: "../views/monthly_active_service_subscriptions.view.lkml"
 include: "../views/service_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "../views/vat_rates.view.lkml"
-include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: monthly_active_service_subscriptions {
   join: countries {
@@ -54,32 +52,5 @@ explore: monthly_active_service_subscriptions {
     sql_on: ${table_metadata.table_name} = 'monthly_active_service_subscriptions_v1' ;;
     type: left_outer
     relationship: many_to_one
-  }
-
-  join: vat_rates {
-    view_label: "VAT Rates"
-    sql_on:
-      ${monthly_active_service_subscriptions.subscription__country_code} = ${vat_rates.country_code}
-      AND (
-        ${monthly_active_service_subscriptions.effective_date} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
-        OR (${monthly_active_service_subscriptions.effective_date} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
-      ) ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      vat
-    ]
-  }
-
-  join: exchange_rates {
-    sql_on:
-      ${monthly_active_service_subscriptions.subscription__plan_currency} = ${exchange_rates.base_currency}
-      AND ${exchange_rates.quote_currency} = 'USD'
-      AND ${monthly_active_service_subscriptions.effective_date} = ${exchange_rates.date_raw} ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      price
-    ]
   }
 }

--- a/subscription_platform/explores/service_subscriptions.explore.lkml
+++ b/subscription_platform/explores/service_subscriptions.explore.lkml
@@ -1,8 +1,6 @@
 include: "../views/service_subscriptions.view.lkml"
 include: "../views/table_metadata.view.lkml"
 include: "/shared/views/countries.view.lkml"
-include: "../views/vat_rates.view.lkml"
-include: "//looker-hub/subscription_platform/views/exchange_rates.view.lkml"
 
 explore: service_subscriptions {
   join: countries {
@@ -33,32 +31,5 @@ explore: service_subscriptions {
     sql_on: ${table_metadata.table_name} = 'service_subscriptions_v1' ;;
     type: left_outer
     relationship: many_to_one
-  }
-
-  join: vat_rates {
-    view_label: "VAT Rates"
-    sql_on:
-      ${service_subscriptions.country_code} = ${vat_rates.country_code}
-      AND (
-        ${service_subscriptions.effective_date} BETWEEN ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} - 1
-        OR (${service_subscriptions.effective_date} >= ${vat_rates.effective_date} AND ${vat_rates.next_effective_date} IS NULL)
-      ) ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      vat
-    ]
-  }
-
-  join: exchange_rates {
-    sql_on:
-      ${service_subscriptions.plan_currency} = ${exchange_rates.base_currency}
-      AND ${exchange_rates.quote_currency} = 'USD'
-      AND ${service_subscriptions.effective_date} = ${exchange_rates.date_raw} ;;
-    type: left_outer
-    relationship: many_to_one
-    fields: [
-      price
-    ]
   }
 }

--- a/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_logical_subscriptions.view.lkml
@@ -32,6 +32,10 @@ view: +daily_active_logical_subscriptions {
   dimension: subscription__country_name {
     map_layer_name: countries
   }
+  dimension: subscription__country_vat_rate {
+    group_item_label: "Country VAT Rate"
+    value_format_name: percent_2
+  }
 
   dimension: subscription__services_quantity {
     type: number
@@ -58,6 +62,23 @@ view: +daily_active_logical_subscriptions {
   dimension: subscription__plan_amount {
     value_format_name: decimal_2
   }
+  dimension: subscription__plan_amount_usd {
+    group_item_label: "Plan Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: subscription__plan_currency_usd_exchange_rate {
+    group_item_label: "Plan Currency USD Exchange Rate"
+    value_format_name: percent_4
+  }
+
+  dimension: subscription__current_period_discount_amount_usd {
+    group_item_label: "Current Period Discount Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: subscription__ongoing_discount_amount_usd {
+    group_item_label: "Ongoing Discount Amount (USD)"
+    value_format_name: usd
+  }
 
   dimension_group: subscription_active {
     type: duration
@@ -66,265 +87,13 @@ view: +daily_active_logical_subscriptions {
     intervals: [day, week, month, quarter, year]
   }
 
-  dimension_group: until_current_period_ends {
-    type: duration
-    sql_start:
-      LEAST(
-        TIMESTAMP_SUB(TIMESTAMP(${TABLE}.date + 1), INTERVAL 1 MICROSECOND),
-        ${TABLE}.subscription.current_period_ends_at
-      ) ;;
-    sql_end: ${TABLE}.subscription.current_period_ends_at ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-
-  dimension: current_period_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__current_period_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_revenue_months {
-    type: number
-    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__is_trial} IS TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${current_period_discounted_plan_amount}
-              / ${subscription__plan_interval_months}
-              * ${current_period_annual_recurring_revenue_months}
-            )
-        WHEN ${subscription__plan_interval_type} IN ('week', 'day')
-          THEN ${current_period_discounted_plan_amount}
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__ongoing_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension_group: after_current_period_before_ongoing_discount_ends {
-    type: duration
-    sql_start: ${subscription__current_period_ends_at_raw} ;;
-    sql_end: TIMESTAMP_SUB(${subscription__ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_months {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (12 - ${current_period_annual_recurring_revenue_months})
-        ELSE
-          LEAST(
-            (
-              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_months}) + 1)
-              * ${subscription__plan_interval_months}
-            ),
-            (12 - ${current_period_annual_recurring_revenue_months})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (52 - ${subscription__plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${subscription__plan_interval_count}) + 1)
-              * ${subscription__plan_interval_count}
-            ),
-            (52 - ${subscription__plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_days {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (365 - ${subscription__plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_count}) + 1)
-              * ${subscription__plan_interval_count}
-            ),
-            (365 - ${subscription__plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__auto_renew} IS NOT TRUE
-          OR COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_months}
-              * ${ongoing_discounted_annual_recurring_revenue_months}
-            )
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_weeks}
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_days}
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__auto_renew} IS NOT TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_months}
-              * GREATEST(
-                (
-                  12
-                  - ${current_period_annual_recurring_revenue_months}
-                  - ${ongoing_discounted_annual_recurring_revenue_months}
-                ),
-                0
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_count}
-              * GREATEST(
-                (
-                  52
-                  - ${subscription__plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
-                ),
-                0
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_count}
-              * GREATEST(
-                (
-                  365
-                  - ${subscription__plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_days}
-                ),
-                0
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: annual_recurring_gross_revenue {
-    type: number
-    sql:
-      ${current_period_annual_recurring_gross_revenue}
-      + ${ongoing_discounted_annual_recurring_gross_revenue}
-      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_net_revenue {
-    type: number
-    sql:
-      ${annual_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_revenue_usd {
-    group_label: "Subscription"
-    label: "Annual Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${annual_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
+  dimension: subscription__annual_recurring_revenue_usd {
+    group_item_label: "Annual Recurring Revenue (USD)"
     value_format_name: usd
   }
 
-  dimension: monthly_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__is_trial} IS TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${subscription__plan_interval_count}
-                * IF(${subscription__auto_renew}, GREATEST((4 - ${subscription__plan_interval_count}), 0), 0)
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${subscription__plan_interval_count}
-                * IF(${subscription__auto_renew}, GREATEST((30 - ${subscription__plan_interval_count}), 0), 0)
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_net_revenue {
-    type: number
-    sql:
-      ${monthly_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_revenue_usd {
-    group_label: "Subscription"
-    label: "Monthly Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${monthly_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
+  dimension: subscription__monthly_recurring_revenue_usd {
+    group_item_label: "Monthly Recurring Revenue (USD)"
     value_format_name: usd
   }
 
@@ -352,7 +121,7 @@ view: +daily_active_logical_subscriptions {
     label: "Total Annual Recurring Revenue (USD)"
     type: sum_distinct
     sql_distinct_key: ${subscription__id} ;;
-    sql: ${annual_recurring_revenue_usd} ;;
+    sql: ${subscription__annual_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 
@@ -360,7 +129,7 @@ view: +daily_active_logical_subscriptions {
     label: "Total Monthly Recurring Revenue (USD)"
     type: sum_distinct
     sql_distinct_key: ${subscription__id} ;;
-    sql: ${monthly_recurring_revenue_usd} ;;
+    sql: ${subscription__monthly_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 }

--- a/subscription_platform/views/daily_active_service_subscriptions.view.lkml
+++ b/subscription_platform/views/daily_active_service_subscriptions.view.lkml
@@ -32,6 +32,10 @@ view: +daily_active_service_subscriptions {
   dimension: subscription__country_name {
     map_layer_name: countries
   }
+  dimension: subscription__country_vat_rate {
+    group_item_label: "Country VAT Rate"
+    value_format_name: percent_2
+  }
 
   dimension: subscription__service__id {
     sql: ${TABLE}.service_id ;;
@@ -72,6 +76,23 @@ view: +daily_active_service_subscriptions {
   dimension: subscription__plan_amount {
     value_format_name: decimal_2
   }
+  dimension: subscription__plan_amount_usd {
+    group_item_label: "Plan Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: subscription__plan_currency_usd_exchange_rate {
+    group_item_label: "Plan Currency USD Exchange Rate"
+    value_format_name: percent_4
+  }
+
+  dimension: subscription__current_period_discount_amount_usd {
+    group_item_label: "Current Period Discount Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: subscription__ongoing_discount_amount_usd {
+    group_item_label: "Ongoing Discount Amount (USD)"
+    value_format_name: usd
+  }
 
   dimension_group: subscription_active {
     type: duration
@@ -80,265 +101,13 @@ view: +daily_active_service_subscriptions {
     intervals: [day, week, month, quarter, year]
   }
 
-  dimension_group: until_current_period_ends {
-    type: duration
-    sql_start:
-      LEAST(
-        TIMESTAMP_SUB(TIMESTAMP(${TABLE}.date + 1), INTERVAL 1 MICROSECOND),
-        ${TABLE}.subscription.current_period_ends_at
-      ) ;;
-    sql_end: ${TABLE}.subscription.current_period_ends_at ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-
-  dimension: current_period_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__current_period_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_revenue_months {
-    type: number
-    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__is_trial} IS TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${current_period_discounted_plan_amount}
-              / ${subscription__plan_interval_months}
-              * ${current_period_annual_recurring_revenue_months}
-            )
-        WHEN ${subscription__plan_interval_type} IN ('week', 'day')
-          THEN ${current_period_discounted_plan_amount}
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__ongoing_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension_group: after_current_period_before_ongoing_discount_ends {
-    type: duration
-    sql_start: ${subscription__current_period_ends_at_raw} ;;
-    sql_end: TIMESTAMP_SUB(${subscription__ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_months {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (12 - ${current_period_annual_recurring_revenue_months})
-        ELSE
-          LEAST(
-            (
-              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_months}) + 1)
-              * ${subscription__plan_interval_months}
-            ),
-            (12 - ${current_period_annual_recurring_revenue_months})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (52 - ${subscription__plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${subscription__plan_interval_count}) + 1)
-              * ${subscription__plan_interval_count}
-            ),
-            (52 - ${subscription__plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_days {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (365 - ${subscription__plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_count}) + 1)
-              * ${subscription__plan_interval_count}
-            ),
-            (365 - ${subscription__plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__auto_renew} IS NOT TRUE
-          OR COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_months}
-              * ${ongoing_discounted_annual_recurring_revenue_months}
-            )
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_weeks}
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_days}
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__auto_renew} IS NOT TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_months}
-              * GREATEST(
-                (
-                  12
-                  - ${current_period_annual_recurring_revenue_months}
-                  - ${ongoing_discounted_annual_recurring_revenue_months}
-                ),
-                0
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_count}
-              * GREATEST(
-                (
-                  52
-                  - ${subscription__plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
-                ),
-                0
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_count}
-              * GREATEST(
-                (
-                  365
-                  - ${subscription__plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_days}
-                ),
-                0
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: annual_recurring_gross_revenue {
-    type: number
-    sql:
-      ${current_period_annual_recurring_gross_revenue}
-      + ${ongoing_discounted_annual_recurring_gross_revenue}
-      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_net_revenue {
-    type: number
-    sql:
-      ${annual_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_revenue_usd {
-    group_label: "Subscription"
-    label: "Annual Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${annual_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
+  dimension: subscription__annual_recurring_revenue_usd {
+    group_item_label: "Annual Recurring Revenue (USD)"
     value_format_name: usd
   }
 
-  dimension: monthly_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__is_trial} IS TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${subscription__plan_interval_count}
-                * IF(${subscription__auto_renew}, GREATEST((4 - ${subscription__plan_interval_count}), 0), 0)
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${subscription__plan_interval_count}
-                * IF(${subscription__auto_renew}, GREATEST((30 - ${subscription__plan_interval_count}), 0), 0)
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_net_revenue {
-    type: number
-    sql:
-      ${monthly_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_revenue_usd {
-    group_label: "Subscription"
-    label: "Monthly Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${monthly_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
+  dimension: subscription__monthly_recurring_revenue_usd {
+    group_item_label: "Monthly Recurring Revenue (USD)"
     value_format_name: usd
   }
 
@@ -370,16 +139,16 @@ view: +daily_active_service_subscriptions {
   measure: total_annual_recurring_revenue_usd {
     label: "Total Annual Recurring Revenue (USD)"
     type: sum_distinct
-    sql_distinct_key: ${subscription__id} ;;
-    sql: ${annual_recurring_revenue_usd} ;;
+    sql_distinct_key: ${subscription__logical_subscription_id} ;;
+    sql: ${subscription__annual_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 
   measure: total_monthly_recurring_revenue_usd {
     label: "Total Monthly Recurring Revenue (USD)"
     type: sum_distinct
-    sql_distinct_key: ${subscription__id} ;;
-    sql: ${monthly_recurring_revenue_usd} ;;
+    sql_distinct_key: ${subscription__logical_subscription_id} ;;
+    sql: ${subscription__monthly_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 }

--- a/subscription_platform/views/logical_subscriptions.view.lkml
+++ b/subscription_platform/views/logical_subscriptions.view.lkml
@@ -27,6 +27,10 @@ view: +logical_subscriptions {
   dimension: country_name {
     map_layer_name: countries
   }
+  dimension: country_vat_rate {
+    label: "Country VAT Rate"
+    value_format_name: percent_2
+  }
 
   dimension: services_quantity {
     type: number
@@ -51,11 +55,22 @@ view: +logical_subscriptions {
   dimension: plan_amount {
     value_format_name: decimal_2
   }
+  dimension: plan_amount_usd {
+    label: "Plan Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: plan_currency_usd_exchange_rate {
+    label: "Plan Currency USD Exchange Rate"
+    value_format_name: percent_4
+  }
 
-  dimension: effective_date {
-    type: date_raw
-    sql: COALESCE(DATE(${TABLE}.ended_at), ${table_metadata.last_modified_date} - 1) ;;
-    hidden: yes
+  dimension: current_period_discount_amount_usd {
+    label: "Current Period Discount Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: ongoing_discount_amount_usd {
+    label: "Ongoing Discount Amount (USD)"
+    value_format_name: usd
   }
 
   dimension_group: active {
@@ -70,14 +85,6 @@ view: +logical_subscriptions {
     sql_start: ${TABLE}.started_at ;;
     sql_end: TIMESTAMP(CURRENT_DATE()) ;;
     intervals: [day, week, month, quarter, year]
-  }
-
-  dimension_group: until_current_period_ends {
-    type: duration
-    sql_start: LEAST(TIMESTAMP(CURRENT_DATE()), ${TABLE}.current_period_ends_at) ;;
-    sql_end: ${TABLE}.current_period_ends_at ;;
-    intervals: [day, week, month]
-    hidden: yes
   }
 
   dimension: month_numbers {
@@ -99,251 +106,13 @@ view: +logical_subscriptions {
     hidden: yes
   }
 
-  dimension: current_period_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${plan_amount} - COALESCE(${current_period_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_revenue_months {
-    type: number
-    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${is_active} IS NOT TRUE
-          OR ${is_trial} IS TRUE
-          THEN 0
-        WHEN ${plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${current_period_discounted_plan_amount}
-              / ${plan_interval_months}
-              * ${current_period_annual_recurring_revenue_months}
-            )
-        WHEN ${plan_interval_type} IN ('week', 'day')
-          THEN ${current_period_discounted_plan_amount}
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${plan_amount} - COALESCE(${ongoing_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension_group: after_current_period_before_ongoing_discount_ends {
-    type: duration
-    sql_start: ${current_period_ends_at_raw} ;;
-    sql_end: TIMESTAMP_SUB(${ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_months {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${ongoing_discount_ends_at_raw} IS NULL
-          THEN (12 - ${current_period_annual_recurring_revenue_months})
-        ELSE
-          LEAST(
-            (
-              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${plan_interval_months}) + 1)
-              * ${plan_interval_months}
-            ),
-            (12 - ${current_period_annual_recurring_revenue_months})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${ongoing_discount_ends_at_raw} IS NULL
-          THEN (52 - ${plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${plan_interval_count}) + 1)
-              * ${plan_interval_count}
-            ),
-            (52 - ${plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_days {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${ongoing_discount_ends_at_raw} IS NULL
-          THEN (365 - ${plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${plan_interval_count}) + 1)
-              * ${plan_interval_count}
-            ),
-            (365 - ${plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${is_active} IS NOT TRUE
-          OR ${auto_renew} IS NOT TRUE
-          OR COALESCE(${ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${plan_interval_months}
-              * ${ongoing_discounted_annual_recurring_revenue_months}
-            )
-        WHEN ${plan_interval_type} = 'week'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_weeks}
-            )
-        WHEN ${plan_interval_type} = 'day'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_days}
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${is_active} IS NOT TRUE
-          OR ${auto_renew} IS NOT TRUE
-          THEN 0
-        WHEN ${plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${plan_amount}
-              / ${plan_interval_months}
-              * GREATEST(
-                (
-                  12
-                  - ${current_period_annual_recurring_revenue_months}
-                  - ${ongoing_discounted_annual_recurring_revenue_months}
-                ),
-                0
-              )
-            )
-        WHEN ${plan_interval_type} = 'week'
-          THEN (
-              ${plan_amount}
-              / ${plan_interval_count}
-              * GREATEST(
-                (
-                  52
-                  - ${plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
-                ),
-                0
-              )
-            )
-        WHEN ${plan_interval_type} = 'day'
-          THEN (
-              ${plan_amount}
-              / ${plan_interval_count}
-              * GREATEST(
-                (
-                  365
-                  - ${plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_days}
-                ),
-                0
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: annual_recurring_gross_revenue {
-    type: number
-    sql:
-      ${current_period_annual_recurring_gross_revenue}
-      + ${ongoing_discounted_annual_recurring_gross_revenue}
-      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_net_revenue {
-    type: number
-    sql:
-      ${annual_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
   dimension: annual_recurring_revenue_usd {
     label: "Annual Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${annual_recurring_net_revenue}
-      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 
-  dimension: monthly_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${is_active} IS NOT TRUE
-          OR ${is_trial} IS TRUE
-          THEN 0
-        WHEN ${plan_interval_type} IN ('year', 'month')
-          THEN (${current_period_discounted_plan_amount} / ${plan_interval_months})
-        WHEN ${plan_interval_type} = 'week'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${plan_interval_count}
-                * IF(${auto_renew}, GREATEST((4 - ${plan_interval_count}), 0), 0)
-              )
-            )
-        WHEN ${plan_interval_type} = 'day'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${plan_interval_count}
-                * IF(${auto_renew}, GREATEST((30 - ${plan_interval_count}), 0), 0)
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_net_revenue {
-    type: number
-    sql:
-      ${monthly_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
   dimension: monthly_recurring_revenue_usd {
     label: "Monthly Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${monthly_recurring_net_revenue}
-      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 

--- a/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_logical_subscriptions.view.lkml
@@ -39,6 +39,10 @@ view: +monthly_active_logical_subscriptions {
   dimension: subscription__country_name {
     map_layer_name: countries
   }
+  dimension: subscription__country_vat_rate {
+    group_item_label: "Country VAT Rate"
+    value_format_name: percent_2
+  }
 
   dimension: subscription__services_quantity {
     type: number
@@ -65,15 +69,22 @@ view: +monthly_active_logical_subscriptions {
   dimension: subscription__plan_amount {
     value_format_name: decimal_2
   }
+  dimension: subscription__plan_amount_usd {
+    group_item_label: "Plan Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: subscription__plan_currency_usd_exchange_rate {
+    group_item_label: "Plan Currency USD Exchange Rate"
+    value_format_name: percent_4
+  }
 
-  dimension: effective_date {
-    type: date_raw
-    sql:
-      COALESCE(
-        DATE(${TABLE}.subscription.ended_at),
-        LEAST(${TABLE}.month_end_date, ${table_metadata.last_modified_date} - 1)
-      ) ;;
-    hidden: yes
+  dimension: subscription__current_period_discount_amount_usd {
+    group_item_label: "Current Period Discount Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: subscription__ongoing_discount_amount_usd {
+    group_item_label: "Ongoing Discount Amount (USD)"
+    value_format_name: usd
   }
 
   dimension_group: subscription_active {
@@ -87,266 +98,13 @@ view: +monthly_active_logical_subscriptions {
     intervals: [day, week, month, quarter, year]
   }
 
-  dimension_group: until_current_period_ends {
-    type: duration
-    sql_start:
-      LEAST(
-        TIMESTAMP_SUB(TIMESTAMP(${TABLE}.month_end_date + 1), INTERVAL 1 MICROSECOND),
-        TIMESTAMP(CURRENT_DATE()),
-        ${TABLE}.subscription.current_period_ends_at
-      ) ;;
-    sql_end: ${TABLE}.subscription.current_period_ends_at ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-
-  dimension: current_period_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__current_period_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_revenue_months {
-    type: number
-    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__is_trial} IS TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${current_period_discounted_plan_amount}
-              / ${subscription__plan_interval_months}
-              * ${current_period_annual_recurring_revenue_months}
-            )
-        WHEN ${subscription__plan_interval_type} IN ('week', 'day')
-          THEN ${current_period_discounted_plan_amount}
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__ongoing_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension_group: after_current_period_before_ongoing_discount_ends {
-    type: duration
-    sql_start: ${subscription__current_period_ends_at_raw} ;;
-    sql_end: TIMESTAMP_SUB(${subscription__ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_months {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (12 - ${current_period_annual_recurring_revenue_months})
-        ELSE
-          LEAST(
-            (
-              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_months}) + 1)
-              * ${subscription__plan_interval_months}
-            ),
-            (12 - ${current_period_annual_recurring_revenue_months})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (52 - ${subscription__plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${subscription__plan_interval_count}) + 1)
-              * ${subscription__plan_interval_count}
-            ),
-            (52 - ${subscription__plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_days {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (365 - ${subscription__plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_count}) + 1)
-              * ${subscription__plan_interval_count}
-            ),
-            (365 - ${subscription__plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__auto_renew} IS NOT TRUE
-          OR COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_months}
-              * ${ongoing_discounted_annual_recurring_revenue_months}
-            )
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_weeks}
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_days}
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__auto_renew} IS NOT TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_months}
-              * GREATEST(
-                (
-                  12
-                  - ${current_period_annual_recurring_revenue_months}
-                  - ${ongoing_discounted_annual_recurring_revenue_months}
-                ),
-                0
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_count}
-              * GREATEST(
-                (
-                  52
-                  - ${subscription__plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
-                ),
-                0
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_count}
-              * GREATEST(
-                (
-                  365
-                  - ${subscription__plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_days}
-                ),
-                0
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: annual_recurring_gross_revenue {
-    type: number
-    sql:
-      ${current_period_annual_recurring_gross_revenue}
-      + ${ongoing_discounted_annual_recurring_gross_revenue}
-      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_net_revenue {
-    type: number
-    sql:
-      ${annual_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_revenue_usd {
-    group_label: "Subscription"
-    label: "Annual Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${annual_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
+  dimension: subscription__annual_recurring_revenue_usd {
+    group_item_label: "Annual Recurring Revenue (USD)"
     value_format_name: usd
   }
 
-  dimension: monthly_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__is_trial} IS TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${subscription__plan_interval_count}
-                * IF(${subscription__auto_renew}, GREATEST((4 - ${subscription__plan_interval_count}), 0), 0)
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${subscription__plan_interval_count}
-                * IF(${subscription__auto_renew}, GREATEST((30 - ${subscription__plan_interval_count}), 0), 0)
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_net_revenue {
-    type: number
-    sql:
-      ${monthly_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_revenue_usd {
-    group_label: "Subscription"
-    label: "Monthly Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${monthly_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
+  dimension: subscription__monthly_recurring_revenue_usd {
+    group_item_label: "Monthly Recurring Revenue (USD)"
     value_format_name: usd
   }
 
@@ -374,7 +132,7 @@ view: +monthly_active_logical_subscriptions {
     label: "Total Annual Recurring Revenue (USD)"
     type: sum_distinct
     sql_distinct_key: ${subscription__id} ;;
-    sql: ${annual_recurring_revenue_usd} ;;
+    sql: ${subscription__annual_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 
@@ -382,7 +140,7 @@ view: +monthly_active_logical_subscriptions {
     label: "Total Monthly Recurring Revenue (USD)"
     type: sum_distinct
     sql_distinct_key: ${subscription__id} ;;
-    sql: ${monthly_recurring_revenue_usd} ;;
+    sql: ${subscription__monthly_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 }

--- a/subscription_platform/views/monthly_active_service_subscriptions.view.lkml
+++ b/subscription_platform/views/monthly_active_service_subscriptions.view.lkml
@@ -39,6 +39,10 @@ view: +monthly_active_service_subscriptions {
   dimension: subscription__country_name {
     map_layer_name: countries
   }
+  dimension: subscription__country_vat_rate {
+    group_item_label: "Country VAT Rate"
+    value_format_name: percent_2
+  }
 
   dimension: subscription__service__id {
     sql: ${TABLE}.service_id ;;
@@ -79,15 +83,22 @@ view: +monthly_active_service_subscriptions {
   dimension: subscription__plan_amount {
     value_format_name: decimal_2
   }
+  dimension: subscription__plan_amount_usd {
+    group_item_label: "Plan Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: subscription__plan_currency_usd_exchange_rate {
+    group_item_label: "Plan Currency USD Exchange Rate"
+    value_format_name: percent_4
+  }
 
-  dimension: effective_date {
-    type: date_raw
-    sql:
-      COALESCE(
-        DATE(${TABLE}.subscription.ended_at),
-        LEAST(${TABLE}.month_end_date, ${table_metadata.last_modified_date} - 1)
-      ) ;;
-    hidden: yes
+  dimension: subscription__current_period_discount_amount_usd {
+    group_item_label: "Current Period Discount Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: subscription__ongoing_discount_amount_usd {
+    group_item_label: "Ongoing Discount Amount (USD)"
+    value_format_name: usd
   }
 
   dimension_group: subscription_active {
@@ -101,266 +112,13 @@ view: +monthly_active_service_subscriptions {
     intervals: [day, week, month, quarter, year]
   }
 
-  dimension_group: until_current_period_ends {
-    type: duration
-    sql_start:
-      LEAST(
-        TIMESTAMP_SUB(TIMESTAMP(${TABLE}.month_end_date + 1), INTERVAL 1 MICROSECOND),
-        TIMESTAMP(CURRENT_DATE()),
-        ${TABLE}.subscription.current_period_ends_at
-      ) ;;
-    sql_end: ${TABLE}.subscription.current_period_ends_at ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-
-  dimension: current_period_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__current_period_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_revenue_months {
-    type: number
-    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__is_trial} IS TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${current_period_discounted_plan_amount}
-              / ${subscription__plan_interval_months}
-              * ${current_period_annual_recurring_revenue_months}
-            )
-        WHEN ${subscription__plan_interval_type} IN ('week', 'day')
-          THEN ${current_period_discounted_plan_amount}
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${subscription__plan_amount} - COALESCE(${subscription__ongoing_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension_group: after_current_period_before_ongoing_discount_ends {
-    type: duration
-    sql_start: ${subscription__current_period_ends_at_raw} ;;
-    sql_end: TIMESTAMP_SUB(${subscription__ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_months {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (12 - ${current_period_annual_recurring_revenue_months})
-        ELSE
-          LEAST(
-            (
-              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_months}) + 1)
-              * ${subscription__plan_interval_months}
-            ),
-            (12 - ${current_period_annual_recurring_revenue_months})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (52 - ${subscription__plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${subscription__plan_interval_count}) + 1)
-              * ${subscription__plan_interval_count}
-            ),
-            (52 - ${subscription__plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_days {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__ongoing_discount_ends_at_raw} IS NULL
-          THEN (365 - ${subscription__plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${subscription__plan_interval_count}) + 1)
-              * ${subscription__plan_interval_count}
-            ),
-            (365 - ${subscription__plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__auto_renew} IS NOT TRUE
-          OR COALESCE(${subscription__ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_months}
-              * ${ongoing_discounted_annual_recurring_revenue_months}
-            )
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_weeks}
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${subscription__plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_days}
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__auto_renew} IS NOT TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_months}
-              * GREATEST(
-                (
-                  12
-                  - ${current_period_annual_recurring_revenue_months}
-                  - ${ongoing_discounted_annual_recurring_revenue_months}
-                ),
-                0
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_count}
-              * GREATEST(
-                (
-                  52
-                  - ${subscription__plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
-                ),
-                0
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${subscription__plan_amount}
-              / ${subscription__plan_interval_count}
-              * GREATEST(
-                (
-                  365
-                  - ${subscription__plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_days}
-                ),
-                0
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: annual_recurring_gross_revenue {
-    type: number
-    sql:
-      ${current_period_annual_recurring_gross_revenue}
-      + ${ongoing_discounted_annual_recurring_gross_revenue}
-      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_net_revenue {
-    type: number
-    sql:
-      ${annual_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_revenue_usd {
-    group_label: "Subscription"
-    label: "Annual Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${annual_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
+  dimension: subscription__annual_recurring_revenue_usd {
+    group_item_label: "Annual Recurring Revenue (USD)"
     value_format_name: usd
   }
 
-  dimension: monthly_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${subscription__is_active} IS NOT TRUE
-          OR ${subscription__is_trial} IS TRUE
-          THEN 0
-        WHEN ${subscription__plan_interval_type} IN ('year', 'month')
-          THEN (${current_period_discounted_plan_amount} / ${subscription__plan_interval_months})
-        WHEN ${subscription__plan_interval_type} = 'week'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${subscription__plan_interval_count}
-                * IF(${subscription__auto_renew}, GREATEST((4 - ${subscription__plan_interval_count}), 0), 0)
-              )
-            )
-        WHEN ${subscription__plan_interval_type} = 'day'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${subscription__plan_interval_count}
-                * IF(${subscription__auto_renew}, GREATEST((30 - ${subscription__plan_interval_count}), 0), 0)
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_net_revenue {
-    type: number
-    sql:
-      ${monthly_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_revenue_usd {
-    group_label: "Subscription"
-    label: "Monthly Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${monthly_recurring_net_revenue}
-      * IF(${subscription__plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
+  dimension: subscription__monthly_recurring_revenue_usd {
+    group_item_label: "Monthly Recurring Revenue (USD)"
     value_format_name: usd
   }
 
@@ -392,16 +150,16 @@ view: +monthly_active_service_subscriptions {
   measure: total_annual_recurring_revenue_usd {
     label: "Total Annual Recurring Revenue (USD)"
     type: sum_distinct
-    sql_distinct_key: ${subscription__id} ;;
-    sql: ${annual_recurring_revenue_usd} ;;
+    sql_distinct_key: ${subscription__logical_subscription_id} ;;
+    sql: ${subscription__annual_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 
   measure: total_monthly_recurring_revenue_usd {
     label: "Total Monthly Recurring Revenue (USD)"
     type: sum_distinct
-    sql_distinct_key: ${subscription__id} ;;
-    sql: ${monthly_recurring_revenue_usd} ;;
+    sql_distinct_key: ${subscription__logical_subscription_id} ;;
+    sql: ${subscription__monthly_recurring_revenue_usd} ;;
     value_format_name: usd
   }
 }

--- a/subscription_platform/views/service_subscriptions.view.lkml
+++ b/subscription_platform/views/service_subscriptions.view.lkml
@@ -31,6 +31,10 @@ view: +service_subscriptions {
   dimension: country_name {
     map_layer_name: countries
   }
+  dimension: country_vat_rate {
+    label: "Country VAT Rate"
+    value_format_name: percent_2
+  }
 
   dimension: service__id {
     sql: ${TABLE}.service_id ;;
@@ -59,11 +63,22 @@ view: +service_subscriptions {
   dimension: plan_amount {
     value_format_name: decimal_2
   }
+  dimension: plan_amount_usd {
+    label: "Plan Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: plan_currency_usd_exchange_rate {
+    label: "Plan Currency USD Exchange Rate"
+    value_format_name: percent_4
+  }
 
-  dimension: effective_date {
-    type: date_raw
-    sql: COALESCE(DATE(${TABLE}.ended_at), ${table_metadata.last_modified_date} - 1) ;;
-    hidden: yes
+  dimension: current_period_discount_amount_usd {
+    label: "Current Period Discount Amount (USD)"
+    value_format_name: usd
+  }
+  dimension: ongoing_discount_amount_usd {
+    label: "Ongoing Discount Amount (USD)"
+    value_format_name: usd
   }
 
   dimension_group: active {
@@ -78,14 +93,6 @@ view: +service_subscriptions {
     sql_start: ${TABLE}.started_at ;;
     sql_end: TIMESTAMP(CURRENT_DATE()) ;;
     intervals: [day, week, month, quarter, year]
-  }
-
-  dimension_group: until_current_period_ends {
-    type: duration
-    sql_start: LEAST(TIMESTAMP(CURRENT_DATE()), ${TABLE}.current_period_ends_at) ;;
-    sql_end: ${TABLE}.current_period_ends_at ;;
-    intervals: [day, week, month]
-    hidden: yes
   }
 
   dimension: month_numbers {
@@ -107,251 +114,13 @@ view: +service_subscriptions {
     hidden: yes
   }
 
-  dimension: current_period_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${plan_amount} - COALESCE(${current_period_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_revenue_months {
-    type: number
-    sql: LEAST((${months_until_current_period_ends} + 1), 12) ;;
-    hidden: yes
-  }
-  dimension: current_period_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${is_active} IS NOT TRUE
-          OR ${is_trial} IS TRUE
-          THEN 0
-        WHEN ${plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${current_period_discounted_plan_amount}
-              / ${plan_interval_months}
-              * ${current_period_annual_recurring_revenue_months}
-            )
-        WHEN ${plan_interval_type} IN ('week', 'day')
-          THEN ${current_period_discounted_plan_amount}
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_discounted_plan_amount {
-    type: number
-    sql: GREATEST((${plan_amount} - COALESCE(${ongoing_discount_amount}, 0)), 0) ;;
-    hidden: yes
-  }
-  dimension_group: after_current_period_before_ongoing_discount_ends {
-    type: duration
-    sql_start: ${current_period_ends_at_raw} ;;
-    sql_end: TIMESTAMP_SUB(${ongoing_discount_ends_at_raw}, INTERVAL 1 MICROSECOND) ;;
-    intervals: [day, week, month]
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_months {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${ongoing_discount_ends_at_raw} IS NULL
-          THEN (12 - ${current_period_annual_recurring_revenue_months})
-        ELSE
-          LEAST(
-            (
-              (DIV(${months_after_current_period_before_ongoing_discount_ends}, ${plan_interval_months}) + 1)
-              * ${plan_interval_months}
-            ),
-            (12 - ${current_period_annual_recurring_revenue_months})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_weeks {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${ongoing_discount_ends_at_raw} IS NULL
-          THEN (52 - ${plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(CAST(${weeks_after_current_period_before_ongoing_discount_ends} AS INTEGER), ${plan_interval_count}) + 1)
-              * ${plan_interval_count}
-            ),
-            (52 - ${plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_revenue_days {
-    type: number
-    sql:
-      CASE
-        WHEN COALESCE(${ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${ongoing_discount_ends_at_raw} IS NULL
-          THEN (365 - ${plan_interval_count})
-        ELSE
-          LEAST(
-            (
-              (DIV(${days_after_current_period_before_ongoing_discount_ends}, ${plan_interval_count}) + 1)
-              * ${plan_interval_count}
-            ),
-            (365 - ${plan_interval_count})
-          )
-      END ;;
-    hidden: yes
-  }
-  dimension: ongoing_discounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${is_active} IS NOT TRUE
-          OR ${auto_renew} IS NOT TRUE
-          OR COALESCE(${ongoing_discount_amount}, 0) = 0
-          THEN 0
-        WHEN ${plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${plan_interval_months}
-              * ${ongoing_discounted_annual_recurring_revenue_months}
-            )
-        WHEN ${plan_interval_type} = 'week'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_weeks}
-            )
-        WHEN ${plan_interval_type} = 'day'
-          THEN (
-              ${ongoing_discounted_plan_amount}
-              / ${plan_interval_count}
-              * ${ongoing_discounted_annual_recurring_revenue_days}
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: ongoing_undiscounted_annual_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${is_active} IS NOT TRUE
-          OR ${auto_renew} IS NOT TRUE
-          THEN 0
-        WHEN ${plan_interval_type} IN ('year', 'month')
-          THEN (
-              ${plan_amount}
-              / ${plan_interval_months}
-              * GREATEST(
-                (
-                  12
-                  - ${current_period_annual_recurring_revenue_months}
-                  - ${ongoing_discounted_annual_recurring_revenue_months}
-                ),
-                0
-              )
-            )
-        WHEN ${plan_interval_type} = 'week'
-          THEN (
-              ${plan_amount}
-              / ${plan_interval_count}
-              * GREATEST(
-                (
-                  52
-                  - ${plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_weeks}
-                ),
-                0
-              )
-            )
-        WHEN ${plan_interval_type} = 'day'
-          THEN (
-              ${plan_amount}
-              / ${plan_interval_count}
-              * GREATEST(
-                (
-                  365
-                  - ${plan_interval_count}
-                  - ${ongoing_discounted_annual_recurring_revenue_days}
-                ),
-                0
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-
-  dimension: annual_recurring_gross_revenue {
-    type: number
-    sql:
-      ${current_period_annual_recurring_gross_revenue}
-      + ${ongoing_discounted_annual_recurring_gross_revenue}
-      + ${ongoing_undiscounted_annual_recurring_gross_revenue} ;;
-    hidden: yes
-  }
-  dimension: annual_recurring_net_revenue {
-    type: number
-    sql:
-      ${annual_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
   dimension: annual_recurring_revenue_usd {
     label: "Annual Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${annual_recurring_net_revenue}
-      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 
-  dimension: monthly_recurring_gross_revenue {
-    type: number
-    sql:
-      CASE
-        WHEN ${is_active} IS NOT TRUE
-          OR ${is_trial} IS TRUE
-          THEN 0
-        WHEN ${plan_interval_type} IN ('year', 'month')
-          THEN (${current_period_discounted_plan_amount} / ${plan_interval_months})
-        WHEN ${plan_interval_type} = 'week'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${plan_interval_count}
-                * IF(${auto_renew}, GREATEST((4 - ${plan_interval_count}), 0), 0)
-              )
-            )
-        WHEN ${plan_interval_type} = 'day'
-          THEN (
-              ${current_period_discounted_plan_amount}
-              + (
-                ${ongoing_discounted_plan_amount}
-                / ${plan_interval_count}
-                * IF(${auto_renew}, GREATEST((30 - ${plan_interval_count}), 0), 0)
-              )
-            )
-      END ;;
-    hidden: yes
-  }
-  dimension: monthly_recurring_net_revenue {
-    type: number
-    sql:
-      ${monthly_recurring_gross_revenue}
-      / (1 + COALESCE(${vat_rates.vat}, 0)) ;;
-    hidden: yes
-  }
   dimension: monthly_recurring_revenue_usd {
     label: "Monthly Recurring Revenue (USD)"
-    type: number
-    sql:
-      ${monthly_recurring_net_revenue}
-      * IF(${plan_currency} = 'USD', 1, COALESCE(${exchange_rates.price}, 0)) ;;
     value_format_name: usd
   }
 
@@ -387,7 +156,7 @@ view: +service_subscriptions {
   measure: total_annual_recurring_revenue_usd {
     label: "Total Annual Recurring Revenue (USD)"
     type: sum_distinct
-    sql_distinct_key: ${id} ;;
+    sql_distinct_key: ${logical_subscription_id} ;;
     sql: ${annual_recurring_revenue_usd} ;;
     value_format_name: usd
   }
@@ -395,7 +164,7 @@ view: +service_subscriptions {
   measure: total_monthly_recurring_revenue_usd {
     label: "Total Monthly Recurring Revenue (USD)"
     type: sum_distinct
-    sql_distinct_key: ${id} ;;
+    sql_distinct_key: ${logical_subscription_id} ;;
     sql: ${monthly_recurring_revenue_usd} ;;
     value_format_name: usd
   }


### PR DESCRIPTION
## [DENG-9508](https://mozilla-hub.atlassian.net/browse/DENG-9508): Implement projected monthly/annual revenue for subscriptions in BigQuery

Subscription revenue columns were added to the underlying BigQuery views in https://github.com/mozilla/bigquery-etl/pull/8035, and this PR takes advantage of those new columns to greatly simplify the logical subscription and service subscription Looker views.

---
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
