### PR TITLE
add explore and view for report content

### DIFF
--- a/firefox_desktop/explores/report_content.explore.lkml
+++ b/firefox_desktop/explores/report_content.explore.lkml
@@ -1,0 +1,6 @@
+include: "../views/report_content.view.lkml"
+
+explore: report_content {
+  view_label: "Reported Content"
+  description: "Reported content from HNT"
+}

--- a/firefox_desktop/views/report_content.view.lkml
+++ b/firefox_desktop/views/report_content.view.lkml
@@ -1,0 +1,55 @@
+view: report_content {
+  sql_table_name: `moz-fx-data-shared-prod.firefox_desktop_derived.report_content_v1` ;;
+
+  dimension: card_type {
+    type: string
+    description: "The type of the content card (e.g., \"spoc\", \"organic\")"
+    sql: ${TABLE}.card_type ;;
+  }
+  dimension: corpus_item_id {
+    type: string
+    description: "content identifier"
+    sql: ${TABLE}.corpus_item_id ;;
+  }
+  dimension: report_reason {
+    type: string
+    description: "The reason selected by the user when reporting the content"
+    sql: ${TABLE}.report_reason ;;
+  }
+  dimension: section {
+    type: string
+    description: "If click belongs in a section, the name of the section"
+    sql: ${TABLE}.section ;;
+  }
+  dimension: section_position {
+    type: number
+    description: "If click belongs in a section, the numeric position of the section"
+    sql: ${TABLE}.section_position ;;
+  }
+  dimension_group: submission {
+    type: time
+    description: "Day the event was received in the newtab content ping"
+    timeframes: [raw, date, week, month, quarter, year]
+    convert_tz: no
+    datatype: date
+    sql: ${TABLE}.submission_date ;;
+  }
+  dimension: title {
+    type: string
+    description: "Title of the recommendation."
+    sql: ${TABLE}.title ;;
+  }
+  dimension: topic {
+    type: string
+    description: "The topic of the recommendation. Like \"entertainment\"."
+    sql: ${TABLE}.topic ;;
+  }
+  dimension: url {
+    type: string
+    description: "URL of the recommendation."
+    sql: ${TABLE}.url ;;
+  }
+  measure: count {
+    type: count
+  }
+}


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
