### PR TITLE
[DENG-9210] Add descriptions to health check dashboard bug templates

### DIFF
--- a/monitoring/views/grouped_schema_error_counts.view.lkml
+++ b/monitoring/views/grouped_schema_error_counts.view.lkml
@@ -18,25 +18,21 @@ view: +schema_error_counts {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "{{
-        'https://bugzilla.mozilla.org/enter_bug.cgi?'
-      }}{{
-        'product=Data+Platform+and+Tools'
-      }}{{
-        '&component=General'
-      }}{{
-        '&bug_type=defect'
-      }}{{
-        '&status_whiteboard=%5Bdataquality%5D'
-      }}{{
-        '&short_desc=schema+error+in+%60'
-      }}{{
-        document_namespace }}.{{ document_type
-      }}{{
-        '%60+for+'
-      }}{{
-        path | encode_uri
-      }}"
+      url: "
+https://bugzilla.mozilla.org/enter_bug.cgi?
+product=Data+Platform+and+Tools
+&component=General
+&bug_type=defect
+&status_whiteboard=%5Bdataquality%5D
+&short_desc=schema+error+in+%60
+{{document_namespace }}.{{ document_type }}
+%60+for+{{ path | url_encode }}
+&comment=Schema error for {{ path | url_encode }} in `{{ document_namespace }}.{{ document_type }}`.
+%0D%0A%0D%0A
+Encountered {{ error_count_last_week }} errors in the past week which is a change of {{ percent_change._rendered_value }} from the previous week. The error count is {{ percent_affected_pings._rendered_value }} of {{ stable_and_derived_table_sizes.row_count_last_week }} valid pings.
+%0D%0A%0D%0A
+See runbook for resolution: {{ 'https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/1134854153/Schema+Errors' | url_encode }}
+"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }
@@ -68,4 +64,10 @@ view: +schema_error_counts {
     value_format_name: percent_2
   }
 
+  measure: percent_affected_pings {
+    label: "% affected pings"
+    type: number
+    sql: ${error_count_last_week} / ${stable_and_derived_table_sizes.row_count_last_week} ;;
+    value_format_name: percent_2
+  }
 }

--- a/monitoring/views/missing_namespaces_and_document_types.view.lkml
+++ b/monitoring/views/missing_namespaces_and_document_types.view.lkml
@@ -88,23 +88,16 @@ view: missing_namespaces_and_document_types {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "{{
-        'https://bugzilla.mozilla.org/enter_bug.cgi?'
-      }}{{
-        'product=Data+Platform+and+Tools'
-      }}{{
-        '&component=General'
-      }}{{
-        '&bug_type=defect'
-      }}{{
-        '&status_whiteboard=%5Bdataquality%5D'
-      }}{{
-        '&short_desc=missing+namespaces+and+document+types+in+%60'
-      }}{{
-        document_namespace
-      }}{{
-        '%60+ADD+LIST+OF+DOCUMENT+TYPES+HERE'
-      }}"
+      url: "
+https://bugzilla.mozilla.org/enter_bug.cgi?
+product=Data+Platform+and+Tools
+&component=General
+&bug_type=defect
+&status_whiteboard=%5Bdataquality%5D
+&short_desc=missing+namespaces+and+document+types+in+%60{{ document_namespace }}%60%3A%20 {{ list_of_document_types._rendered_value }}
+&comment=`{{ document_namespace }}` had {{ total_errors }} pings with missing schemas in the past week. Document types: {{ list_of_document_types._rendered_value }}%0D%0A%0D%0A
+See runbook for resolution details: {{ 'https://mozilla-hub.atlassian.net/wiki/spaces/IP/pages/284721153/Missing+Document+Namespace+Bugs' | url_encode }}
+"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }
@@ -115,20 +108,17 @@ view: missing_namespaces_and_document_types {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "{{
-        'https://bugzilla.mozilla.org/enter_bug.cgi?'
-      }}{{
-        'product=Data+Platform+and+Tools'
-      }}{{
-        '&component=General'
-      }}{{
-        '&bug_type=defect'
-      }}{{
-        '&status_whiteboard=%5Bdataquality%5D'
-      }}{{
-        '&short_desc=missing+namespace+and+document+types+in+%60'
-      }}{{
-        document_namespace }}.{{ document_type }}%60"
+      url: "
+https://bugzilla.mozilla.org/enter_bug.cgi?
+product=Data+Platform+and+Tools
+&component=General
+&bug_type=defect
+&status_whiteboard=%5Bdataquality%5D
+&short_desc=missing+namespace+and+document+types+in+
+{{ document_namespace }}.{{ document_type }}
+&comment=`{{ document_namespace }}.{{ document_type }}` had {{ total_errors }} pings with missing schemas in the past week.%0D%0A%0D%0A
+See runbook for resolution details: {{ 'https://mozilla-hub.atlassian.net/wiki/spaces/IP/pages/284721153/Missing+Document+Namespace+Bugs' | url_encode }}
+"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }
@@ -141,5 +131,9 @@ view: missing_namespaces_and_document_types {
   measure: total_errors {
     type: sum
     sql: ${TABLE}.total_errors ;;
+  }
+  measure: list_of_document_types {
+    type: list
+    list_field: document_type
   }
 }

--- a/monitoring/views/structured_missing_columns.view.lkml
+++ b/monitoring/views/structured_missing_columns.view.lkml
@@ -8,25 +8,21 @@ view: +structured_missing_columns {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "{{
-        'https://bugzilla.mozilla.org/enter_bug.cgi?'
-      }}{{
-        'product=Data+Platform+and+Tools'
-      }}{{
-        '&component=General'
-      }}{{
-        '&bug_type=defect'
-      }}{{
-        '&status_whiteboard=%5Bdataquality%5D'
-      }}{{
-        '&short_desc=structured+missing+columns+in+%60'
-      }}{{
-        document_namespace }}.{{ document_type }}_v{{ document_version
-      }}{{
-        '%60+for+'
-      }}{{
-        path | encode_uri
-      }}"
+      url: "
+https://bugzilla.mozilla.org/enter_bug.cgi?
+product=Data+Platform+and+Tools
+&component=General
+&bug_type=defect
+&status_whiteboard=%5Bdataquality%5D
+&short_desc=structured+missing+columns+in+%60
+{{ document_namespace }}.{{ document_type }}_v{{ document_version }}
+%60+for+{{path | encode_uri}}
+&comment=Missing column {{ path | url_encode }} in `{{ document_namespace }}.{{ document_type }}_v{{ document_version }}`.
+%0D%0A%0D%0A
+Found in {{ path_count_last_week }} pings in the past week which is a change of {{ percent_change._rendered_value }} from the previous week. This is affecting {{ percent_affected_pings._rendered_value }} of valid pings.
+%0D%0A%0D%0A
+See runbook for resolution: {{ 'https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/590446607/Missing+Column+Error' | url_encode }}
+"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }
@@ -68,5 +64,12 @@ view: +structured_missing_columns {
     type: sum
     sql: ${stable_and_derived_table_sizes.row_count} ;;
     filters: [submission_date: "7 days ago for 7 days"]
+  }
+
+  measure: percent_affected_pings {
+    label: "% affected pings"
+    type: number
+    sql: ${path_count_last_week} / ${total_ping_count} ;;
+    value_format_name: percent_2
   }
 }

--- a/monitoring/views/telemetry_missing_columns.view.lkml
+++ b/monitoring/views/telemetry_missing_columns.view.lkml
@@ -8,25 +8,21 @@ view: +telemetry_missing_columns {
     sql: "create Bug" ;;
     link: {
       label: "create new Bug"
-      url: "{{
-          'https://bugzilla.mozilla.org/enter_bug.cgi?'
-          }}{{
-            'product=Data+Platform+and+Tools'
-          }}{{
-            '&component=General'
-          }}{{
-            '&bug_type=defect'
-          }}{{
-            '&status_whiteboard=%5Bdataquality%5D'
-          }}{{
-            '&short_desc=telemetry+missing+columns+in+%60'
-          }}{{
-            document_namespace }}.{{ document_type }}_v{{ document_version
-          }}{{
-            '%60+for+'
-          }}{{
-            path | encode_uri
-          }}"
+      url: "
+https://bugzilla.mozilla.org/enter_bug.cgi?
+product=Data+Platform+and+Tools
+&component=General
+&bug_type=defect
+&status_whiteboard=%5Bdataquality%5D
+&short_desc=telemetry+missing+columns+in+%60
+{{ document_namespace }}.{{ document_type }}_v{{ document_version }}
+%60+for+{{path | encode_uri}}
+&comment=Missing column {{ path | url_encode }} in `{{ document_namespace }}.{{ document_type }}_v{{ document_version }}`.
+%0D%0A%0D%0A
+Found in {{ path_count_last_week }} pings in the past week which is a change of {{ percent_change._rendered_value }} from the previous week. This is affecting {{ percent_affected_pings._rendered_value }} of valid pings.
+%0D%0A%0D%0A
+See runbook for resolution: {{ 'https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/590446607/Missing+Column+Error' | url_encode }}
+"
       icon_url: "https://bugzilla.mozilla.org/favicon.ico"
     }
   }
@@ -68,5 +64,12 @@ view: +telemetry_missing_columns {
     type: sum
     sql: ${stable_and_derived_table_sizes.row_count} ;;
     filters: [submission_date: "7 days ago for 7 days"]
+  }
+
+  measure: percent_affected_pings {
+    label: "% affected pings"
+    type: number
+    sql: ${path_count_last_week} / ${total_ping_count} ;;
+    value_format_name: percent_2
   }
 }


### PR DESCRIPTION
Adds error counts and runbook links to the created bug descriptions.  Also changes the formatting of the url because I found that a multiline string works

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781) or the [calculation of DAU or visited URIs](https://github.com/mozilla/bigquery-etl/blob/9bca48821a8a0d40b1700cc14ecd8068d132ed06/sql/moz-fx-data-shared-prod/telemetry_derived/firefox_desktop_exact_mau28_by_dimensions_v1/query.sql).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
