### PR TITLE
fix: update src/sync_dashboard/requirementx.txt to work with python 3.11

### DIFF
--- a/src/sync_dashboards/requirements.txt
+++ b/src/sync_dashboards/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML==5.4.1
-click==7.1.2
-looker-sdk==23.14.1
-pip-tools==5.5.0
+PyYAML==6.0.3
+click==8.3.1
+looker-sdk==25.20.0
+pip-tools==7.5.2


### PR DESCRIPTION
# fix: update src/sync_dashboard/requirementx.txt to work with python 3.11


follow-up to: https://github.com/mozilla/looker-spoke-default/pull/1288

Updated src/sync_dashboard/requirements.txt to work with the new python version (3.11)