### PR TITLE
feat(DENG-9369): add crash signature counts to experiment monitoring dashboard

### DIFF
--- a/experimentation/dashboards/experiment_enrollments.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments.dashboard.lookml
@@ -1504,6 +1504,74 @@
     col: 0
     width: 12
     height: 7
+  - title: Crash Signatures by Branch
+    name: Crash Signatures by Branch
+    model: experimentation
+    explore: experiment_crash_rates
+    type: looker_grid
+    fields: [experiment_crash_rates.crash_signature, experiment_crash_rates.branch, sum_of_crash_count]
+    filters:
+      experiment_crash_rates.crash_signature: "-NULL"
+    sorts: [sum_of_crash_count desc]
+    limit: 500
+    dynamic_fields:
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: experiment_crash_rates.crash_count
+      expression: ''
+      label: Sum of Crash Count
+      measure: sum_of_crash_count
+      type: sum
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: 12
+    rows_font_size: 12
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    defaults_version: 1
+    y_axes: []
+    listen:
+      Experiment: experiment_crash_rates.experiment
+      Time Range [UTC]: experiment_crash_rates.window_start_date
+    row: 98
+    col: 0
+    width: 24
+    height: 6
   filters:
   - name: Experiment
     title: Experiment

--- a/experimentation/dashboards/experiment_enrollments_glean.dashboard.lookml
+++ b/experimentation/dashboards/experiment_enrollments_glean.dashboard.lookml
@@ -1504,6 +1504,74 @@
     col: 0
     width: 12
     height: 7
+  - title: Crash Signatures by Branch
+    name: Crash Signatures by Branch
+    model: experimentation
+    explore: experiment_crash_rates
+    type: looker_grid
+    fields: [experiment_crash_rates.crash_signature, experiment_crash_rates.branch, sum_of_crash_count]
+    filters:
+      experiment_crash_rates.crash_signature: "-NULL"
+    sorts: [sum_of_crash_count desc]
+    limit: 500
+    dynamic_fields:
+    - _kind_hint: measure
+      _type_hint: number
+      based_on: experiment_crash_rates.crash_count
+      expression: ''
+      label: Sum of Crash Count
+      measure: sum_of_crash_count
+      type: sum
+    column_limit: 50
+    show_view_names: false
+    show_row_numbers: true
+    transpose: false
+    truncate_text: true
+    hide_totals: false
+    hide_row_totals: false
+    size_to_fit: true
+    table_theme: white
+    limit_displayed_rows: false
+    enable_conditional_formatting: false
+    header_text_alignment: left
+    header_font_size: 12
+    rows_font_size: 12
+    conditional_formatting_include_totals: false
+    conditional_formatting_include_nulls: false
+    x_axis_gridlines: false
+    y_axis_gridlines: true
+    show_y_axis_labels: true
+    show_y_axis_ticks: true
+    y_axis_tick_density: default
+    y_axis_tick_density_custom: 5
+    show_x_axis_label: true
+    show_x_axis_ticks: true
+    y_axis_scale_mode: linear
+    x_axis_reversed: false
+    y_axis_reversed: false
+    plot_size_by_field: false
+    trellis: ''
+    stacking: ''
+    legend_position: center
+    point_style: none
+    show_value_labels: false
+    label_density: 25
+    x_axis_scale: auto
+    y_axis_combined: true
+    ordering: none
+    show_null_labels: false
+    show_totals_labels: false
+    show_silhouette: false
+    totals_color: "#808080"
+    defaults_version: 1
+    y_axes: []
+    listen:
+      Experiment: experiment_crash_rates.experiment
+      Time Range [UTC]: experiment_crash_rates.window_start_date
+    row: 98
+    col: 0
+    width: 24
+    height: 6
   filters:
   - name: Experiment
     title: Experiment


### PR DESCRIPTION
Adds a crash signatures table to the experiment monitoring dashboard, per [DENG-9369](https://mozilla-hub.atlassian.net/browse/DENG-9369)

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
