### PR TITLE
DENG-10567: move microsurvey_redacted to standalone spoke explore

### DIFF
--- a/firefox_desktop/explores/microsurvey_redacted.explore.lkml
+++ b/firefox_desktop/explores/microsurvey_redacted.explore.lkml
@@ -1,0 +1,27 @@
+include: "//looker-hub/firefox_desktop/views/microsurvey_redacted_table.view.lkml"
+include: "//looker-hub/firefox_desktop/datagroups/microsurvey_redacted_last_updated.datagroup.lkml"
+
+explore: microsurvey_redacted {
+  label: "Microsurvey Redacted"
+  description: "Microsurvey ping data using the table view to expose all metrics and event dimensions. Highly sensitive fields (e.g. write-in responses) are redacted via the stable_views_redacted generator in bigquery-etl."
+  view_name: microsurvey_redacted_table
+  view_label: "Microsurvey Redacted"
+  sql_always_where: ${microsurvey_redacted_table.submission_date} >= '2026-01-01' ;;
+  persist_with: microsurvey_redacted_last_updated
+
+  always_filter: {
+    filters: [
+      microsurvey_redacted_table.submission_date: "28 days",
+    ]
+  }
+
+  join: microsurvey_redacted_table__events {
+    relationship: one_to_many
+    sql: LEFT JOIN UNNEST(${microsurvey_redacted_table.events}) AS microsurvey_redacted_table__events ;;
+  }
+
+  join: microsurvey_redacted_table__events__extra {
+    relationship: one_to_many
+    sql: LEFT JOIN UNNEST(${microsurvey_redacted_table__events.extra}) AS microsurvey_redacted_table__events__extra ;;
+  }
+}

--- a/firefox_desktop/firefox_desktop.model.lkml
+++ b/firefox_desktop/firefox_desktop.model.lkml
@@ -72,7 +72,6 @@ include: "//looker-hub/firefox_desktop/views/quick_suggest.view.lkml"
 include: "//looker-hub/firefox_desktop/views/quick_suggest_table.view.lkml"
 include: "//looker-hub/firefox_desktop/views/review_checker_clients_table.view.lkml"
 include: "//looker-hub/firefox_desktop/views/review_checker_events_table.view.lkml"
-include: "//looker-hub/firefox_desktop/views/microsurvey_redacted_table.view.lkml"
 include: "//looker-hub/firefox_desktop/views/review_checker_microsurvey_table.view.lkml"
 include: "//looker-hub/firefox_desktop/views/search_with.view.lkml"
 include: "//looker-hub/firefox_desktop/views/search_with_table.view.lkml"
@@ -153,29 +152,6 @@ explore: +event_counts {
 }
 
 
-explore: +microsurvey_redacted {
-  label: "Microsurvey Redacted"
-  description: "Microsurvey ping data with write-in responses redacted. Includes all metrics and event dimensions."
-  view_name: microsurvey_redacted_table
-  view_label: "Microsurvey Redacted"
-  sql_always_where: ${microsurvey_redacted_table.submission_date} >= '2010-01-01' ;;
-
-  always_filter: {
-    filters: [
-      microsurvey_redacted_table.submission_date: "28 days",
-    ]
-  }
-
-  join: microsurvey_redacted_table__events {
-    relationship: one_to_many
-    sql: LEFT JOIN UNNEST(${microsurvey_redacted_table.events}) AS microsurvey_redacted_table__events ;;
-  }
-
-  join: microsurvey_redacted_table__events__extra {
-    relationship: one_to_many
-    sql: LEFT JOIN UNNEST(${microsurvey_redacted_table__events.extra}) AS microsurvey_redacted_table__events__extra ;;
-  }
-}
 
 explore: +baseline {
   label: "Baseline (Glean)"


### PR DESCRIPTION
Should fix https://bugzilla.mozilla.org/show_bug.cgi?id=2024002.
Should be merged after https://github.com/mozilla/lookml-generator/pull/1412.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
