### PR TITLE
Remove country explore joins

### DIFF
--- a/firefox_desktop/explores/metric_definitions_desktop_engagement_v1.explore.lkml
+++ b/firefox_desktop/explores/metric_definitions_desktop_engagement_v1.explore.lkml
@@ -4,10 +4,4 @@ include: "//looker-hub/firefox_okrs/datagroups/desktop_engagement_last_updated.d
 
 explore: +metric_definitions_desktop_engagement_v1 {
   persist_with: desktop_engagement_last_updated
-
-  join: countries {
-    type: left_outer
-    relationship: one_to_one
-    sql_on: ${metric_definitions_desktop_engagement_v1.country} = ${countries.code} ;;
-  }
 }

--- a/firefox_desktop/explores/metric_definitions_desktop_new_profiles.explore.lkml
+++ b/firefox_desktop/explores/metric_definitions_desktop_new_profiles.explore.lkml
@@ -4,10 +4,4 @@ include: "//looker-hub/firefox_desktop/datagroups/desktop_new_profiles_last_upda
 
 explore: +metric_definitions_desktop_new_profiles {
   persist_with: desktop_new_profiles_last_updated
-
-  join: countries {
-    type: left_outer
-    relationship: one_to_one
-    sql_on: ${metric_definitions_desktop_new_profiles.country} = ${countries.code} ;;
-  }
 }

--- a/firefox_desktop/explores/metric_definitions_desktop_retention_by_metric_date.explore.lkml
+++ b/firefox_desktop/explores/metric_definitions_desktop_retention_by_metric_date.explore.lkml
@@ -4,10 +4,4 @@ include: "//looker-hub/firefox_okrs/datagroups/desktop_retention_last_updated.da
 
 explore: +metric_definitions_desktop_retention_by_metric_date {
   persist_with: desktop_retention_last_updated
-
-  join: countries {
-    type: left_outer
-    relationship: one_to_one
-    sql_on: ${metric_definitions_desktop_retention_by_metric_date.country} = ${countries.code} ;;
-  }
 }

--- a/multi_product/explores/metric_definitions_mobile_engagement.explore.lkml
+++ b/multi_product/explores/metric_definitions_mobile_engagement.explore.lkml
@@ -5,9 +5,4 @@ include: "//looker-hub/firefox_okrs/datagroups/mobile_engagement_last_updated.da
 explore: +metric_definitions_mobile_engagement {
   persist_with: mobile_engagement_last_updated
 
-  join: countries {
-    type: left_outer
-    relationship: one_to_one
-    sql_on: ${metric_definitions_mobile_engagement.country} = ${countries.code} ;;
-  }
 }

--- a/multi_product/explores/metric_definitions_mobile_new_profiles.explore.lkml
+++ b/multi_product/explores/metric_definitions_mobile_new_profiles.explore.lkml
@@ -5,9 +5,4 @@ include: "//looker-hub/firefox_okrs/datagroups/mobile_new_profiles_last_updated.
 explore: +metric_definitions_mobile_new_profiles {
   persist_with: mobile_new_profiles_last_updated
 
-  join: countries {
-    type: left_outer
-    relationship: one_to_one
-    sql_on: ${metric_definitions_mobile_new_profiles.country} = ${countries.code} ;;
-  }
 }

--- a/multi_product/explores/metric_definitions_mobile_retention_by_metric_date.explore.lkml
+++ b/multi_product/explores/metric_definitions_mobile_retention_by_metric_date.explore.lkml
@@ -5,9 +5,4 @@ include: "//looker-hub/firefox_okrs/datagroups/mobile_retention_last_updated.dat
 explore: +metric_definitions_mobile_retention_by_metric_date {
   persist_with: mobile_retention_last_updated
 
-  join: countries {
-    type: left_outer
-    relationship: one_to_one
-    sql_on: ${metric_definitions_mobile_retention_by_metric_date.country} = ${countries.code} ;;
-  }
 }


### PR DESCRIPTION
- Removes join: countries from the spoke-default refinements now that the join is defined in metric-hub TOML, https://github.com/mozilla/metric-hub/pull/1381,  https://github.com/mozilla/metric-hub/pull/1382 and will be generated natively in          
  looker-hub — avoids duplicate join conflicts. This reverses the changes that I made in https://github.com/mozilla/looker-spoke-default/commit/3af2685045a12cefffb2b3efa7ad87357faa2596                                                                                                                            
                                               

