### PR TITLE
Update dashboard sync file and handle deleted dashboards

### DIFF
--- a/lookml_dashboards.yaml
+++ b/lookml_dashboards.yaml
@@ -11,11 +11,7 @@
 # Format:
 # user_defined_dashboard_id: "lookml_dashboard_id"
 ---
-101: "kpi::firefox_corporate_kpis"
-66: "duet::desktop_numbers_that_matter"
-155: "mozilla_vpn::mozilla_vpn"
 412: "mozilla_vpn::vpn_saasboard__active_subscriptions"
-416: "mozilla_vpn::vpn_saasboard__subscriptions_growth"
 414: "mozilla_vpn::vpn_saasboard__retention"
 413: "mozilla_vpn::vpn_saasboard__churn"
 433: "mozilla_vpn::vpn_saasboard__revenue"

--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -50,7 +50,11 @@ def get_all_linked_dashboards(sdk: methods.Looker40SDK) -> dict:
     remote_config = {}
 
     transport_options = looker_sdk.rtl.transport.TransportOptions({"timeout": 60 * 150})
-    dashboards = sdk.search_dashboards(deleted=False, transport_options=transport_options)
+    dashboards = sdk.search_dashboards(
+        deleted=False,
+        fields="id,model,lookml_link_id",
+        transport_options=transport_options,
+    )
 
     for dashboard in dashboards:
         if dashboard.model is None and dashboard.lookml_link_id:
@@ -64,36 +68,61 @@ def get_all_linked_dashboards(sdk: methods.Looker40SDK) -> dict:
 def sync_dashboards(
     sdk: methods.Looker40SDK, mappings: dict, remote_mappings: dict
 ) -> None:
-    try:
-        for lookml_dashboard_id, dashboard_ids in mappings.items():
-            # unlink any UUDs that are not included in the local mapping
-            if remote_mappings.get(lookml_dashboard_id):
-                unlink_dashboard_ids = set(remote_mappings[lookml_dashboard_id]) - set(
-                    dashboard_ids
-                )
-                for unlink_dashboard_id in unlink_dashboard_ids:
+    for lookml_dashboard_id, dashboard_ids in mappings.items():
+        # unlink any UUDs that are not included in the local mapping
+        if remote_mappings.get(lookml_dashboard_id):
+            unlink_dashboard_ids = set(remote_mappings[lookml_dashboard_id]) - set(
+                dashboard_ids
+            )
+            for unlink_dashboard_id in unlink_dashboard_ids:
+                try:
                     sdk.update_dashboard(
                         unlink_dashboard_id, models.WriteDashboard(lookml_link_id="")
                     )
                     logging.warning(
                         f"Dashboard {unlink_dashboard_id} unlinked from LookML dashboard {lookml_dashboard_id}"
                     )
+                except looker_sdk.error.SDKError as e:
+                    logging.error(
+                        f"Dashboard {unlink_dashboard_id} unlink failed with {e}"
+                    )
 
-            # link and sync UUDs based on local mappings
-            for dashboard_id in dashboard_ids:
-                dashboard = sdk.dashboard(dashboard_id)
+        # link and sync UUDs based on local mappings
+        for dashboard_id in dashboard_ids:
+            try:
+                sdk.dashboard(dashboard_id)
+            except looker_sdk.error.SDKError:
+                logging.error(
+                    f"Dashboard {dashboard_id} not found on Looker instance. "
+                    f"Remove '{dashboard_id}: \"{lookml_dashboard_id}\"' from "
+                    f"lookml_dashboards.yaml."
+                )
+                continue
+
+            try:
                 sdk.dashboard(lookml_dashboard_id)
+            except looker_sdk.error.SDKError:
+                logging.error(
+                    f"LookML dashboard '{lookml_dashboard_id}' not found on Looker "
+                    f"instance. Update or remove the entry for dashboard {dashboard_id} "
+                    f"in lookml_dashboards.yaml."
+                )
+                continue
+
+            try:
                 sdk.update_dashboard(
                     str(dashboard_id),
                     models.WriteDashboard(lookml_link_id=lookml_dashboard_id),
                 )
-
                 sdk.sync_lookml_dashboard(lookml_dashboard_id, models.WriteDashboard())
                 logging.info(
                     f"Dashboard {dashboard_id} synced with LookML dashboard {lookml_dashboard_id}"
                 )
-    except looker_sdk.error.SDKError as e:
-        logging.error(f"Dashboard {dashboard_id} dashboard sync failed with {e}")
+            except looker_sdk.error.SDKError as e:
+                logging.error(
+                    f"Dashboard {dashboard_id} sync with LookML dashboard "
+                    f"{lookml_dashboard_id} failed with {e}"
+                )
 
 
 def load_config(filename: str) -> dict:

--- a/src/sync_dashboards/main.py
+++ b/src/sync_dashboards/main.py
@@ -67,7 +67,8 @@ def get_all_linked_dashboards(sdk: methods.Looker40SDK) -> dict:
 
 def sync_dashboards(
     sdk: methods.Looker40SDK, mappings: dict, remote_mappings: dict
-) -> None:
+) -> int:
+    failures = 0
     for lookml_dashboard_id, dashboard_ids in mappings.items():
         # unlink any UUDs that are not included in the local mapping
         if remote_mappings.get(lookml_dashboard_id):
@@ -83,6 +84,7 @@ def sync_dashboards(
                         f"Dashboard {unlink_dashboard_id} unlinked from LookML dashboard {lookml_dashboard_id}"
                     )
                 except looker_sdk.error.SDKError as e:
+                    failures += 1
                     logging.error(
                         f"Dashboard {unlink_dashboard_id} unlink failed with {e}"
                     )
@@ -92,6 +94,7 @@ def sync_dashboards(
             try:
                 sdk.dashboard(dashboard_id)
             except looker_sdk.error.SDKError:
+                failures += 1
                 logging.error(
                     f"Dashboard {dashboard_id} not found on Looker instance. "
                     f"Remove '{dashboard_id}: \"{lookml_dashboard_id}\"' from "
@@ -102,6 +105,7 @@ def sync_dashboards(
             try:
                 sdk.dashboard(lookml_dashboard_id)
             except looker_sdk.error.SDKError:
+                failures += 1
                 logging.error(
                     f"LookML dashboard '{lookml_dashboard_id}' not found on Looker "
                     f"instance. Update or remove the entry for dashboard {dashboard_id} "
@@ -119,10 +123,13 @@ def sync_dashboards(
                     f"Dashboard {dashboard_id} synced with LookML dashboard {lookml_dashboard_id}"
                 )
             except looker_sdk.error.SDKError as e:
+                failures += 1
                 logging.error(
                     f"Dashboard {dashboard_id} sync with LookML dashboard "
                     f"{lookml_dashboard_id} failed with {e}"
                 )
+
+    return failures
 
 
 def load_config(filename: str) -> dict:
@@ -152,7 +159,9 @@ def sync(ctx: dict, config: str):
     sdk = ctx.obj["SDK"]
     mappings = load_config(config)
     remote_mappings = get_all_linked_dashboards(sdk)
-    sync_dashboards(sdk, mappings, remote_mappings)
+    failures = sync_dashboards(sdk, mappings, remote_mappings)
+    if failures:
+        raise click.ClickException(f"{failures} dashboard(s) failed to sync")
 
 
 @cli.command()


### PR DESCRIPTION
This fixes the failing dashboard sync and handles better error handling when remote dashboards got deleted: https://github.com/mozilla/looker-spoke-default/actions/runs/24904940723/job/72931806064

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
