### PR TITLE
feat(relay_backend): add Firefox retention by Relay mask usage dashboard

### DIFF
--- a/relay_backend/dashboards/relay_mask_firefox_retention.dashboard.lookml
+++ b/relay_backend/dashboards/relay_mask_firefox_retention.dashboard.lookml
@@ -1,0 +1,194 @@
+- dashboard: relay_mask_firefox_retention
+  title: Firefox Retention by Relay Mask Usage
+  layout: newspaper
+  preferred_viewer: dashboards-next
+  description: "Firefox Desktop 4th-week retention segmented by Relay mask count. Correlation only — not causation."
+
+  filters:
+  - name: Submission Date
+    title: Submission Date
+    type: field_filter
+    default_value: 56 days ago for 28 days
+    allow_multiple_values: true
+    required: true
+    ui_config:
+      type: relative_timeframes
+      display: inline
+    model: relay_backend
+    explore: relay_mask_firefox_retention
+    listens_to_filters: []
+    field: relay_mask_firefox_retention.submission_date
+
+  - name: Premium Status
+    title: Premium Status
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: button_group
+      display: inline
+    model: relay_backend
+    explore: relay_mask_firefox_retention
+    listens_to_filters: []
+    field: relay_mask_firefox_retention.relay_premium_status
+
+  elements:
+
+  # ===== HEADER / CAVEAT =====
+
+  - name: caveat_header
+    type: text
+    title_text: ''
+    body_text: |
+      <div style="border-bottom: solid 1px #4285F4; padding: 8px 0;">
+        <h2 style="color: #4285F4; margin: 0;">Firefox Retention by Relay Mask Usage</h2>
+      </div>
+      <p><strong>Note:</strong> This dashboard shows <em>correlation</em> between Relay mask usage
+      and Firefox retention. It does <strong>not</strong> demonstrate causation. A controlled
+      experiment by Mozilla's cross-product analytics team found no conclusive causal
+      effect. Users who create more masks are likely more engaged Firefox users to begin with.</p>
+      <p><strong>Related resources:</strong></p>
+      <ul>
+        <li><a href="https://mozilla.cloud.looker.com/dashboards/1978">Relay Product Stats Dashboard</a></li>
+        <li><a href="https://mozilla.cloud.looker.com/dashboards/1777">Firefox Desktop OKR Dashboard (Retention)</a></li>
+        <li><a href="https://mozilla.cloud.looker.com/dashboards/1178">DAU KPI Dashboard</a></li>
+        <li><a href="https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/842629837">Querying Firefox Retention and Engagement (Confluence)</a></li>
+        <li><a href="https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/314704478">Daily Active Users (DAU) Metric (Confluence)</a></li>
+        <li><a href="https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/814481685">Firefox New Profiles, Retention and Engagement (Confluence)</a></li>
+        <li><a href="https://mozilla-hub.atlassian.net/wiki/spaces/PXI/pages/1608843281">Cross-Product Firefox Analytics (Confluence)</a></li>
+        <li><a href="https://mozilla-hub.atlassian.net/browse/MPP-4588">MPP-4588: This ticket</a></li>
+      </ul>
+    row: 0
+    col: 0
+    width: 24
+    height: 5
+
+  # ===== RETENTION BY MASK TIER =====
+
+  - title: Retention Rate by Mask Count Tier
+    name: retention_rate_by_mask_tier
+    model: relay_backend
+    explore: relay_mask_firefox_retention
+    type: looker_column
+    fields: [relay_mask_firefox_retention.mask_count_tier, relay_mask_firefox_retention.retention_rate]
+    sorts: [relay_mask_firefox_retention.mask_count_tier]
+    listen:
+      Submission Date: relay_mask_firefox_retention.submission_date
+      Premium Status: relay_mask_firefox_retention.relay_premium_status
+    row: 5
+    col: 0
+    width: 12
+    height: 12
+    series_colors:
+      relay_mask_firefox_retention.retention_rate: "#4285F4"
+    y_axes:
+    - label: Retention Rate
+      orientation: left
+      series:
+      - id: relay_mask_firefox_retention.retention_rate
+        name: Retention Rate
+      showLabels: true
+      showValues: true
+      valueFormat: "#.0%"
+
+  - title: Sample Size by Mask Count Tier
+    name: sample_size_by_mask_tier
+    model: relay_backend
+    explore: relay_mask_firefox_retention
+    type: looker_column
+    fields: [relay_mask_firefox_retention.mask_count_tier, relay_mask_firefox_retention.total_clients]
+    sorts: [relay_mask_firefox_retention.mask_count_tier]
+    listen:
+      Submission Date: relay_mask_firefox_retention.submission_date
+      Premium Status: relay_mask_firefox_retention.relay_premium_status
+    row: 5
+    col: 12
+    width: 12
+    height: 12
+    series_colors:
+      relay_mask_firefox_retention.total_clients: "#EA8600"
+    y_axes:
+    - label: Active Clients
+      orientation: left
+      series:
+      - id: relay_mask_firefox_retention.total_clients
+        name: Total Clients
+      showLabels: true
+      showValues: true
+
+  # ===== RETENTION OVER TIME =====
+
+  - title: Retention Rate Over Time by Relay Usage
+    name: retention_over_time_by_relay
+    model: relay_backend
+    explore: relay_mask_firefox_retention
+    type: looker_line
+    fields: [relay_mask_firefox_retention.metric_date_date, relay_mask_firefox_retention.has_relay_account,
+      relay_mask_firefox_retention.retention_rate]
+    pivots: [relay_mask_firefox_retention.has_relay_account]
+    fill_fields: [relay_mask_firefox_retention.metric_date_date]
+    sorts: [relay_mask_firefox_retention.metric_date_date]
+    listen:
+      Submission Date: relay_mask_firefox_retention.submission_date
+      Premium Status: relay_mask_firefox_retention.relay_premium_status
+    row: 17
+    col: 0
+    width: 12
+    height: 12
+    y_axes:
+    - label: Retention Rate
+      orientation: left
+      series:
+      - id: 'Yes - relay_mask_firefox_retention.retention_rate'
+        name: Has Relay Account
+      - id: 'No - relay_mask_firefox_retention.retention_rate'
+        name: No Relay Account
+      showLabels: true
+      showValues: true
+      valueFormat: "#.0%"
+
+  - title: Retention Rate Over Time by Mask Tier
+    name: retention_over_time_by_mask_tier
+    model: relay_backend
+    explore: relay_mask_firefox_retention
+    type: looker_line
+    fields: [relay_mask_firefox_retention.metric_date_date, relay_mask_firefox_retention.mask_count_tier,
+      relay_mask_firefox_retention.retention_rate]
+    pivots: [relay_mask_firefox_retention.mask_count_tier]
+    fill_fields: [relay_mask_firefox_retention.metric_date_date]
+    sorts: [relay_mask_firefox_retention.metric_date_date]
+    listen:
+      Submission Date: relay_mask_firefox_retention.submission_date
+      Premium Status: relay_mask_firefox_retention.relay_premium_status
+    row: 17
+    col: 12
+    width: 12
+    height: 12
+    y_axes:
+    - label: Retention Rate
+      orientation: left
+      series:
+      - id: relay_mask_firefox_retention.retention_rate
+        name: Retention Rate
+      showLabels: true
+      showValues: true
+      valueFormat: "#.0%"
+
+  # ===== SUMMARY TABLE =====
+
+  - title: Summary Table
+    name: summary_table
+    model: relay_backend
+    explore: relay_mask_firefox_retention
+    type: looker_grid
+    fields: [relay_mask_firefox_retention.mask_count_tier, relay_mask_firefox_retention.total_clients,
+      relay_mask_firefox_retention.retained_clients, relay_mask_firefox_retention.retention_rate]
+    sorts: [relay_mask_firefox_retention.mask_count_tier]
+    listen:
+      Submission Date: relay_mask_firefox_retention.submission_date
+      Premium Status: relay_mask_firefox_retention.relay_premium_status
+    row: 29
+    col: 0
+    width: 24
+    height: 6

--- a/relay_backend/explores/relay_mask_firefox_retention.explore.lkml
+++ b/relay_backend/explores/relay_mask_firefox_retention.explore.lkml
@@ -1,0 +1,14 @@
+include: "../views/relay_mask_firefox_retention.view.lkml"
+
+explore: relay_mask_firefox_retention {
+  label: "Relay Masks vs Firefox Retention"
+  description: "Firefox Desktop 4th-week retention segmented by Relay mask count.
+    Shows CORRELATION only — not causation. Users who create masks
+    are likely more engaged to begin with."
+
+  always_filter: {
+    filters: [
+      relay_mask_firefox_retention.submission_date: "56 days ago for 28 days",
+    ]
+  }
+}

--- a/relay_backend/views/relay_mask_firefox_retention.view.lkml
+++ b/relay_backend/views/relay_mask_firefox_retention.view.lkml
@@ -1,0 +1,115 @@
+view: relay_mask_firefox_retention {
+
+  sql_table_name: `mozdata.relay.relay_mask_firefox_retention` ;;
+
+  dimension_group: submission {
+    type: time
+    sql: ${TABLE}.submission_date ;;
+    datatype: date
+    convert_tz: no
+    timeframes: [
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+  }
+
+  dimension_group: metric_date {
+    type: time
+    sql: ${TABLE}.metric_date ;;
+    datatype: date
+    convert_tz: no
+    timeframes: [
+      date,
+      week,
+      month,
+      quarter,
+      year
+    ]
+  }
+
+  dimension: mask_count_tier {
+    type: string
+    sql: ${TABLE}.mask_count_tier ;;
+    order_by_field: mask_count_tier_sort
+  }
+
+  dimension: mask_count_tier_sort {
+    hidden: yes
+    type: number
+    sql:
+      CASE ${TABLE}.mask_count_tier
+        WHEN 'No Relay account' THEN 0
+        WHEN '0 masks' THEN 1
+        WHEN '1-5 masks' THEN 2
+        WHEN '6-10 masks' THEN 3
+        WHEN '11-25 masks' THEN 4
+        WHEN '26-50 masks' THEN 5
+        WHEN '51+ masks' THEN 6
+      END ;;
+  }
+
+  dimension: has_relay_account {
+    type: yesno
+    sql: ${TABLE}.has_relay_account ;;
+  }
+
+  dimension: relay_premium_status {
+    type: string
+    sql: ${TABLE}.relay_premium_status ;;
+  }
+
+  dimension: total_masks {
+    type: number
+    sql: ${TABLE}.total_masks ;;
+  }
+
+  dimension: country {
+    type: string
+    sql: ${TABLE}.country ;;
+  }
+
+  dimension: normalized_channel {
+    type: string
+    sql: ${TABLE}.normalized_channel ;;
+  }
+
+  dimension: active_metric_date {
+    type: yesno
+    sql: ${TABLE}.active_metric_date ;;
+  }
+
+  dimension: retained_week_4 {
+    type: yesno
+    sql: ${TABLE}.retained_week_4 ;;
+  }
+
+  dimension: client_id {
+    type: string
+    sql: ${TABLE}.client_id ;;
+    hidden: yes
+  }
+
+  measure: total_clients {
+    type: count_distinct
+    sql: ${client_id} ;;
+    filters: [active_metric_date: "yes"]
+    description: "Count of distinct active clients"
+  }
+
+  measure: retained_clients {
+    type: count_distinct
+    sql: ${client_id} ;;
+    filters: [retained_week_4: "yes"]
+    description: "Count of distinct clients retained at week 4"
+  }
+
+  measure: retention_rate {
+    type: number
+    sql: SAFE_DIVIDE(${retained_clients}, ${total_clients}) ;;
+    value_format_name: percent_2
+    description: "Week 4 retention rate (retained_clients / total_clients)"
+  }
+}


### PR DESCRIPTION
Relay wants to show correlation between mask usage and Firefox retention. The view reads from a pre-computed `relay_mask_firefox_retention` table in bigquery-etl ([bigquery-etl PR](https://github.com/mozilla/bigquery-etl/pull/9333)) which joins Relay events, fx_accounts bridge, and desktop retention data. Any Looker user can see the dashboard without `client-association` workgroup access.

Related:
- [MPP-4588](https://mozilla-hub.atlassian.net/browse/MPP-4588)
- [bigquery-etl/pull/9333](https://github.com/mozilla/bigquery-etl/pull/9333)

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.