### PR TITLE
fix(relay_backend): use rolling 28-day window for retention dashboard

### DIFF
--- a/relay_backend/explores/relay_mask_firefox_retention.explore.lkml
+++ b/relay_backend/explores/relay_mask_firefox_retention.explore.lkml
@@ -8,7 +8,7 @@ explore: relay_mask_firefox_retention {
 
   always_filter: {
     filters: [
-      relay_mask_firefox_retention.submission_date: "56 days ago for 28 days",
+      relay_mask_firefox_retention.submission_date: "28 days",
     ]
   }
 }


### PR DESCRIPTION
The old filter targeted a fixed historical range with no data yet. Rolling window shows whatever data exists.

Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
