### PR TITLE
fix(fxci): dedupe task run cost measure

### DIFF
--- a/fxci/dashboards/tasks_overview.dashboard.lookml
+++ b/fxci/dashboards/tasks_overview.dashboard.lookml
@@ -305,22 +305,11 @@
     model: fxci
     explore: tasks
     type: single_value
-    fields: [sum_of_run_cost]
+    fields: [task_run_costs.total_cost]
     filters:
       task_run_costs.submission_date: 6 months
     limit: 500
     column_limit: 50
-    dynamic_fields:
-    - category: measure
-      expression: ''
-      label: Sum of Run Cost
-      value_format:
-      value_format_name: decimal_2
-      based_on: task_run_costs.run_cost
-      _kind_hint: measure
-      measure: sum_of_run_cost
-      type: sum
-      _type_hint: number
     custom_color_enabled: true
     show_single_value_title: true
     show_comparison: false
@@ -346,23 +335,12 @@
     model: fxci
     explore: tasks
     type: looker_grid
-    fields: [tasks.tags__trust_domain, tasks.tags__kind, sum_of_run_cost]
+    fields: [tasks.tags__trust_domain, tasks.tags__kind, task_run_costs.total_cost]
     filters:
       tasks.submission_date: 6 months
       task_run_costs.submission_date: 6 months
     limit: 500
     column_limit: 50
-    dynamic_fields:
-    - category: measure
-      expression: ''
-      label: Sum of Run Cost
-      value_format:
-      value_format_name: decimal_0
-      based_on: task_run_costs.run_cost
-      _kind_hint: measure
-      measure: sum_of_run_cost
-      type: sum
-      _type_hint: number
     show_view_names: false
     show_row_numbers: true
     transpose: false
@@ -416,24 +394,13 @@
     model: fxci
     explore: tasks
     type: looker_grid
-    fields: [sum_of_run_cost, tasks.tags__trust_domain]
+    fields: [task_run_costs.total_cost, tasks.tags__trust_domain]
     filters:
       tasks.submission_date: 6 months
       task_run_costs.submission_date: 6 months
-    sorts: [sum_of_run_cost desc 0]
+    sorts: [task_run_costs.total_cost desc 0]
     limit: 500
     column_limit: 50
-    dynamic_fields:
-    - category: measure
-      expression: ''
-      label: Sum of Run Cost
-      value_format:
-      value_format_name: decimal_0
-      based_on: task_run_costs.run_cost
-      _kind_hint: measure
-      measure: sum_of_run_cost
-      type: sum
-      _type_hint: number
     show_view_names: false
     show_row_numbers: true
     transpose: false
@@ -489,34 +456,13 @@
     model: fxci
     explore: tasks
     type: looker_grid
-    fields: [tasks.task_queue_id, sum_of_run_cost]
+    fields: [tasks.task_queue_id, task_run_costs.total_cost]
     filters:
       tasks.submission_date: 6 months
       task_run_costs.submission_date: 6 months
-    sorts: [sum_of_run_cost desc 0]
+    sorts: [task_run_costs.total_cost desc 0]
     limit: 500
     column_limit: 50
-    dynamic_fields:
-    - category: measure
-      expression:
-      label: Num Task Runs
-      value_format:
-      value_format_name:
-      based_on: task_runs.key
-      _kind_hint: measure
-      measure: num_task_runs
-      type: count_distinct
-      _type_hint: number
-    - category: measure
-      expression: ''
-      label: Sum of Run Cost
-      value_format:
-      value_format_name: decimal_0
-      based_on: task_run_costs.run_cost
-      _kind_hint: measure
-      measure: sum_of_run_cost
-      type: sum
-      _type_hint: number
     show_view_names: false
     show_row_numbers: true
     transpose: false

--- a/fxci/dashboards/tasks_overview.dashboard.lookml
+++ b/fxci/dashboards/tasks_overview.dashboard.lookml
@@ -326,6 +326,7 @@
       time.
     listen:
       Submission Date: task_runs.submission_date
+      Cloud Provider: task_run_costs.cloud_provider
     row: 0
     col: 16
     width: 8
@@ -385,6 +386,7 @@
     hidden_pivots: {}
     listen:
       Submission Date: task_runs.submission_date
+      Cloud Provider: task_run_costs.cloud_provider
     row: 22
     col: 12
     width: 12
@@ -447,6 +449,7 @@
     hidden_pivots: {}
     listen:
       Submission Date: task_runs.submission_date
+      Cloud Provider: task_run_costs.cloud_provider
     row: 14
     col: 12
     width: 12
@@ -509,6 +512,7 @@
     hidden_pivots: {}
     listen:
       Submission Date: task_runs.submission_date
+      Cloud Provider: task_run_costs.cloud_provider
     row: 6
     col: 12
     width: 12
@@ -528,3 +532,19 @@
     explore: tasks
     listens_to_filters: []
     field: task_runs.submission_date
+  - name: Cloud Provider
+    title: Cloud Provider
+    type: field_filter
+    default_value: ''
+    allow_multiple_values: true
+    required: false
+    ui_config:
+      type: button_group
+      display: popover
+      options:
+      - azure
+      - gcp
+    model: fxci
+    explore: tasks
+    listens_to_filters: []
+    field: task_run_costs.cloud_provider

--- a/fxci/views/task_run_costs.view.lkml
+++ b/fxci/views/task_run_costs.view.lkml
@@ -8,9 +8,11 @@ view: task_run_costs {
     sql: CONCAT(${TABLE}.task_id, '-', ${TABLE}.run_id) ;;  }
 
   measure: total_cost {
-    type:  sum
+    type:  sum_distinct
     sql:  ${run_cost} ;;
+    sql_distinct_key: ${key} ;;
     value_format: "$#,##0.00"
     label: "Total Run Cost"
+    description: "Total task run cost, deduplicated by task run key."
   }
 }

--- a/lookml_dashboards.yaml
+++ b/lookml_dashboards.yaml
@@ -17,3 +17,4 @@
 433: "mozilla_vpn::vpn_saasboard__revenue"
 501: "mozilla_vpn::vpn_acquisition_funnel_view_desktop_user_journey"
 1978: "relay_backend::relay_product_stats"
+2049: "fxci::fxci_tasks_overview"


### PR DESCRIPTION
## Summary
- make `task_run_costs.total_cost` aggregate by distinct task run key
- update the checked-in FXCI tasks overview dashboard to use the model measure instead of custom raw-sum cost fields
- add a `Cloud Provider` dashboard filter with `azure` and `gcp` options, wired only to cost tiles
- map user dashboard 2049 to the checked-in FXCI tasks overview dashboard so it can be synced from source after merge

## Context
This follows the FXCI Azure/GCP task-cost work in `bigquery-etl`:
- mozilla/bigquery-etl#9368 added `fxci.worker_usage`
- mozilla/bigquery-etl#9369 attributed task costs across Azure and GCP
- mozilla/bigquery-etl#9371 and mozilla/bigquery-etl#9375 backfilled worker usage
- mozilla/bigquery-etl#9392 completed worker cost history with `cloud_provider`
- mozilla/bigquery-etl#9401 initiated the task run cost backfill
- mozilla/bigquery-etl#9414 completed the task run cost backfill

Dashboard 2049 is currently user-managed Looker content. This PR wires it to the existing checked-in FXCI LookML dashboard and moves the cost aggregation into the shared model measure, so the dashboard does not need per-tile custom cost sums.

I also tested the cloud-provider filter behavior on user dashboard 2861 (`Tasks Overview - New`) before checking the LookML version in here. The filter maps to `task_run_costs.cloud_provider` only on cost tiles, so task-count and duration tiles are not constrained by a field they do not use.

## Validation
- [x] `lams --reporting=no`
- [x] Browser verification on dashboard 2861 with `Cloud Provider = azure`: cost tiles update and task/duration tiles stay loaded
- [x] Browser verification on dashboard 2861 with `Cloud Provider = gcp`: cost tiles update and task/duration tiles stay loaded
- [x] Browser verification reset to `Cloud Provider` any value

Checklist for reviewer:

When adding a new derived dataset:
- [x] N/A - this does not add a derived dataset.
- [x] N/A - no new core metric or complex business logic is added in Looker.
- [x] N/A - this reuses existing `task_run_costs` data and fixes the aggregation grain.
- [x] N/A - no new validation or health-check logic is added in Looker.
