### PR TITLE
Added a filter to retrieve production data only.

### DIFF
--- a/firefox_accounts/views/auth_entrypoint_conversion.view.lkml
+++ b/firefox_accounts/views/auth_entrypoint_conversion.view.lkml
@@ -20,6 +20,8 @@ view: auth_entrypoint_conversion {
         FROM `mozdata.accounts_frontend.events_stream` AS es
         WHERE es.submission_timestamp >= TIMESTAMP('2025-01-01 00:00:00+00')
           AND es.submission_timestamp < CURRENT_TIMESTAMP()
+          -- Restrict frontend telemetry to production data.
+          AND es.client_info.app_channel = 'production'
           AND es.metrics.string.session_flow_id IS NOT NULL
           AND es.event IN (
             'email.first_view',
@@ -88,6 +90,8 @@ view: auth_entrypoint_conversion {
       FROM `mozdata.accounts_backend.events_stream` AS es
       WHERE es.submission_timestamp >= TIMESTAMP('2025-01-01 00:00:00+00')
       AND es.submission_timestamp < CURRENT_TIMESTAMP()
+       -- Restrict backend telemetry to production data.
+       AND es.client_info.app_channel = 'production'
       AND es.metrics.string.session_flow_id IS NOT NULL
       AND es.event IN (
       'login.complete',
@@ -223,6 +227,8 @@ view: auth_entrypoint_conversion {
       FROM `mozdata.accounts_frontend.events_stream` AS es
       WHERE es.submission_timestamp >= TIMESTAMP('2025-01-01 00:00:00+00')
       AND es.submission_timestamp < CURRENT_TIMESTAMP()
+      -- Restrict cached-login successes to production data.
+      AND es.client_info.app_channel = 'production'
       AND es.metrics.string.session_flow_id IS NOT NULL
       AND es.event = 'cached_login.success_view'
       ),


### PR DESCRIPTION
Checklist for reviewer:

When adding a new derived dataset:
- [ ] Ensure that the data is not available already (fully or partially) and recommend extending an existing dataset in favor of creating new ones. Data may be available in [bigquery-etl repository](https://github.com/mozilla/bigquery-etl), [looker-hub](https://github.com/mozilla/looker-hub) or in [looker-spoke-default](https://github.com/mozilla/looker-spoke-default/tree/e1315853507fc1ac6e78d252d53dc8df5f5f322b).
- [ ] Avoid merging a PR that includes the logic of a [core metric](https://docs.telemetry.mozilla.org/metrics/index.html) or complex business logic. The recommendation is to implement core business logic in bigquery-etl. E.g. The [type of search](https://github.com/mozilla/bigquery-etl/blob/a3e59f90326816a2ecaaa3e9d5b57fe9552f7d70/sql/moz-fx-data-shared-prod/search_derived/mobile_search_clients_daily_v1/query.sql#L781).
- [ ] Avoid merging code in Looker Explores/Views that implement analysis with multiple lines of code or that will be likely replicated in the future. Instead, aim for extending an existing dataset to include the required logic, and use [Looker aggregates](https://cloud.google.com/looker/docs/aggregate_awareness) to facilitate the analysis.
- [ ] Avoid merging a PR with logic that requires validation and health checks. It is recommended to implement it in bigquery-etl for full test coverage and failure alerts.
